### PR TITLE
Fixed pagination issue upon removal of last map in library and favorites

### DIFF
--- a/client/src/app/pages/dashboard/maps/map-list/map-list.component.ts
+++ b/client/src/app/pages/dashboard/maps/map-list/map-list.component.ts
@@ -121,13 +121,19 @@ export class MapListComponent implements OnInit {
   }
 
   libraryUpdate(): void {
-    if (this.type === MapListType.TYPE_LIBRARY)
+    if (this.type === MapListType.TYPE_LIBRARY) {
+      if (this.maps.length === 1 && this.currentPage * this.pageLimit >= this.mapCount && this.currentPage > 1)
+        this.currentPage -= 1;
       this.loadMaps();
+    }
   }
 
   favoriteUpdate() {
-    if (this.type === MapListType.TYPE_FAVORITES)
+    if (this.type === MapListType.TYPE_FAVORITES) {
+      if (this.maps.length === 1 && this.currentPage * this.pageLimit >= this.mapCount && this.currentPage > 1)
+        this.currentPage -= 1;
       this.loadMaps();
+    }
   }
 
   isMapInFavorites(m: MomentumMap) {

--- a/client/src/app/pages/dashboard/maps/map-list/map-list.component.ts
+++ b/client/src/app/pages/dashboard/maps/map-list/map-list.component.ts
@@ -122,16 +122,16 @@ export class MapListComponent implements OnInit {
 
   libraryUpdate(): void {
     if (this.type === MapListType.TYPE_LIBRARY) {
-      if (this.maps.length === 1 && this.currentPage * this.pageLimit >= this.mapCount && this.currentPage > 1)
-        this.currentPage -= 1;
+      if (this.isLastItemInLastPage())
+        this.currentPage--;
       this.loadMaps();
     }
   }
 
   favoriteUpdate() {
     if (this.type === MapListType.TYPE_FAVORITES) {
-      if (this.maps.length === 1 && this.currentPage * this.pageLimit >= this.mapCount && this.currentPage > 1)
-        this.currentPage -= 1;
+      if (this.isLastItemInLastPage())
+        this.currentPage--;
       this.loadMaps();
     }
   }
@@ -141,5 +141,9 @@ export class MapListComponent implements OnInit {
       return true;
     else
       return m.favorites && m.favorites.length > 0;
+  }
+
+  isLastItemInLastPage(): boolean {
+    return this.maps.length === 1 && this.currentPage * this.pageLimit >= this.mapCount && this.currentPage > 1;
   }
 }


### PR DESCRIPTION
Fixes #473

I added a check upon removal from library/favorites in `libraryUpdate()` and `libraryUpdate()` that checks for whether the user in on the last page + the last map of that page is being removed + the user isn't on page 1. Then all I needed to do was decrement the page count so it wouldn't query a page now out of index.