### PR TITLE
Fix zone properties improperly saving

### DIFF
--- a/client/src/app/pages/dashboard/maps/upload-form/map-upload-form.component.ts
+++ b/client/src/app/pages/dashboard/maps/upload-form/map-upload-form.component.ts
@@ -172,7 +172,7 @@ export class MapUploadFormComponent implements OnInit, AfterViewInit {
               pointsHeight: triggerObj.pointsHeight,
             };
             if (triggerObj.zoneProps)
-              zoneMdlTrigger.zoneProps = {properties: triggerObj.zoneProps};
+              zoneMdlTrigger.zoneProps = {properties: triggerObj.zoneProps.properties};
             zoneMdl.triggers.push(zoneMdlTrigger);
           }
         }


### PR DESCRIPTION
Closes #362

The given zone file already had the properties key inside of it, so not accessing it was causing it to embed another properties key inside of it.