### PR TITLE
Fixed gamemode circle timer alignment on main page

### DIFF
--- a/client/src/app/pages/main/gamemodes/gamemodes.component.html
+++ b/client/src/app/pages/main/gamemodes/gamemodes.component.html
@@ -13,20 +13,17 @@
          (click)="setCurrentGamemode(i)">
       <div class="base-timer" *ngIf="gameModeIndex == i">
         <svg class="base-timer__svg" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-          <g class="base-timer__circle">
-            <circle class="base-timer__path-elapsed" cx="50" cy="50" r="45"></circle>
-            <path
-              id="base-timer-path-remaining"
-              stroke-dasharray="283"
-              class="base-timer__path-remaining"
-              d="
-                  M 50, 50
-                  m -45, 0
-                  a 45,45 0 1,0 90,0
-                  a 45,45 0 1,0 -90,0
-                "
-            ></path>
-          </g>
+          <path
+            id="base-timer-path-remaining"
+            stroke-dasharray="283"
+            class="base-timer__path-remaining"
+            d="
+                M 50, 50
+                m -45, 0
+                a 45,45 0 1,0 90,0
+                a 45,45 0 1,0 -90,0
+              "
+          ></path>
         </svg>
       </div>
       <img class="gamemode-icon" [ngClass]="{'selected': (this.gameModeIndex == i)}"

--- a/client/src/app/pages/main/gamemodes/gamemodes.component.html
+++ b/client/src/app/pages/main/gamemodes/gamemodes.component.html
@@ -29,7 +29,7 @@
           </g>
         </svg>
       </div>
-      <img width="100%" class="gamemode-icon" [ngClass]="{'selected': (this.gameModeIndex == i)}"
+      <img class="gamemode-icon" [ngClass]="{'selected': (this.gameModeIndex == i)}"
            [src]="gamemode.iconUrl"
            [alt]="gamemode.modeTitle"
            *ngIf="gameModeSectionVisible">

--- a/client/src/app/pages/main/gamemodes/gamemodes.component.scss
+++ b/client/src/app/pages/main/gamemodes/gamemodes.component.scss
@@ -47,7 +47,7 @@
   z-index: 1000;
   width: 55%;
   position: absolute;
-  top: -8px;
+  top: 5px;
   right: -8px;
   padding: 3px;
   transform: rotate(30deg);

--- a/client/src/app/pages/main/gamemodes/gamemodes.component.scss
+++ b/client/src/app/pages/main/gamemodes/gamemodes.component.scss
@@ -10,9 +10,15 @@
 
 .gamemode {
   min-width: 50px;
+  padding-top: 15px;
+  padding-bottom: 15px;
 }
 
 .gamemode-icon {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
   opacity: 0.25;
   transition: opacity 0.5s;
 }
@@ -84,14 +90,19 @@
 
 .base-timer {
   position: absolute;
-  top: -14px;
-  left: 4px;
-  width: 90px;
-  height: 90px;
+  width: 100%;
+  height: 100%;
+  margin-top: -15px;
+  margin-left: -15px;
 }
 
 .base-timer__svg {
   transform: scaleX(-1);
+  position: absolute;
+  fill: none;
+  stroke: none;
+	top: 0;
+	left: 0;
 }
 
 .base-timer__circle {

--- a/client/src/app/pages/main/gamemodes/gamemodes.component.scss
+++ b/client/src/app/pages/main/gamemodes/gamemodes.component.scss
@@ -100,19 +100,8 @@
   transform: scaleX(-1);
   position: absolute;
   fill: none;
-  stroke: none;
 	top: 0;
 	left: 0;
-}
-
-.base-timer__circle {
-  fill: none;
-  stroke: none;
-}
-
-.base-timer__path-elapsed {
-  stroke-width: 4px;
-  stroke: transparent;
 }
 
 .base-timer__path-remaining {


### PR DESCRIPTION
Fixes #442

Tested in Firefox and Chrome (and Edge but that's basically Chrome) at every screen width breakpoint.

I had to manually center both the image and the svg ring to their parent div. I also removed some unnecessary SVG code. Drawing the the invisible ring over the pre-existing one was not needed and moving `fill: none;` to `.base-timer__svg` kept the circle as a ring.