### PR TITLE
Fix #401 w/ javascript on (click) action

### DIFF
--- a/client/src/app/pages/main/nav/nav.component.html
+++ b/client/src/app/pages/main/nav/nav.component.html
@@ -8,13 +8,13 @@
     <div class="collapse navbar-collapse mx-auto" [ngClass]="{'show': navbarOpen}">
       <ul class="navbar-nav ml-auto">
         <li class="nav-item">
-          <a class="nav-link" href="#about">About</a>
+          <a class="nav-link" href="#about" (click)="scrollTo('about')">About</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#gamemodes">Game Modes</a>
+          <a class="nav-link" href="#gamemodes" (click)="scrollTo('gamemodes')">Game Modes</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#footer">Links</a>
+          <a class="nav-link" href="#footer" (click)="scrollTo('footer')">Links</a>
         </li>
         <li class="nav-item">
           <img class="nav-link" *ngIf="!isLoggedIn" (click)="showPrivateAlphaWarning()" style="cursor: pointer; padding: 1em 0 0 0.5em" src="assets/images/steam-login.png">

--- a/client/src/app/pages/main/nav/nav.component.ts
+++ b/client/src/app/pages/main/nav/nav.component.ts
@@ -56,16 +56,8 @@ export class NavComponent implements OnInit {
     });
   }
 
-  scrollTo(elementID:string): boolean {
-    switch(elementID){
-      case 'about':
-      case 'gamemodes':
-      case 'footer':
-        document.getElementById(`${elementID}`).scrollIntoView();
-        break;
-      default:
-        console.log("Unexpected Navigation Location");
-    }
+  scrollTo(elementID : string): boolean {
+    document.getElementById(`${elementID}`).scrollIntoView({ behavior: 'smooth' });
     return false;
   }
 }

--- a/client/src/app/pages/main/nav/nav.component.ts
+++ b/client/src/app/pages/main/nav/nav.component.ts
@@ -55,4 +55,17 @@ export class NavComponent implements OnInit {
       }
     });
   }
+
+  scrollTo(elementID:string): boolean {
+    switch(elementID){
+      case 'about':
+      case 'gamemodes':
+      case 'footer':
+        document.getElementById(`${elementID}`).scrollIntoView();
+        break;
+      default:
+        console.log("Unexpected Navigation Location");
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
Fixes #401 

This issue had two potential fixes:

> **1. Make the href double activate to ensure it jumps down to the element** 
> 
> 
> **Pros:**
> - Keeps the current functionality while fixing the bug exactly (href anchor will be appended to the url & the button clicks will function correctly)
> 
> **Cons:**
> - The browser back button will take two clicks to go back
> - The browser will _almost_ definitely refresh the page. This is slightly jarring for a button which just scrolls down the page
> - Could potentially cause the "you are leaving the website" popup to appear because it is technically redirecting when running the script to perform the double click


> **2. Change functionality to the on-click "(click)" action and a corresponding function call** 
> 
> **Pros:**
> - Works every time without reloading the page
> - The overridden href can be left in so pre-existing links (ex. http://momentum-mod.org/#gamemodes) will still work and scroll to the correct position. This also ensures the cursor will still change to the hand icon
> 
> **Cons:**
> - Will not append the href anchor tag to the url (stays as http://momentum-mod.org/)
> 

I did the second fix as it seemed like the better option. The href tag not being on the url is slightly annoying but could be remedied by a feature like a mouseover activated "copy link" button which copies the corresponding link for sharing a specific section (this is a common fix)