### PR TITLE
Added scrolling to global search results

### DIFF
--- a/client/src/app/@theme/components/search/search-field.component.html
+++ b/client/src/app/@theme/components/search/search-field.component.html
@@ -14,7 +14,7 @@
       </div>
       <span class="info">{{ hint }}</span>
       <div class="mx-auto mt-4 content">
-        <div class="row justify-content-center">
+        <div class="row justify-content-center results">
           <div class="col-10 col-md-6" *ngIf="users?.length">
             <search-results [user]="true" [onlyMaps]="onlyMaps" [onlyUsers]="onlyUsers" [elems]="users"
                             (selectedURL)="selectedElem($event)"></search-results>

--- a/client/src/app/@theme/components/search/search-field.component.scss
+++ b/client/src/app/@theme/components/search/search-field.component.scss
@@ -1,6 +1,6 @@
 .results {
   overflow-y: auto;
-  height: calc(77vh - 5.4rem);
+  height: calc(90vh - 8vw - 5rem - 4px);
   scrollbar-width: none;
 }
 

--- a/client/src/app/@theme/components/search/search-field.component.scss
+++ b/client/src/app/@theme/components/search/search-field.component.scss
@@ -1,3 +1,13 @@
+.results {
+  overflow-y: auto;
+  height: calc(77vh - 5.4rem);
+  scrollbar-width: none;
+}
+
+.results::-webkit-scrollbar {
+  width: 0;
+}
+
 .content {
   max-width: 1000px;
 }

--- a/client/src/app/@theme/components/search/search-field.component.scss
+++ b/client/src/app/@theme/components/search/search-field.component.scss
@@ -1,6 +1,7 @@
 .results {
   overflow-y: auto;
-  height: calc(90vh - 8vw - 5rem - 4px);
+  height: calc(90vh - 8vw - 4.6rem - 4px);
+  padding-bottom: 0.4rem;
   scrollbar-width: none;
 }
 

--- a/client/src/app/@theme/components/search/styles/search.component.modal-drop.scss
+++ b/client/src/app/@theme/components/search/styles/search.component.modal-drop.scss
@@ -22,7 +22,7 @@
 :host.modal-drop {
 
   .search-input {
-    margin-top: 10%;
+    margin-top: 10vh;
   }
 
   .search {
@@ -70,7 +70,7 @@
     }
 
     input {
-      font-size: 6vw;
+      font-size: 10vh;
       width: 60%;
       padding: 0.25rem;
       text-align: left;
@@ -171,10 +171,6 @@
   }
 
   @media screen and (max-width: 40rem) {
-    form {
-      margin: 2rem 0;
-    }
-
     input {
       width: 100%;
       left: 0;

--- a/client/src/app/@theme/components/search/styles/search.component.modal-drop.scss
+++ b/client/src/app/@theme/components/search/styles/search.component.modal-drop.scss
@@ -70,7 +70,7 @@
     }
 
     input {
-      font-size: 10vh;
+      font-size: 6vw;
       width: 60%;
       padding: 0.25rem;
       text-align: left;


### PR DESCRIPTION
Fixes #454

The fix required setting the search results to have `overflow-y: auto` but in order for that to work you have to specify the height of the div.

Here's how it looks when you scroll down a bit:
![image](https://user-images.githubusercontent.com/5974776/119583963-8f239400-bd7c-11eb-9876-278b16caf33e.png)
If you want the Users and Maps headers to stay visible it would have to be broken down into two scrollable columns or the HTML layout would be need to be reworked so that the headers are in their own separate div.

### Comparisons
I set the top margin to `10vh` instead of `10%` to simplify the height calculation for `results`. This change makes it look slightly different from before. New on the left, old on the right.
Here's how they look on an average 1920x1080 screen (non-fullscreened browser):
![image](https://user-images.githubusercontent.com/5974776/119581097-becf9d80-bd76-11eb-9a65-6ffbbfe07289.png)

And here's how they would roughly look on a phone (phone resolutions differ between phones):
![image](https://user-images.githubusercontent.com/5974776/119581330-2e458d00-bd77-11eb-849e-49971ded62c4.png)

### Height Calculation
The `calc` statement for the results div height is a little jank. Here's the breakdown:

- `90vh` The top margin is now 10vh so we start with 90vh left
- `8vw` The input text is scaled as `6vw` but it seems there's a bit of extra space allocated (maybe line spacing?). ![image](https://user-images.githubusercontent.com/5974776/119581541-9eeca980-bd77-11eb-87f9-115474e8a109.png) 
Regardless, I just trial and errored my way to `8vw`
- `5rem` Calculated based on: `0.9`(hint text size) + `0.85 * 2`(padding top and bottom of hint text) + `0.25 * 2` (padding on input) + `1.5` (top margin of results).
- `4px` The input underline is a 4px bottom border.

I also added 0.4rem of padding on the bottom so when you bottom out the search results it doesn't look weird.

All of this seems to work. I tested extremely skewed resolutions (4000x500, 400,2500)  along with more standard resolutions and it seems to be aligned properly.

### Scrollbars
I hid the scrollbar for this behavior since I didn't think it looked good:
![image](https://user-images.githubusercontent.com/5974776/119583163-d6108a00-bd7a-11eb-8f21-a00c8e0730f4.png)
Note that I had to use `scrollbar-width: none;` for FireFox and `::-webkit-scrollbar` for Chrome since apparently they don't both do it the same way.
I'm also not sure where to disable main page scrolling when the search modal is open if that's a desired behavior. Applying `overflow: none` to the various parent/body elements when I was experimenting in the browser didn't seem to do anything so I'm not sure where to even begin looking in that case.