### PR TITLE
Added infinite list for recent activities

### DIFF
--- a/client/src/app/@core/data/activity.service.spec.ts
+++ b/client/src/app/@core/data/activity.service.spec.ts
@@ -50,7 +50,7 @@ describe('ActivityService', () => {
     });
     it('#getRecentActivity() should return recent Activity', () => {
       httpClientSpy.get.and.returnValue(of(expectedActivities));
-      activityService.getRecentActivity().subscribe(value =>
+      activityService.getRecentActivity(0).subscribe(value =>
           expect(value).toEqual(expectedActivities, 'expected activity'),
         fail,
       );

--- a/client/src/app/@core/data/activity.service.ts
+++ b/client/src/app/@core/data/activity.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpParams} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {Activities} from '../models/activities.model';
 
@@ -23,9 +23,11 @@ export class ActivityService {
   }
 
   /**
+   * @param offset number of activities offset from most recent activity
    * @return a list of the most recent activities
    */
-  getRecentActivity(): Observable<Activities> {
-    return this.http.get<Activities>('/api/activities');
+  getRecentActivity(offset: number): Observable<Activities> {
+    const params = new HttpParams().append('offset', offset.toString());
+    return this.http.get<Activities>('/api/activities', {params});
   }
 }

--- a/client/src/app/@theme/components/activity/activity-card/activity-card.component.html
+++ b/client/src/app/@theme/components/activity/activity-card/activity-card.component.html
@@ -15,5 +15,5 @@
       </div>
     </div>
   </nb-card-header>
-  <activity-list [activities]="actsFiltered" [hasRequested]="initialAct"></activity-list>
+  <activity-list [activities]="actsFiltered" [hasRequested]="initialAct" (showMore)="getMoreActivities()"></activity-list>
 </nb-card>

--- a/client/src/app/@theme/components/activity/activity-card/activity-card.component.ts
+++ b/client/src/app/@theme/components/activity/activity-card/activity-card.component.ts
@@ -28,6 +28,8 @@ export class ActivityCardComponent implements OnInit {
   activities: Activity[];
   actsFiltered: Activity[];
   initialAct: boolean;
+  recentActPage = 1;
+  canLoadMore = true;
 
   ngOnInit(): void {
     if (!this.initialAct) {
@@ -41,6 +43,7 @@ export class ActivityCardComponent implements OnInit {
     else
       this.actsFiltered = acts.filter((value => value.type === this.filterValue));
   }
+
   getActivities(): void {
     const func = (resp) => {
       this.initialAct = true;
@@ -54,6 +57,21 @@ export class ActivityCardComponent implements OnInit {
         this.actService.getUserActivity(usr.id).subscribe(func);
       });
     else if (this.recent)
-      this.actService.getRecentActivity().subscribe(func);
+      this.actService.getRecentActivity(0).subscribe(func);
+  }
+
+  getMoreActivities(): void {
+    if (!this.canLoadMore || !this.recent)
+      return;
+
+    this.canLoadMore = false;
+    this.actService.getRecentActivity(10 * this.recentActPage++).subscribe((res) => {
+      // Don't call the API anymore if there are no more activities left
+      if (res.activities.length !== 0) {
+        this.canLoadMore = true;
+        this.activities.push(...res.activities);
+        this.filterActivites(this.activities);
+      }
+    });
   }
 }

--- a/client/src/app/@theme/components/activity/activity-list/activity-list.component.html
+++ b/client/src/app/@theme/components/activity/activity-list/activity-list.component.html
@@ -1,4 +1,4 @@
-<nb-list>
+<nb-list nbInfiniteList [threshold]="0" (bottomThreshold)="loadMore()" listenWindowScroll>
   <nb-list-item *ngIf="activities.length === 0 && hasRequested">
     <h4 class="m-0 text-center text"><i>No activities found</i></h4>
   </nb-list-item>

--- a/client/src/app/@theme/components/activity/activity-list/activity-list.component.spec.ts
+++ b/client/src/app/@theme/components/activity/activity-list/activity-list.component.spec.ts
@@ -2,7 +2,7 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {ActivityListComponent} from './activity-list.component';
 import {ActivityContentComponent} from '../..';
-import {NbListModule, NbUserModule} from '@nebular/theme';
+import {NbListModule, NbUserModule, NbLayoutScrollService, NbLayoutRulerService} from '@nebular/theme';
 import {APP_BASE_HREF} from '@angular/common';
 import {RouterModule} from '@angular/router';
 import {TimeagoModule} from 'ngx-timeago';
@@ -17,6 +17,8 @@ describe('ActivityListComponent', () => {
       declarations: [ ActivityListComponent, ActivityContentComponent ],
       providers: [
         { provide: APP_BASE_HREF, useValue: '/' },
+        NbLayoutScrollService,
+        NbLayoutRulerService,
       ],
     })
     .compileComponents();

--- a/client/src/app/@theme/components/activity/activity-list/activity-list.component.ts
+++ b/client/src/app/@theme/components/activity/activity-list/activity-list.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, Output, EventEmitter} from '@angular/core';
 import {Activity} from '../../../../@core/models/activity.model';
 
 @Component({
@@ -10,6 +10,8 @@ export class ActivityListComponent implements OnInit {
 
   @Input('activities') activities: Activity[];
   @Input('hasRequested') hasRequested: boolean;
+  @Output() showMore = new EventEmitter();
+
   constructor() {
     this.hasRequested = false;
     this.activities = [];
@@ -18,4 +20,7 @@ export class ActivityListComponent implements OnInit {
   ngOnInit() {
   }
 
+  loadMore(): void {
+    this.showMore.emit(null);
+  }
 }


### PR DESCRIPTION
For issue #200 

I used Nebular's built-in infinite list functionality. 

I wasn't sure what threshold I should have picked (0 is when scroll bar all the way down). The emitter for the activity-list will also re-emit if you keep scrolling to the bottom and back up when there are no more activities left to load but the function to handle the emit in activity-card will immediately return and not call the API if the list is exhausted. I also had to add a check that it would only load more for recent activity since I noticed activity-card was reused for followed activities. Lastly, I had to make a slight adjustment to the activity service so that I could call older activities from the API.