### PR TITLE
Fixed video text vertical centering on main page

### DIFF
--- a/client/src/app/pages/main/gamemodes/gamemodes.component.html
+++ b/client/src/app/pages/main/gamemodes/gamemodes.component.html
@@ -38,8 +38,8 @@
       {{this.currentGameMode.modeTitle}}
     </div>
   </div>
-  <div class="row align-items-center mb-5 mb-lg-5 gamemode-data-section">
-    <div class="row align-items-center col-sm-12 col-md-6">
+  <div class="row align-items-center justify-content-center mb-5 mb-lg-5">
+    <div class="row align-items-center col-sm-12 col-md-6 mb-3 mb-md-0">
       <ng-container *ngIf="this.currentGameMode.useYoutubeEmbed; then youtubeTemplate; else webmTemplate"></ng-container>
       <ng-template #webmTemplate>
         <video class="gamemode-video" [src]="this.currentGameMode.url" [poster]="this.currentGameMode.imageUrl" preload="metadata" loop autoplay

--- a/client/src/app/pages/main/gamemodes/gamemodes.component.html
+++ b/client/src/app/pages/main/gamemodes/gamemodes.component.html
@@ -38,8 +38,8 @@
       {{this.currentGameMode.modeTitle}}
     </div>
   </div>
-  <div class="row justify-content-center mb-5 mb-lg-5 gamemode-data-section">
-    <div class="col-sm-12 col-md-6 mb-3">
+  <div class="row align-items-center mb-5 mb-lg-5 gamemode-data-section">
+    <div class="row align-items-center col-sm-12 col-md-6">
       <ng-container *ngIf="this.currentGameMode.useYoutubeEmbed; then youtubeTemplate; else webmTemplate"></ng-container>
       <ng-template #webmTemplate>
         <video class="gamemode-video" [src]="this.currentGameMode.url" [poster]="this.currentGameMode.imageUrl" preload="metadata" loop autoplay

--- a/client/src/app/pages/main/gamemodes/gamemodes.component.scss
+++ b/client/src/app/pages/main/gamemodes/gamemodes.component.scss
@@ -80,10 +80,6 @@
   }
 }
 
-.gamemode-data-section {
-  min-height: 320px;
-}
-
 .gamemode-video {
   width: 100%;
 }


### PR DESCRIPTION
Fixes #488

First I centered the text and video using `align-items-center` but it left an annoying 4ish pixel gutter at the bottom of the video seen here:
![image](https://user-images.githubusercontent.com/5974776/114280759-a8040000-99ef-11eb-9d40-066d2c9fe8a4.png)
so I opted to set its parent wrapper div as another row element so I could center it again using `align-items-center`. This 4 pixel gutter might be because of the YouTube embeds since it does not occur with those so when all the videos are WebM you might be able to remove this second row element workaround.

I also removed the bottom margin for the md breakpoint and up on the wrapper div since it would offset the video when the elements are stacked side-by-side.

Lastly I removed min-height from `gamemode-data-section` since it was causing an additionally large amount of margin padding  that wasn't present on the original version. It also did not affect the actual video size since the video is scaled based on width.