### PR TITLE
Added error messages for external Steam API request errors

### DIFF
--- a/server/src/controllers/auth.js
+++ b/server/src/controllers/auth.js
@@ -88,12 +88,11 @@ module.exports = {
 					ticket: userTicket
 				}
 			}).then((sres) => {
-				const params = sres.data.response.params;
-				if (!params)
-					res.sendStatus(400); // Bad request, it'll have an error object instead
+				if (sres.data.response.error)
+					res.sendStatus(400).json(sres.data.response.error); // Bad request, and pass the error object as reason
 
-				if (params.result === 'OK') {
-					if (idToVerify === params.steamid) {
+				if (sres.data.response.params.result === 'OK') {
+					if (idToVerify === sres.data.response.params.steamid) {
 						user.findOrCreateFromGame(idToVerify).then((usr) => {
 							auth.genAccessToken(usr, true).then(token => {
 								res.json({

--- a/server/src/controllers/auth.js
+++ b/server/src/controllers/auth.js
@@ -89,7 +89,7 @@ module.exports = {
 				}
 			}).then((sres) => {
 				if (sres.data.response.error)
-					res.sendStatus(400).json(sres.data.response.error); // Bad request, and pass the error object as reason
+					res.sendStatus(400); // Bad request, and not sending the error object just in case of hidden bans
 
 				if (sres.data.response.params.result === 'OK') {
 					if (idToVerify === sres.data.response.params.steamid) {

--- a/server/src/controllers/auth.js
+++ b/server/src/controllers/auth.js
@@ -88,8 +88,12 @@ module.exports = {
 					ticket: userTicket
 				}
 			}).then((sres) => {
-				if (sres.data.response.params.result === 'OK') {
-					if (idToVerify === sres.data.response.params.steamid) {
+				const params = sres.data.response.params;
+				if (!params)
+					res.sendStatus(400); // Bad request, it'll have an error object instead
+
+				if (params.result === 'OK') {
+					if (idToVerify === params.steamid) {
 						user.findOrCreateFromGame(idToVerify).then((usr) => {
 							auth.genAccessToken(usr, true).then(token => {
 								res.json({

--- a/server/src/models/user.js
+++ b/server/src/models/user.js
@@ -772,9 +772,28 @@ module.exports = {
 				steamids: steamIDs.join(','),
 			}
 		}).then(res => {
-			if (res.data && res.data.response && res.data.response.players)
-                return Promise.resolve(res.data.response.players);
+			if (res.data && res.data.response) {
+				const players = res.data.response.players;
+
+				if (players.length === 0) {
+					return Promise.reject(new ServerError(404, 'No players found'));
+				}
+
+				return Promise.resolve(players);
+			}
 			return Promise.reject(new ServerError(500, 'Failed to get user(s) from Steam'));
+		}).catch(error => {
+			if (error.response) {
+				// The request was made and the server responded with a status code
+				// that falls out of the range of 2xx
+				return Promise.reject(new ServerError(400, 'Bad request'));
+			} else if (error.request) {
+				// The request was made but no response was received
+				return Promise.reject(new ServerError(404, 'Steam servers did not give a response :('));
+			} else {
+				// Something happened in setting up the request that triggered an Error
+				return Promise.reject(error);
+			}
 		});
 	},
 


### PR DESCRIPTION
Partly solves issue #258 

For the `models/user.js`, I handled the case and added an error message for when, given a list of steam ids, no players were found. I also added error messages for when the response code is not 200. 

As for the `controllers/auth.js`, I could neither find how the response object looks like for cases when `params.result !== 'OK'`, nor do I know how to generate a user ticket to test this API endpoint on Postman with. The docs for that API endpoint doesn't show the structure of the response either, so I really won't be able to properly parse `sres.data`. However, I found that if I passed in an invalid ticket value (like 0), the response body would look something like this instead:
```
{
    "response": {
        "error": {
            "errorcode": 3,
            "errordesc": "Invalid parameter"
        }
    }
}
```
For those cases, I just sent a Bad Request instead.