### PR TITLE
Fix: A couple issues with the Docker implementation

### DIFF
--- a/buildAndRunDocker.sh
+++ b/buildAndRunDocker.sh
@@ -5,9 +5,9 @@ echo -e '-= Stopping MMoD Website Server Container =-\n'
 docker container stop mmod-website-server
 
 echo -e '-= Runnning the MMoD Website Server Image =-\n'
-docker run -v ./server/public/img/maps:/app/server/public/img/maps \
-           -v ./server/public/maps:/app/server/public/maps \
-           -v ./server/public/runs:/app/server/public/runs \
+docker run -v $PWD/server/public/img/maps:/app/server/public/img/maps \
+           -v $PWD/server/public/maps:/app/server/public/maps \
+           -v $PWD/server/public/runs:/app/server/public/runs \
            --network host \
            --name "mmod-website-server" \
            --env-file env-vars.list \

--- a/runDocker.sh
+++ b/runDocker.sh
@@ -12,4 +12,4 @@ docker run -v $PWD/server/public/img/maps:/app/server/public/img/maps \
            --name "mmod-website" \
            --env-file env-vars.list \
            -d \
-           mmod-website
+           docker.pkg.github.com/momentum-mod/website/mmod-website:staging

--- a/runDocker.sh
+++ b/runDocker.sh
@@ -1,5 +1,5 @@
 echo -e '-= Pulling MMOD Website Server Image from GitHub Packages =-\n'
-docker pull docker.pkg.github.com/momentum-mod/website/mmod-website:latest
+docker pull docker.pkg.github.com/momentum-mod/website/mmod-website:staging
 
 echo -e '-= Stopping MMoD Website Container =-\n'
 docker container stop mmod-website

--- a/runDocker.sh
+++ b/runDocker.sh
@@ -5,9 +5,9 @@ echo -e '-= Stopping MMoD Website Container =-\n'
 docker container stop mmod-website
 
 echo -e '-= Runnning the MMoD Website Server Image =-\n'
-docker run -v ./server/public/img/maps:/app/server/public/img/maps \
-           -v ./server/public/maps:/app/server/public/maps \
-           -v ./server/public/runs:/app/server/public/runs \
+docker run -v $PWD/server/public/img/maps:/app/server/public/img/maps \
+           -v $PWD/server/public/maps:/app/server/public/maps \
+           -v $PWD/server/public/runs:/app/server/public/runs \
            --network host \
            --name "mmod-website" \
            --env-file env-vars.list \


### PR DESCRIPTION
Use `$PWD/xyz` instead of `./xyz` to fix Docker error when trying to mount volumes
Use `staging` image tag instead of `latest`
Use the full name `docker.pkg.github.com/momentum-mod/website/mmod-website:staging` in the run command instead of `mmod-website`