### PR TITLE
Use publish docker action manually

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,8 +1,6 @@
 name: Publish Docker
 on:
-  push:
-    branches: 
-      - staging
+  workflow_dispatch
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Stops multiple publish docker actions happening together, instead triggering the action when wanted.