### PR TITLE
Emoji fix

### DIFF
--- a/server/config/sqlize.js
+++ b/server/config/sqlize.js
@@ -46,8 +46,8 @@ const sequelize = new Sequelize({
 	logging: config.db.logging,
 	dialect: 'mysql',
 	define: { // TODO: consider definition to be at column/table level?
-		charset: 'utf8',
-		collate: 'utf8_unicode_ci'
+		charset: 'utf8mb4',
+		collate: 'utf8mb4_unicode_ci'
 	},
 	pool: config.db.pool,
 });

--- a/server/src/models/db/user.js
+++ b/server/src/models/db/user.js
@@ -12,7 +12,7 @@ module.exports = (sequelize, type) => {
 			allowNull: true,
 			defaultValue: null,
 		},
-		alias: type.STRING(32),
+		alias: type.STRING(64),
 		avatar: {
 			type: type.STRING,
 			get() {}, // hidden (use avatarURL)

--- a/server/src/models/validation/user.js
+++ b/server/src/models/validation/user.js
@@ -4,7 +4,7 @@ const Joi = require('joi');
 module.exports = {
 	id: Joi.number().integer().positive(),
 	steamID: Joi.string().regex(/^[0-9]{1,20}$/),
-	alias: Joi.string().min(1).max(32),
+	alias: Joi.string().min(1).max(64),
 	roles: Joi.number().integer().min(0),
 	bans: Joi.number().integer().min(0),
 };


### PR DESCRIPTION
Potential fix for #327, needs testing. As discussed with @Gocnak the game itself will require a different font to fully support names with emojis. Many players in the current year add emojis/odd symbols and often entirely replace their name with said symbols, so I think we should support this, to avoid numerous names being displayed as boxes.

I wasn't able to track down what type.STRING would refer to, I'm assuming it is internalized as VARCHAR.

As tested in-game 0.8.0:
![In-Game Emojis](https://share.snksrv.com/i/Nex5hf.png)
Actual name: `✪ 五😍😍`