### PR TITLE
Move to Cloudflare Pages Frontend Hosting

### DIFF
--- a/client/src/app/@core/data/activity.service.ts
+++ b/client/src/app/@core/data/activity.service.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {HttpClient, HttpParams} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {Activities} from '../models/activities.model';
+import {environment} from '../../../environments/environment';
 
 @Injectable()
 export class ActivityService {
@@ -11,7 +12,7 @@ export class ActivityService {
    * @return activities of users you follow
    */
   getFollowedActivity(): Observable<Activities> {
-    return this.http.get<Activities>('/api/user/activities/followed');
+    return this.http.get<Activities>(environment.api + '/api/user/activities/followed');
   }
 
   /**
@@ -19,7 +20,7 @@ export class ActivityService {
    * @return a list of specific users's activity
    */
   getUserActivity(userID: number): Observable<Activities> {
-    return this.http.get<Activities>('/api/users/' + userID + '/activities');
+    return this.http.get<Activities>(environment.api + '/api/users/' + userID + '/activities');
   }
 
   /**
@@ -28,6 +29,6 @@ export class ActivityService {
    */
   getRecentActivity(offset: number): Observable<Activities> {
     const params = new HttpParams().append('offset', offset.toString());
-    return this.http.get<Activities>('/api/activities', {params});
+    return this.http.get<Activities>(environment.api + '/api/activities', {params});
   }
 }

--- a/client/src/app/@core/data/admin.service.ts
+++ b/client/src/app/@core/data/admin.service.ts
@@ -4,6 +4,7 @@ import {Observable} from 'rxjs';
 import {User} from '../models/user.model';
 import {MomentumMaps} from '../models/momentum-maps.model';
 import {Reports} from '../models/reports.model';
+import {environment} from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -18,7 +19,7 @@ export class AdminService {
    * @return updates a specific map
    */
   updateMap(mapID: number, map: object): Observable<any> {
-    return this.http.patch('/api/admin/maps/' + mapID, map);
+    return this.http.patch(environment.api + '/api/admin/maps/' + mapID, map);
   }
 
   /**
@@ -26,11 +27,11 @@ export class AdminService {
    * @return a list of maps
    */
   getMaps(context?: object): Observable<MomentumMaps> {
-    return this.http.get<MomentumMaps>('/api/admin/maps/', context);
+    return this.http.get<MomentumMaps>(environment.api + '/api/admin/maps/', context);
   }
 
   deleteMap(mapID: number): Observable<any> {
-    return this.http.delete('/api/admin/maps/' + mapID, {
+    return this.http.delete(environment.api + '/api/admin/maps/' + mapID, {
       responseType: 'text',
     });
   }
@@ -41,7 +42,7 @@ export class AdminService {
    * @return Update a specific user
    */
   updateUser(userID: number, user: User): Observable<any> {
-    return this.http.patch('/api/admin/users/' + userID, user, {
+    return this.http.patch(environment.api + '/api/admin/users/' + userID, user, {
       responseType: 'text',
     });
   }
@@ -51,7 +52,7 @@ export class AdminService {
    * @return a list of reports
    */
   getReports(options?: object): Observable<Reports> {
-    return this.http.get<Reports>('/api/admin/reports', options || {});
+    return this.http.get<Reports>(environment.api + '/api/admin/reports', options || {});
   }
 
   /**
@@ -59,21 +60,21 @@ export class AdminService {
    * @param report Report with new values of properties
    */
   updateReport(reportID: number, report: object): Observable<any> {
-    return this.http.patch('/api/admin/reports/' + reportID, report);
+    return this.http.patch(environment.api + '/api/admin/reports/' + reportID, report);
   }
 
   /**
    * @param userStats UserStats with new values of properties
    */
   updateAllUserStats(userStats: object): Observable<any> {
-    return this.http.patch('/api/admin/user-stats', userStats);
+    return this.http.patch(environment.api + '/api/admin/user-stats', userStats);
   }
 
   /**
    * @return The XP systems and their settings
    */
   getXPSystems(): Observable<any> {
-    return this.http.get('/api/admin/xpsys');
+    return this.http.get(environment.api + '/api/admin/xpsys');
   }
 
   /**
@@ -81,7 +82,7 @@ export class AdminService {
    * @return status code 204 means it was updated
    */
   updateXPSystems(xpSystems: object): Observable<any> {
-    return this.http.put('/api/admin/xpsys', xpSystems);
+    return this.http.put(environment.api + '/api/admin/xpsys', xpSystems);
   }
 
   /**
@@ -89,7 +90,7 @@ export class AdminService {
    * @param alias The params of the user to use.
    */
   createUser(alias: string): Observable<any> {
-    return this.http.post('/api/admin/users', {alias: alias});
+    return this.http.post(environment.api + '/api/admin/users', {alias: alias});
   }
 
   /**
@@ -97,7 +98,7 @@ export class AdminService {
    * @param id The ID of the user to delete
    */
   deleteUser(id: number): Observable<any> {
-    return this.http.delete(`/api/admin/users/${id}`, {
+    return this.http.delete(environment.api + `/api/admin/users/${id}`, {
       responseType: 'text',
     });
   }
@@ -108,7 +109,7 @@ export class AdminService {
    * @param realUser The real user
    */
   mergeUsers(placeholder: User, realUser: User): Observable<any> {
-    return this.http.post('/api/admin/users/merge', {placeholderID: placeholder.id, realID: realUser.id}, {
+    return this.http.post(environment.api + '/api/admin/users/merge', {placeholderID: placeholder.id, realID: realUser.id}, {
       responseType: 'text',
     });
   }

--- a/client/src/app/@core/data/auth.service.ts
+++ b/client/src/app/@core/data/auth.service.ts
@@ -6,6 +6,7 @@ import {HttpClient} from '@angular/common/http';
 import {Observable, of} from 'rxjs';
 import {Router} from '@angular/router';
 import {map, share} from 'rxjs/operators';
+import {environment} from '../../../environments/environment';
 
 export interface TokenRefreshResponse {
   accessToken: string;
@@ -21,7 +22,7 @@ export class AuthService {
   }
 
   public logout(): void {
-    this.http.post('/auth/revoke', {}).subscribe();
+    this.http.post(environment.auth + '/auth/revoke', {}).subscribe();
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
     localStorage.removeItem('user');
@@ -40,7 +41,7 @@ export class AuthService {
   }
 
   public removeSocialAuth(authType: string): Observable<any> {
-    return this.http.delete('/api/user/profile/social/' + authType, {
+    return this.http.delete(environment.api + '/api/user/profile/social/' + authType, {
       responseType: 'text',
     });
   }
@@ -59,7 +60,7 @@ export class AuthService {
     if (!refreshToken) {
       return of(null);
     }
-    return this.http.post('/auth/refresh', { refreshToken: refreshToken }).pipe(
+    return this.http.post(environment.auth + '/auth/refresh', { refreshToken: refreshToken }).pipe(
       share(),
       map((res: TokenRefreshResponse) => {
         const newAccessToken = res.accessToken;

--- a/client/src/app/@core/data/local-user.service.ts
+++ b/client/src/app/@core/data/local-user.service.ts
@@ -15,6 +15,7 @@ import {MomentumMaps} from '../models/momentum-maps.model';
 import {MapSubmissionSummaryElement} from '../models/map-submission-summary-element.model';
 import {UserCredits} from '../models/user-credits.model';
 import {MapNotify} from '../models/map-notify.model';
+import {environment} from '../../../environments/environment';
 
 
 @Injectable({
@@ -78,7 +79,7 @@ export class LocalUserService {
    * @return specific user's profile
    */
   public getLocalUser(options?: object): Observable<User> {
-    return this.http.get<User>('/api/user', options || {});
+    return this.http.get<User>(environment.api + '/api/user', options || {});
   }
 
   /**
@@ -87,7 +88,7 @@ export class LocalUserService {
    * @return response
    */
   public updateUser(user: User): Observable<any> {
-    return this.http.patch('/api/user', user);
+    return this.http.patch(environment.api + '/api/user', user);
   }
 
   /**
@@ -95,7 +96,7 @@ export class LocalUserService {
    * @return a list of map library entries
    */
   public getMapLibrary(options?: object): Observable<MapLibrary> {
-    return this.http.get<MapLibrary>('/api/user/maps/library', options || {});
+    return this.http.get<MapLibrary>(environment.api + '/api/user/maps/library', options || {});
   }
 
   /**
@@ -103,7 +104,7 @@ export class LocalUserService {
    * @return adds map to user library
    */
   public addMapToLibrary(mapID: number): Observable<any> {
-    return this.http.put('/api/user/maps/library/' + mapID, {});
+    return this.http.put(environment.api + '/api/user/maps/library/' + mapID, {});
   }
 
   /**
@@ -111,7 +112,7 @@ export class LocalUserService {
    * @return remove map from user library
    */
   public removeMapFromLibrary(mapID: number): Observable<any> {
-    return this.http.delete('/api/user/maps/library/' + mapID);
+    return this.http.delete(environment.api + '/api/user/maps/library/' + mapID);
   }
 
   /**
@@ -119,7 +120,7 @@ export class LocalUserService {
    * @return the added map in library
    */
   public isMapInLibrary(mapID: number): Observable<any> {
-    return this.http.get('/api/user/maps/library/' + mapID);
+    return this.http.get(environment.api + '/api/user/maps/library/' + mapID);
   }
 
   /**
@@ -127,7 +128,7 @@ export class LocalUserService {
    * @return a list of map favorites
    */
   public getMapFavorites(options?: object): Observable<MapFavorites> {
-    return this.http.get<MapFavorites>('/api/user/maps/favorites', options || {});
+    return this.http.get<MapFavorites>(environment.api + '/api/user/maps/favorites', options || {});
   }
 
   /**
@@ -135,21 +136,21 @@ export class LocalUserService {
    * @return a map favorite
    */
   public getMapFavorite(mapID: number): Observable<MapFavorite> {
-    return this.http.get<MapFavorite>('/api/user/maps/favorites/' + mapID);
+    return this.http.get<MapFavorite>(environment.api + '/api/user/maps/favorites/' + mapID);
   }
 
   /**
    * @param mapID
    */
   public addMapToFavorites(mapID: number): Observable<any> {
-    return this.http.put('/api/user/maps/favorites/' + mapID, {});
+    return this.http.put(environment.api + '/api/user/maps/favorites/' + mapID, {});
   }
 
   /**
    * @param mapID
    */
   public removeMapFromFavorites(mapID: number): Observable<any> {
-    return this.http.delete('/api/user/maps/favorites/' + mapID);
+    return this.http.delete(environment.api + '/api/user/maps/favorites/' + mapID);
   }
 
   /**
@@ -157,7 +158,7 @@ export class LocalUserService {
    * @return A list of credits featuring the local user
    */
   public getMapCredits(options?: object): Observable<UserCredits> {
-    return this.http.get<UserCredits>('/api/user/maps/credits', options || {});
+    return this.http.get<UserCredits>(environment.api + '/api/user/maps/credits', options || {});
   }
 
   /**
@@ -165,14 +166,14 @@ export class LocalUserService {
    * @return retrieve all submitted maps
    */
   public getSubmittedMaps(options?: object): Observable<MomentumMaps> {
-    return this.http.get<MomentumMaps>('/api/user/maps/submitted', options || {});
+    return this.http.get<MomentumMaps>(environment.api + '/api/user/maps/submitted', options || {});
   }
 
   /**
    * @return retrieve summary of the user's submitted maps
    */
   public getSubmittedMapSummary(): Observable<MapSubmissionSummaryElement[]> {
-    return this.http.get<MapSubmissionSummaryElement[]>('/api/user/maps/submitted/summary');
+    return this.http.get<MapSubmissionSummaryElement[]>(environment.api + '/api/user/maps/submitted/summary');
   }
 
   /**
@@ -180,7 +181,7 @@ export class LocalUserService {
    * @return A json object with two booleans determining follow relationship
    */
   public checkFollowStatus(user: User): Observable<FollowStatus> {
-    return this.http.get<FollowStatus>('/api/user/follow/' + user.id);
+    return this.http.get<FollowStatus>(environment.api + '/api/user/follow/' + user.id);
   }
 
   /**
@@ -188,7 +189,7 @@ export class LocalUserService {
    * @return update user following
    */
   public followUser(user: User): Observable<UserFollowObject> {
-    return this.http.post<UserFollowObject>('/api/user/follow', {userID: user.id});
+    return this.http.post<UserFollowObject>(environment.api + '/api/user/follow', {userID: user.id});
   }
 
   /**
@@ -197,7 +198,7 @@ export class LocalUserService {
    * @return update the following status on the user's profile
    */
   public updateFollowStatus(user: User, notifyOn: number): Observable<any> {
-    return this.http.patch('/api/user/follow/' + user.id, {
+    return this.http.patch(environment.api + '/api/user/follow/' + user.id, {
       notifyOn: notifyOn,
     });
   }
@@ -207,7 +208,7 @@ export class LocalUserService {
    * @return user us unfollowed
    */
   public unfollowUser(user: User): Observable<any> {
-    return this.http.delete('/api/user/follow/' + user.id, {
+    return this.http.delete(environment.api + '/api/user/follow/' + user.id, {
       responseType: 'text',
     });
   }
@@ -217,7 +218,7 @@ export class LocalUserService {
   * @return A json object with the potential map and the activity type for notificaions
   */
   public checkMapNotify(mapID: number): Observable<MapNotify> {
-    return this.http.get<MapNotify>('/api/user/notifyMap/' + mapID);
+    return this.http.get<MapNotify>(environment.api + '/api/user/notifyMap/' + mapID);
   }
 
   /**
@@ -226,7 +227,7 @@ export class LocalUserService {
    * @return update the map notification status on the user's profile
    */
   public updateMapNotify(mapID: number, notifyOn: number): Observable<any> {
-    return this.http.put('/api/user/notifyMap/' + mapID, {
+    return this.http.put(environment.api + '/api/user/notifyMap/' + mapID, {
       notifyOn: notifyOn,
     });
   }
@@ -236,13 +237,13 @@ export class LocalUserService {
    * @return Notifications disabled for map
    */
   public disableMapNotify(mapID: number): Observable<any> {
-    return this.http.delete('/api/user/notifyMap/' + mapID, {
+    return this.http.delete(environment.api + '/api/user/notifyMap/' + mapID, {
       responseType: 'text',
     });
   }
 
   public resetAliasToSteamAlias(): Observable<any> {
-    return this.http.patch('/api/user', {
+    return this.http.patch(environment.api + '/api/user', {
       alias: '',
     });
   }

--- a/client/src/app/@core/data/maps.service.ts
+++ b/client/src/app/@core/data/maps.service.ts
@@ -6,6 +6,7 @@ import {MomentumMap} from '../models/momentum-map.model';
 import {MapImage} from '../models/map-image.model';
 import {MomentumMapInfo} from '../models/map-info.model';
 import {MapCredit} from '../models/map-credit.model';
+import {environment} from '../../../environments/environment';
 
 @Injectable()
 export class MapsService {
@@ -19,7 +20,7 @@ export class MapsService {
    * @return Retrieves a specific map
    */
   getMap(id: number, options?: object): Observable<MomentumMap> {
-    return this.http.get<MomentumMap>('/api/maps/' + id, options || {});
+    return this.http.get<MomentumMap>(environment.api + '/api/maps/' + id, options || {});
   }
 
   /**
@@ -27,7 +28,7 @@ export class MapsService {
    * @return a list of maps
    */
   getMaps(options?: object): Observable<MomentumMaps> {
-    return this.http.get<MomentumMaps>('/api/maps', options || {});
+    return this.http.get<MomentumMaps>(environment.api + '/api/maps', options || {});
   }
 
   /**
@@ -35,7 +36,7 @@ export class MapsService {
    * @return Create a map
    */
   createMap(mapData: object): Observable<HttpResponse<MomentumMap>> {
-    return this.http.post<MomentumMap>('/api/maps', mapData, {
+    return this.http.post<MomentumMap>(environment.api + '/api/maps', mapData, {
       observe: 'response',
     });
   }
@@ -46,7 +47,7 @@ export class MapsService {
    * @return response
    */
   updateMapInfo(id: number, mapInfo: MomentumMapInfo): Observable<any> {
-    return this.http.patch('/api/maps/' + id + '/info', mapInfo);
+    return this.http.patch(environment.api + '/api/maps/' + id + '/info', mapInfo);
   }
 
   /**
@@ -54,7 +55,7 @@ export class MapsService {
    * @return credits list of the specific map
    */
   getMapCredits(id: number): Observable<any> {
-    return this.http.get<MapCredit>('/api/maps/' + id + '/credits');
+    return this.http.get<MapCredit>(environment.api + '/api/maps/' + id + '/credits');
   }
 
   /**
@@ -63,7 +64,7 @@ export class MapsService {
    * @return newly created MapCredit
    */
   createMapCredit(id: number, credit: MapCredit): Observable<any> {
-    return this.http.post<MapCredit>('/api/maps/' + id + '/credits', credit);
+    return this.http.post<MapCredit>(environment.api + '/api/maps/' + id + '/credits', credit);
   }
 
   /**
@@ -73,7 +74,7 @@ export class MapsService {
    * @return response
    */
   updateMapCredit(id: number, creditID: number, credit: MapCredit): Observable<any> {
-    return this.http.patch('/api/maps/' + id + '/credits/' + creditID, credit);
+    return this.http.patch(environment.api + '/api/maps/' + id + '/credits/' + creditID, credit);
   }
 
   /**
@@ -82,7 +83,7 @@ export class MapsService {
    * @return response
    */
   deleteMapCredit(id: number, creditID: number): Observable<any> {
-    return this.http.delete('/api/maps/' + id + '/credits/' + creditID, {
+    return this.http.delete(environment.api + '/api/maps/' + id + '/credits/' + creditID, {
       responseType: 'text',
     });
   }
@@ -92,7 +93,7 @@ export class MapsService {
    * @return map file upload location
    */
   getMapFileUploadLocation(id: number): Observable<any> {
-    return this.http.get('/api/maps/' + id + '/upload', {
+    return this.http.get(environment.api + '/api/maps/' + id + '/upload', {
       observe: 'response',
     });
   }
@@ -117,7 +118,7 @@ export class MapsService {
    * @return downloads a map file of a map
    */
   downloadMapFile(id: number): Observable<any> {
-    return this.http.get('/api/maps/' + id + '/download', {
+    return this.http.get(environment.api + '/api/maps/' + id + '/download', {
       responseType: 'blob',
     });
   }
@@ -130,7 +131,7 @@ export class MapsService {
   updateMapAvatar(id: number, thumbnailFile: File): Observable<any> {
     const formData = new FormData();
     formData.append('thumbnailFile', thumbnailFile, thumbnailFile.name);
-    return this.http.put('/api/maps/' + id + '/thumbnail', formData, {
+    return this.http.put(environment.api + '/api/maps/' + id + '/thumbnail', formData, {
       responseType: 'text',
     });
   }
@@ -142,7 +143,7 @@ export class MapsService {
   createMapImage(id: number, mapImageFile: File): Observable<MapImage> {
     const formData = new FormData();
     formData.append('mapImageFile', mapImageFile, mapImageFile.name);
-    return this.http.post<MapImage>('/api/maps/' + id + '/images', formData);
+    return this.http.post<MapImage>(environment.api + '/api/maps/' + id + '/images', formData);
   }
 
   /**
@@ -153,7 +154,7 @@ export class MapsService {
   updateMapImage(id: number, mapImageID: number, mapImageFile: File): Observable<any> {
     const formData = new FormData();
     formData.append('mapImageFile', mapImageFile, mapImageFile.name);
-    return this.http.put('/api/maps/' + id + '/images/' + mapImageID, formData);
+    return this.http.put(environment.api + '/api/maps/' + id + '/images/' + mapImageID, formData);
   }
 
   /**
@@ -161,6 +162,6 @@ export class MapsService {
    * @param mapImageID
    */
   deleteMapImage(id: number, mapImageID: number): Observable<any> {
-    return this.http.delete('/api/maps/' + id + '/images/' + mapImageID);
+    return this.http.delete(environment.api + '/api/maps/' + id + '/images/' + mapImageID);
   }
 }

--- a/client/src/app/@core/data/ranks.service.ts
+++ b/client/src/app/@core/data/ranks.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
+import {environment} from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -10,12 +11,12 @@ export class RanksService {
   constructor(private http: HttpClient) {}
 
   getRanks(mapID: number, options: object): Observable<any> {
-    return this.http.get(`/api/maps/${mapID}/ranks`, options);
+    return this.http.get(`${environment.api}/api/maps/${mapID}/ranks`, options);
   }
   getFriendsRanks(mapID: number, options: object): Observable<any> {
-    return this.http.get(`/api/maps/${mapID}/ranks/friends`, options);
+    return this.http.get(`${environment.api}/api/maps/${mapID}/ranks/friends`, options);
   }
   getAroundRanks(mapID: number, options: object): Observable<any> {
-    return this.http.get(`/api/maps/${mapID}/ranks/around`, options);
+    return this.http.get(`${environment.api}/api/maps/${mapID}/ranks/around`, options);
   }
 }

--- a/client/src/app/@core/data/report.service.ts
+++ b/client/src/app/@core/data/report.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {Report} from '../models/report.model';
+import {environment} from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -11,7 +12,7 @@ export class ReportService {
   constructor(private http: HttpClient) { }
 
   createReport(report: object): Observable<Report> {
-    return this.http.post<Report>('/api/reports', report);
+    return this.http.post<Report>(environment.api + '/api/reports', report);
   }
 
 }

--- a/client/src/app/@core/data/runs.service.ts
+++ b/client/src/app/@core/data/runs.service.ts
@@ -3,6 +3,7 @@ import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {Runs} from '../models/runs.model';
 import {Run} from '../models/run.model';
+import {environment} from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -12,15 +13,15 @@ export class RunsService {
   constructor(private http: HttpClient) { }
 
   getRuns(options?: object): Observable<Runs> {
-    return this.http.get<Runs>('/api/runs', options || {});
+    return this.http.get<Runs>(environment.api + '/api/runs', options || {});
   }
 
   getRun(runID: string, options?: object): Observable<Run> {
-    return this.http.get<Run>('/api/runs/' + runID, options || {});
+    return this.http.get<Run>(environment.api + '/api/runs/' + runID, options || {});
   }
 
   getMapRuns(mapID: number, options?: object): Observable<Runs> {
-    return this.http.get<Runs>(`/api/maps/${mapID}/runs`, options || {});
+    return this.http.get<Runs>(`${environment.api}/api/maps/${mapID}/runs`, options || {});
   }
 
 }

--- a/client/src/app/@core/data/stats.service.ts
+++ b/client/src/app/@core/data/stats.service.ts
@@ -3,6 +3,7 @@ import {Observable} from 'rxjs';
 import {HttpClient} from '@angular/common/http';
 import {GlobalBaseStats} from '../models/global-base-stats.model';
 import {GlobalMapStats} from '../models/global-map-stats.model';
+import {environment} from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -15,14 +16,14 @@ export class StatsService {
    * global base stats
    */
   getGlobalBaseStats(): Observable<GlobalBaseStats> {
-    return this.http.get<GlobalBaseStats>('/api/stats/global');
+    return this.http.get<GlobalBaseStats>(environment.api + '/api/stats/global');
   }
 
   /**
    * @return global stats for all maps
    */
   getGlobalMapStats(): Observable<GlobalMapStats> {
-    return this.http.get<GlobalMapStats>('/api/stats/global/maps');
+    return this.http.get<GlobalMapStats>(environment.api + '/api/stats/global/maps');
   }
 
 }

--- a/client/src/app/@core/data/users.service.ts
+++ b/client/src/app/@core/data/users.service.ts
@@ -7,6 +7,7 @@ import {Followers} from '../models/followers.model';
 import {Followed} from '../models/followed.model';
 import {UserCredits} from '../models/user-credits.model';
 import {Runs} from '../models/runs.model';
+import {environment} from '../../../environments/environment';
 
 @Injectable()
 export class UsersService {
@@ -18,7 +19,7 @@ export class UsersService {
    * @return a list of users
    */
   getUsers(options?: object): Observable<Users> {
-    return this.http.get<Users>('/api/users', options || {});
+    return this.http.get<Users>(environment.api + '/api/users', options || {});
   }
 
   /**
@@ -27,7 +28,7 @@ export class UsersService {
    * @return Retrieves a specific user
    */
   getUser(userID: number, options?: object): Observable<User> {
-    return this.http.get<User>('/api/users/' + userID, options || {});
+    return this.http.get<User>(environment.api + '/api/users/' + userID, options || {});
   }
 
   /**
@@ -35,7 +36,7 @@ export class UsersService {
    * @return followers of that user
    */
   getFollowersOfUser(user: User): Observable<Followers> {
-    return this.http.get<Followers>('/api/users/' + user.id + '/followers');
+    return this.http.get<Followers>(environment.api + '/api/users/' + user.id + '/followers');
   }
 
   /**
@@ -43,14 +44,14 @@ export class UsersService {
    * @return the user's following
    */
   getUserFollows(user: User): Observable<Followed> {
-    return this.http.get<Followed>('/api/users/' + user.id + '/follows');
+    return this.http.get<Followed>(environment.api + '/api/users/' + user.id + '/follows');
   }
 
   getMapCredits(userID: number, options?: object): Observable<UserCredits> {
-    return this.http.get<UserCredits>(`/api/users/${userID}/credits`, options || {});
+    return this.http.get<UserCredits>(`${environment.api}/api/users/${userID}/credits`, options || {});
   }
 
   getRunHistory(userID: number, options?: object): Observable<Runs> {
-    return this.http.get<Runs>(`/api/users/${userID}/runs`, options || {});
+    return this.http.get<Runs>(`${environment.api}/api/users/${userID}/runs`, options || {});
   }
 }

--- a/client/src/app/@core/guards/auth.guard.ts
+++ b/client/src/app/@core/guards/auth.guard.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate} from '@angular/router';
 import {LocalUserService} from '../data/local-user.service';
+import {environment} from '../../../environments/environment';
 
 @Injectable({
   providedIn: 'root',
@@ -20,9 +21,9 @@ export class AuthGuard implements CanActivate {
     }
     const referrer = window.location.pathname;
     if (referrer !== '/')
-      window.location.href = '/auth/steam?r=' + referrer;
+      window.location.href = environment.auth + '/auth/steam?r=' + referrer;
     else
-      window.location.href = '/auth/steam';
+      window.location.href = environment.auth + '/auth/steam';
   }
 
   checkPermissions(roles): boolean {

--- a/client/src/app/@core/utils/notifications.service.ts
+++ b/client/src/app/@core/utils/notifications.service.ts
@@ -6,6 +6,7 @@ import {Observable, ReplaySubject} from 'rxjs';
 import {SiteNotification} from '../models/notification.model';
 import {AuthService} from '../data/auth.service';
 import {NbToastrService} from '@nebular/theme';
+import {environment} from '../../../environments/environment';
 
 
 @Injectable()
@@ -32,12 +33,12 @@ export class NotificationsService {
   }
   checkNotifications() {
     if (this.authService.isAuthenticated())
-      this.http.get<any>('/api/user/notifications').subscribe(resp => this.notifications$.next(resp.notifications));
+      this.http.get<any>(environment.api + '/api/user/notifications').subscribe(resp => this.notifications$.next(resp.notifications));
   }
   get notifications(): Observable<SiteNotification[]> { return this.notifications$.asObservable(); }
 
   markNotificationAsRead(notification: SiteNotification) {
-    this.http.patch('/api/user/notifications/' + notification.id, {read: true})
+    this.http.patch(environment.api + '/api/user/notifications/' + notification.id, {read: true})
       .pipe(finalize(() => this.checkNotifications()))
       .subscribe(resp => {
     }, err => {
@@ -45,7 +46,7 @@ export class NotificationsService {
     });
   }
   dismissNotification(notif: SiteNotification) {
-    this.http.delete('/api/user/notifications/' + notif.id, { responseType: 'text'})
+    this.http.delete(environment.api + '/api/user/notifications/' + notif.id, { responseType: 'text'})
       .pipe(finalize(() => this.checkNotifications()))
       .subscribe(resp => {
     }, err => {

--- a/client/src/app/pages/dashboard/profile/profile-edit/profile-edit.component.ts
+++ b/client/src/app/pages/dashboard/profile/profile-edit/profile-edit.component.ts
@@ -12,6 +12,7 @@ import {User} from '../../../../@core/models/user.model';
 import {AdminService} from '../../../../@core/data/admin.service';
 import {ConfirmDialogComponent} from '../../../../@theme/components/confirm-dialog/confirm-dialog.component';
 import {NbDialogService, NbTabComponent, NbToastrService} from '@nebular/theme';
+import {environment} from '../../../../../environments/environment';
 
 @Component({
   selector: 'profile-edit',
@@ -132,7 +133,7 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
   }
 
   auth(platform: string) {
-    const childWnd = window.open(`/auth/${platform}?jwt=` + localStorage.getItem('accessToken'), 'myWindow',
+    const childWnd = window.open(environment.auth + `/auth/${platform}?jwt=` + localStorage.getItem('accessToken'), 'myWindow',
       'width=500,height=500');
     const timer = setInterval(() => {
       if (childWnd.closed) {

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -5,4 +5,6 @@
  */
 export const environment = {
   production: true,
+  api: 'https://api.momentum-mod.org',
+  auth: 'https://auth.momentum-mod.org',
 };

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -10,4 +10,6 @@
 
 export const environment = {
   production: false,
+  api: 'http://localhost:3002',
+  auth: 'http://localhost:3002',
 };


### PR DESCRIPTION
Copying from discord:

I think [Cloudflare Pages](https://pages.cloudflare.com/) can host our frontend for us automatically, actually. The change would become:

### Local dev:
Hosted on one machine, different ports are the angular and API processes, local proxy just forwards API requests to that port you're hosting it on

### Github review process
Any PR opened can have it hosted on a Cloudflare preview page, making it so that any frontend changes can instantly be previewed before merge, given it doesn't use API functions that don't exist yet.

### Production (cloudflare pages):
Frontend hosted by cloudflare, proxies the API calls to api.momentum-mod.org, which in DNS CNAME's to the VPS that hosts the backend (and frontend currently as well, but will eventually become *JUST* backend)

### Docker image:
Changes to only build the API and serve it on a specific port, where the VPS that runs it uses nginx to proxy into it 

---

It's entirely free, given we don't slam 500 commits out a month. We can (and should) still use GitHub's actions to do CI.

This pulls main website traffic off of our same machine serving the API, making the VPS that hosts the API more bandwidth-free. Previously we only relied on cloudflare to do only caching, but now it can do hosting + caching for us.

This will also significantly cut down the docker image build time to like 2 minutes or something, from the 12 ish it is now