### PR TITLE
Fixed soon™ text clipping out of its box

### DIFF
--- a/client/src/app/pages/main/gamemodes/gamemodes.component.scss
+++ b/client/src/app/pages/main/gamemodes/gamemodes.component.scss
@@ -45,7 +45,7 @@
   text-align: center;
   border-radius: 2px;
   z-index: 1000;
-  width: 55%;
+  width: 55px;
   position: absolute;
   top: 5px;
   right: -8px;


### PR DESCRIPTION
Reported by Mellow1238 on Discord.

The boxes don't need to be dynamically sized since the text size never changes between the screen width breakpoints. I also think the original author probably meant to use pixels instead of percent since 55px seems to be about the width you'd want.