### PR TITLE
Feature: Implement docker

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -7,9 +7,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Publish to Registry
-      uses: momentum-mod/website@staging
+      uses: elgohr/Publish-Docker-Github-Action@2.14
       with:
         name: momentum-mod/website/mmod-website-production
         username: ${{ github.actor }}

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,14 @@
+name: Publish Docker
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish to Registry
+      uses: TheRealHona/website@staging
+      with:
+        name: momentum-mod/website/mmod-website-production
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@2.14
       with:
-        name: momentum-mod/website/mmod-website-production
+        name: momentum-mod/website/mmod-website
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,12 +1,15 @@
 name: Publish Docker
-on: [push]
+on:
+  push:
+    branches: 
+      - staging
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: TheRealHona/website@staging
+      uses: momentum-mod/website@staging
       with:
         name: momentum-mod/website/mmod-website-production
         username: ${{ github.actor }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:12
+
+EXPOSE $NODE_PORT
+
+WORKDIR /app/client
+
+COPY client/. .
+
+RUN npm install -g @angular/cli && yarn install && npm run build:prod
+
+WORKDIR /app/server
+
+COPY /server/package*.json ./
+RUN yarn install
+
+COPY server/. .
+
+RUN mkdir /app/server; mkdir /app/server/public; mv -vf /app/client/dist/* /app/server/public/
+
+ENTRYPOINT ["node", "server.js"]

--- a/buildAndRunDocker.sh
+++ b/buildAndRunDocker.sh
@@ -1,15 +1,15 @@
 echo -e '-= Building MMoD Website Server Docker Image from Dockerfile =-\n'
-docker build -t mmod-website-server-production -f ./Dockerfile .
+docker build -t mmod-website-server -f ./Dockerfile .
 
-echo -e '-= Stopping MMoD Website Server Production Container =-\n'
-docker container stop mmod-website-server-production
+echo -e '-= Stopping MMoD Website Server Container =-\n'
+docker container stop mmod-website-server
 
 echo -e '-= Runnning the MMoD Website Server Image =-\n'
 docker run -v ./server/public/img/maps:/app/server/public/img/maps \
            -v ./server/public/maps:/app/server/public/maps \
            -v ./server/public/runs:/app/server/public/runs \
            --network host \
-           --name "mmod-website-server-production" \
+           --name "mmod-website-server" \
            --env-file env-vars.list \
            -d \
-           mmod-website-server-production
+           mmod-website-server

--- a/env-vars.list
+++ b/env-vars.list
@@ -1,0 +1,32 @@
+# Node related variables, change if you really want to!
+NODE_ENV=production
+NODE_PORT=3002
+
+# The secret used for generating JWTs
+JWT_SECRET=
+
+# The Steam API web key (you can get it from https://steamcommunity.com/dev/apikey)
+STEAM_WEB_API_KEY=
+
+# The database user, password, and host
+MOM_DATABASE_USER=
+MOM_DATABASE_PW=
+MOM_DATABASE_HOST=
+
+# The base URL of your website
+BASE_URL=
+
+# The Twitter consumer Key and Secret for using their API
+TWITTER_CONSUMER_KEY=
+TWITTER_CONSUMER_SECRET=
+
+# The Discord Client ID and Secret for using their API
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+
+# The Twitch Client ID and Secret for using their API
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
+
+# A generated secret for express' sessions
+EXPRESS_SESSION_SECRET=

--- a/runDocker.sh
+++ b/runDocker.sh
@@ -1,0 +1,15 @@
+echo -e '-= Pulling MMOD Website Server Image from GitHub Packages =-\n'
+docker pull docker.pkg.github.com/momentum-mod/website/mmod-website:latest
+
+echo -e '-= Stopping MMoD Website Container =-\n'
+docker container stop mmod-website
+
+echo -e '-= Runnning the MMoD Website Server Image =-\n'
+docker run -v ./server/public/img/maps:/app/server/public/img/maps \
+           -v ./server/public/maps:/app/server/public/maps \
+           -v ./server/public/runs:/app/server/public/runs \
+           --network host \
+           --name "mmod-website" \
+           --env-file env-vars.list \
+           -d \
+           mmod-website

--- a/runDocker.sh
+++ b/runDocker.sh
@@ -1,0 +1,8 @@
+echo -e '-= Building MMoD Website Server Docker Image from Dockerfile =-\n'
+docker build -t mmod-website-server-production -f ./Dockerfile .
+
+echo -e '-= Stopping MMoD Website Server Production Container =-\n'
+docker container stop mmod-website-server-production
+
+echo -e '-= Runnning the MMoD Website Server Image =-\n'
+docker run --network host --name "mmod-website-server-production" --env-file env-vars.list -d mmod-website-server-production

--- a/runDocker.sh
+++ b/runDocker.sh
@@ -5,4 +5,11 @@ echo -e '-= Stopping MMoD Website Server Production Container =-\n'
 docker container stop mmod-website-server-production
 
 echo -e '-= Runnning the MMoD Website Server Image =-\n'
-docker run --network host --name "mmod-website-server-production" --env-file env-vars.list -d mmod-website-server-production
+docker run -v ./server/public/img/maps:/app/server/public/img/maps \
+           -v ./server/public/maps:/app/server/public/maps \
+           -v ./server/public/runs:/app/server/public/runs \
+           --network host \
+           --name "mmod-website-server-production" \
+           --env-file env-vars.list \
+           -d \
+           mmod-website-server-production


### PR DESCRIPTION
Closes #402 

This PR is a draft, as paths for persistent mounting needs to be decided.

Before this is merged, the org needs to setup GitHub packages for pushing the built images with GitHub Actions to. In addition to this, the repo needs to add a secret `GITHUB_TOKEN` for authenticating the push to GitHub packages.