### PR TITLE
Fix large docker image by using a multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM node:12
-
-EXPOSE $NODE_PORT
+FROM node:12 as client
 
 WORKDIR /app/client
 
 COPY client/. .
 
 RUN npm install -g @angular/cli && yarn install && npm run build:prod
+
+FROM node:12 as server
+
+EXPOSE $NODE_PORT
 
 WORKDIR /app/server
 
@@ -15,6 +17,6 @@ RUN yarn install
 
 COPY server/. .
 
-RUN mkdir /app/server; mkdir /app/server/public; mv -vf /app/client/dist/* /app/server/public/
+COPY --from=client /app/client/dist/ /app/server/public/
 
 ENTRYPOINT ["node", "server.js"]


### PR DESCRIPTION
Reduces 1.3GB+ image down to ~200MB

Should squash the commits before merging