### PR TITLE
Add Steam Encrypted App Ticket parsing

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,4 +1,4 @@
-name: Publish Docker
+name: Publish Backend Docker
 on:
   workflow_dispatch
 jobs:
@@ -6,6 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Resolve Yarn Cache Directory
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Cache Yarn Cache Directory
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('./server/yarn.lock') }}
+        restore-keys: ${{ runner.os }}-${{ env.NODE_VERSION }}-
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@3.04
       with:

--- a/env-vars.list
+++ b/env-vars.list
@@ -7,6 +7,10 @@ JWT_SECRET=
 
 # The Steam API web key (you can get it from https://steamcommunity.com/dev/apikey)
 STEAM_WEB_API_KEY=
+# Whether to use the authenticated tickets library, "true" enables it
+STEAM_USE_ENCRYPTED_TICKETS=
+# If the above is true, this value is the secret key to use for decrypting the ticket
+STEAM_TICKETS_SECRET=
 
 # The database user, password, and host
 MOM_DATABASE_USER=

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -31,6 +31,8 @@ const config = {
 		steam: {
 			webAPIKey: process.env.STEAM_WEB_API_KEY,
 			preventLimited: true,
+			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS,
+			ticketsSecretKey: process.env.STEAM_TICKETS_SECRET,
 		},
 		db: {
 			name: 'momentum_test',
@@ -77,6 +79,8 @@ const config = {
 		steam: {
 			webAPIKey: process.env.STEAM_WEB_API_KEY,
 			preventLimited: true,
+			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS,
+			ticketsSecretKey: process.env.STEAM_TICKETS_SECRET,
 		},
 		db: {
 			name: 'momentum',
@@ -123,6 +127,8 @@ const config = {
 		steam: {
 			webAPIKey: process.env.STEAM_WEB_API_KEY,
 			preventLimited: true,
+			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS,
+			ticketsSecretKey: process.env.STEAM_TICKETS_SECRET,
 		},
 		db: {
 			name: 'momentum',

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -62,6 +62,8 @@ module.exports = (app, config) => {
 				level: 'info',
 			})
 		);
+
+		app.use(cors({ origin: config.baseURL, exposedHeaders: [ 'Location' ] }));
 	}
 
 	const logger = bunyan.createLogger({
@@ -76,7 +78,6 @@ module.exports = (app, config) => {
 		app.use(bunyanMiddleware({ logger: logger }));
 	}
 
-	app.use(cors({ origin: config.baseURL, exposedHeaders: [ 'Location' ] }));
 	app.use(express.json());
 	app.use(compress());
 	app.use(express.static(config.root + '/public'));

--- a/server/package.json
+++ b/server/package.json
@@ -36,6 +36,7 @@
     "passport-twitter": "1.0.4",
     "sequelize": "6.2.2",
     "sharp": "0.25.4",
+    "steam-appticket": "^1.0.1",
     "swagger-jsdoc": "4.0.0",
     "swagger-ui-express": "4.1.4",
     "xml2js": "0.4.23"

--- a/server/test/user.js
+++ b/server/test/user.js
@@ -2,76 +2,76 @@
 process.env.NODE_ENV = 'test';
 
 const { forceSyncDB, User, Profile, Map, MapInfo, Activity, MapCredit, MapStats, MapImage, MapTrack, MapZone, UserStats } = require('../config/sqlize'),
-    chai = require('chai'),
-    chaiHttp = require('chai-http'),
-    expect = chai.expect,
-    server = require('../server.js'),
-    auth = require('../src/models/auth'),
+	chai = require('chai'),
+	chaiHttp = require('chai-http'),
+	expect = chai.expect,
+	server = require('../server.js'),
+	auth = require('../src/models/auth'),
 	user = require('../src/models/user'),
-    map = require('../src/models/map'),
-    activity = require('../src/models/activity'),
+	map = require('../src/models/map'),
+	activity = require('../src/models/activity'),
 	fs = require('fs');
 
 chai.use(chaiHttp);
 
 describe('user', () => {
 
-    let accessToken = null;
-    let accessToken2 = null;
-    let adminAccessToken = null;
+	let accessToken = null;
+	let accessToken2 = null;
+	let adminAccessToken = null;
 	let adminGameAccessToken = null;
-    const testUser = {
-        id: 1,
-        steamID: '76561198131664084',
+	const testUser = {
+		id: 1,
+		steamID: '76561198131664084',
 		alias: 'cjshiner',
 		avatarURL: 'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/e4/e4db45e6d6472d9e61b131a04ad2f18a299daafc_full.jpg',
-        roles: user.Role.MAPPER,
-        bans: 0,
-        country: 'US',
-        profile: {
-            bio: '',
-        },
-        stats: {
-            mapsCompleted: 3,
-        },
-    };
-    const testUser2 = {
-        id: 2,
-        steamID: '00000000000000002',
+		roles: user.Role.MAPPER,
+		bans: 0,
+		country: 'US',
+		profile: {
+			bio: '',
+		},
+		stats: {
+			mapsCompleted: 3,
+		},
+	};
+	const testUser2 = {
+		id: 2,
+		steamID: '00000000000000002',
 		alias: 'test2',
 		avatarURL: 'https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/e4/e4db45e6d6472d9e61b131a04ad2f18a299daafc_full.jpg',
-        roles: user.Role.MAPPER,
-        bans: 0,
-        country: 'US',
-        profile: {
-            bio: 'test2',
-        }
-    };
-    const testUser3 = {
-        id: 3,
-        steamID: '00000000000000003',
+		roles: user.Role.MAPPER,
+		bans: 0,
+		country: 'US',
+		profile: {
+			bio: 'test2',
+		}
+	};
+	const testUser3 = {
+		id: 3,
+		steamID: '00000000000000003',
 		alias: 'test3',
 		avatarURL: 'http://google.com',
-        roles: user.Role.MAPPER,
-        bans: 0,
-        country: 'US',
-        profile: {
-            bio: 'test3',
-        }
-    };
+		roles: user.Role.MAPPER,
+		bans: 0,
+		country: 'US',
+		profile: {
+			bio: 'test3',
+		}
+	};
 
-    const testAdmin = {
-        id: 4,
-        steamID: '0909',
+	const testAdmin = {
+		id: 4,
+		steamID: '0909',
 		alias: 'testAdmin',
 		avatarURL: 'http://google.com',
-        roles: user.Role.ADMIN,
-        bans: 0,
-        country: 'US',
-        profile: {
-            bio: 'testAdmin',
-        }
-    };
+		roles: user.Role.ADMIN,
+		bans: 0,
+		country: 'US',
+		profile: {
+			bio: 'testAdmin',
+		}
+	};
 
 	const testAdminGame = {
 		id: 5,
@@ -81,22 +81,22 @@ describe('user', () => {
 		country: 'US',
 	};
 
-    const testMap = {
-        name: 'test_map_one',
-        type: map.MAP_TYPE.UNKNOWN,
-        id: 1,
-        statusFlag: map.STATUS.APPROVED,
-        submitterID: testUser.id,
-        info: {
-            description: 'My first map!!!!',
-            numTracks: 1,
-            creationDate: new Date(),
-        },
-        tracks: [{
-            trackNum: 0,
-            numZones: 1,
-            isLinear: false,
-            difficulty: 5,
+	const testMap = {
+		name: 'test_map_one',
+		type: map.MAP_TYPE.UNKNOWN,
+		id: 1,
+		statusFlag: map.STATUS.APPROVED,
+		submitterID: testUser.id,
+		info: {
+			description: 'My first map!!!!',
+			numTracks: 1,
+			creationDate: new Date(),
+		},
+		tracks: [{
+			trackNum: 0,
+			numZones: 1,
+			isLinear: false,
+			difficulty: 5,
 			zones: [
 				{
 					zoneNum: 0,
@@ -108,123 +108,123 @@ describe('user', () => {
 				}
 			]
 		}],
-        credits: {
-            id: 1,
-            type: map.CreditType.AUTHOR,
-            userID: testUser.id,
-        },
-        images: {
-            id: 1,
-            URL: 'https://media.moddb.com/cache/images/mods/1/29/28895/thumb_620x2000/Wallpaper.jpg'
-        },
-        stats: {
-            id: 1,
-            totalReviews: 1,
-        }
-    };
+		credits: {
+			id: 1,
+			type: map.CreditType.AUTHOR,
+			userID: testUser.id,
+		},
+		images: {
+			id: 1,
+			URL: 'https://media.moddb.com/cache/images/mods/1/29/28895/thumb_620x2000/Wallpaper.jpg'
+		},
+		stats: {
+			id: 1,
+			totalReviews: 1,
+		}
+	};
 
-    const testMap2 = {
-        id: 222,
-        name: 'test_map_two',
-        type: map.MAP_TYPE.BHOP,
-        statusFlag: map.STATUS.APPROVED,
-        submitterID: testUser.id,
-        info: {
-            description: 'My test map!!!!',
-            numTracks: 1,
-            creationDate: new Date(),
-        },
-        tracks: [{
-            trackNum: 0,
-            numZones: 1,
-            isLinear: false,
-            difficulty: 5,
-        }],
-        credits: {
-            id: 2,
-            type: map.CreditType.AUTHOR,
-            userID: testUser.id,
-        },
-        images: {
-            id: 3,
-            URL: 'http://localhost:3002/img/maps/testmap.jpg'
-        }
-    };
+	const testMap2 = {
+		id: 222,
+		name: 'test_map_two',
+		type: map.MAP_TYPE.BHOP,
+		statusFlag: map.STATUS.APPROVED,
+		submitterID: testUser.id,
+		info: {
+			description: 'My test map!!!!',
+			numTracks: 1,
+			creationDate: new Date(),
+		},
+		tracks: [{
+			trackNum: 0,
+			numZones: 1,
+			isLinear: false,
+			difficulty: 5,
+		}],
+		credits: {
+			id: 2,
+			type: map.CreditType.AUTHOR,
+			userID: testUser.id,
+		},
+		images: {
+			id: 3,
+			URL: 'http://localhost:3002/img/maps/testmap.jpg'
+		}
+	};
 
-    const testMap3 = {
-        id: 444,
-        name: 'test_map',
-        type: map.MAP_TYPE.SURF,
-        submitterID: testUser.id,
-        statusFlag: map.STATUS.NEEDS_REVISION,
-        info: {
-            description: 'test3',
-            numTracks: 1,
-            creationDate: new Date(),
-        },
-        tracks: [{
-            trackNum: 0,
-            numZones: 1,
-            isLinear: false,
-            difficulty: 5,
-        }],
-        credits: {
-            id: 3,
-            type: map.CreditType.AUTHOR,
-            userID: testUser.id,
-        },
-    };
+	const testMap3 = {
+		id: 444,
+		name: 'test_map',
+		type: map.MAP_TYPE.SURF,
+		submitterID: testUser.id,
+		statusFlag: map.STATUS.NEEDS_REVISION,
+		info: {
+			description: 'test3',
+			numTracks: 1,
+			creationDate: new Date(),
+		},
+		tracks: [{
+			trackNum: 0,
+			numZones: 1,
+			isLinear: false,
+			difficulty: 5,
+		}],
+		credits: {
+			id: 3,
+			type: map.CreditType.AUTHOR,
+			userID: testUser.id,
+		},
+	};
 
-    const testmappost = {
-        id: 13333,
-        name: 'test_map_post',
-        info: {
-            description: 'testpost',
-            numTracks: 1,
-            creationDate: new Date(),
-        },
-        tracks: [{
-            trackNum: 0,
-            numZones: 1,
-            isLinear: false,
-            difficulty: 5,
-        }],
-    };
+	const testmappost = {
+		id: 13333,
+		name: 'test_map_post',
+		info: {
+			description: 'testpost',
+			numTracks: 1,
+			creationDate: new Date(),
+		},
+		tracks: [{
+			trackNum: 0,
+			numZones: 1,
+			isLinear: false,
+			difficulty: 5,
+		}],
+	};
 
 	const testActivities = [
 		{
-	        userID: testUser.id,
-	        data: 1337,
+			userID: testUser.id,
+			data: 1337,
 			type: activity.ACTIVITY_TYPES.ALL,
-	    },
+		},
 		{
-	        userID: testUser2.id,
-	        data: 1337,
+			userID: testUser2.id,
+			data: 1337,
 			type: activity.ACTIVITY_TYPES.MAP_APPROVED,
-	    },
+		},
 		{
-	        userID: testUser2.id,
-	        data: 1337,
+			userID: testUser2.id,
+			data: 1337,
 			type: activity.ACTIVITY_TYPES.ALL,
-	    }
+		}
 	];
 
 
-    before(() => {
-        return forceSyncDB()
-            .then(() => {
-                testAdmin.roles |= user.Role.ADMIN;
-                return auth.genAccessToken(testAdmin);
-            })
-            .then((token) => {
-                adminAccessToken = token;
-                return User.create(testAdmin,{
-                    include: [{
-                        model: Profile,
-                        as: 'profile',
-                    }]
-                })
-            })
+	before(() => {
+		return forceSyncDB()
+			.then(() => {
+				testAdmin.roles |= user.Role.ADMIN;
+				return auth.genAccessToken(testAdmin);
+			})
+			.then((token) => {
+				adminAccessToken = token;
+				return User.create(testAdmin,{
+					include: [{
+						model: Profile,
+						as: 'profile',
+					}]
+				})
+			})
 			.then(() => {
 				testAdminGame.roles |= user.Role.ADMIN;
 				return auth.genAccessToken(testAdminGame, true);
@@ -232,356 +232,356 @@ describe('user', () => {
 				adminGameAccessToken = token;
 				return User.create(testAdminGame);
 			})
-            .then(() => {
-                return auth.genAccessToken(testUser2);
-            })
-            .then((token) => {
-                accessToken2 = token;
-                return User.create(testUser2, {
-                    include: [
-                        {  model: Profile, as: 'profile',},
-                    ]
-                })
-            })
-            .then(() => {
-                return auth.genAccessToken(testUser);
-            })
-            .then((token) => {
-                accessToken = token;
-                return User.create(testUser, {
-                        include: [
-                            {  model: Profile, as: 'profile'},
-                            {  model: UserStats, as: 'stats'},
-                        ]
-                })
-            })
-            .then(() => {
-                return Map.create(testMap, {
-                    include: [
-                        {  model: MapInfo, as: 'info',},
-                        {  model: MapCredit, as: 'credits'},
+			.then(() => {
+				return auth.genAccessToken(testUser2);
+			})
+			.then((token) => {
+				accessToken2 = token;
+				return User.create(testUser2, {
+					include: [
+						{  model: Profile, as: 'profile',},
+					]
+				})
+			})
+			.then(() => {
+				return auth.genAccessToken(testUser);
+			})
+			.then((token) => {
+				accessToken = token;
+				return User.create(testUser, {
+						include: [
+							{  model: Profile, as: 'profile'},
+							{  model: UserStats, as: 'stats'},
+						]
+				})
+			})
+			.then(() => {
+				return Map.create(testMap, {
+					include: [
+						{  model: MapInfo, as: 'info',},
+						{  model: MapCredit, as: 'credits'},
 						{  model: MapTrack, as: 'tracks', include: [{ model: MapZone, as: 'zones' }] },
-                    ]
-                })
-            })
-            .then(user => {
-                return Map.create(testMap2, {
-                    include: [
-                        {  model: MapInfo, as: 'info',},
-                        {  model: MapImage, as: 'images'},
-                        {  model: MapCredit, as: 'credits'},
-                    ]
-                })
-            })
-            .then(user => {
-                return Map.create(testMap3, {
-                    include: [
-                        {  model: MapInfo, as: 'info',},
-                        {  model: MapCredit, as: 'credits'},
-                    ]
-                })
-            }).then(() => {
-                    return User.create(testUser3, {
-                        include: [{
-                            model: Profile,
-                            as: 'profile',
-                        }]
-                    })
-                .then(user => {
-                    testUser.id = user.id;
-                    return Activity.bulkCreate(testActivities);
-                });
-            });
-    });
+					]
+				})
+			})
+			.then(user => {
+				return Map.create(testMap2, {
+					include: [
+						{  model: MapInfo, as: 'info',},
+						{  model: MapImage, as: 'images'},
+						{  model: MapCredit, as: 'credits'},
+					]
+				})
+			})
+			.then(user => {
+				return Map.create(testMap3, {
+					include: [
+						{  model: MapInfo, as: 'info',},
+						{  model: MapCredit, as: 'credits'},
+					]
+				})
+			}).then(() => {
+					return User.create(testUser3, {
+						include: [{
+							model: Profile,
+							as: 'profile',
+						}]
+					})
+				.then(user => {
+					testUser.id = user.id;
+					return Activity.bulkCreate(testActivities);
+				});
+			});
+	});
 
-    describe('modules', () => {
+	describe('modules', () => {
 
-    });
+	});
 
-    describe('endpoints', () => {
+	describe('endpoints', () => {
 
-        describe('GET /api/user', () => {
-            it('should respond with user data', () => {
-                return chai.request(server)
-                    .get('/api/user')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('id');
-                        expect(res.body).to.have.property('createdAt');
-                    });
-            });
-
-
-            it('should respond with user data and expand profile data', () => {
-                return chai.request(server)
-                    .get('/api/user')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({ expand: "profile"})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('id');
-                        expect(res.body.profile).to.have.property('bio');
-                    });
-            });
-
-            it('should respond with user data and expand user stats', () => {
-                return chai.request(server)
-                    .get('/api/user')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({expand: 'stats'})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('id');
-                        expect(res.body.stats).to.have.property('totalJumps');
-                        expect(res.body.stats).to.have.property('id');
-                    });
-            });
-
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
-
-        describe('PATCH /api/user', () => {
-            it('should update the authenticated users profile', () => {
-                return chai.request(server)
-                    .patch('/api/user')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .send({
-                        alias: 'test2',
-                        profile: {
-                            bio: 'test',
-                        },
-                    })
-                    .then(res => {
-                        expect(res).to.have.status(204);
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .patch('/api/user')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
-
-        describe('GET /api/user/profile', () => {
-            it('should respond with authenticated users profile info', () => {
-                return chai.request(server)
-                    .get('/api/user/profile')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('id');
-                        expect(res.body).to.have.property('bio');
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/profile/')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+		describe('GET /api/user', () => {
+			it('should respond with user data', () => {
+				return chai.request(server)
+					.get('/api/user')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('id');
+						expect(res.body).to.have.property('createdAt');
+					});
+			});
 
 
-        // Come back to this test when the functionality is done
+			it('should respond with user data and expand profile data', () => {
+				return chai.request(server)
+					.get('/api/user')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({ expand: "profile"})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('id');
+						expect(res.body.profile).to.have.property('bio');
+					});
+			});
 
-        /*
-        describe('DELETE /api/user/profile/social/{type}', () => {
-            it('should return 200 and unlink the twitter account from the authd user', () => {
-                return chai.request(server)
-                .delete('/api/user/profile/social/' + 'twitter')
-                .set('Authorization', 'Bearer ' + accessToken)
-                .then(res => {
-                    expect(res).to.have.status(200);
-                    expect(res).to.be.json;
-                });
-            });
-             it('should return 200 and unlink the discord account from the authd user', () => {
-                return chai.request(server)
-                .delete('/api/user/profile/social/' + 'discord')
-                .set('Authorization', 'Bearer ' + accessToken)
-                .then(res => {
-                    expect(res).to.have.status(200);
-                    expect(res).to.be.json;
-                });
-            });
-             it('should return 200 and unlink the twitch account from the authd user', () => {
-                return chai.request(server)
-                .delete('/api/user/profile/social/' + 'twitch')
-                .set('Authorization', 'Bearer ' + accessToken)
-                .then(res => {
-                    expect(res).to.have.status(200);
-                    expect(res).to.be.json;
-                });
-            });
-        });
-        */
+			it('should respond with user data and expand user stats', () => {
+				return chai.request(server)
+					.get('/api/user')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({expand: 'stats'})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('id');
+						expect(res.body.stats).to.have.property('totalJumps');
+						expect(res.body.stats).to.have.property('id');
+					});
+			});
 
-        describe('GET /api/user/follow/{userID}', () => {
-            it('should check the relationship of the given and local user', () => {
-                return chai.request(server)
-                    .post('/api/user/follow')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .send({
-                        userID: testUser2.id
-                    })
-                    .then(res => {
-                        return chai.request(server)
-                            .get('/api/user/follow/' + testUser2.id)
-                            .set('Authorization', 'Bearer ' + accessToken)
-                            .then(res2 => {
-                                expect(res).to.have.status(200);
-                                expect(res).to.be.json;
-                                expect(res2).to.have.status(200);
-                                expect(res2).to.be.json;
-                                expect(res2.body).to.have.property('local');
-                                expect(res2.body.local).to.have.property('followeeID');
-                            });
-                    });
-            });
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
-            it('should only respond with the 200 code since the followed relationship does not exist', () => {
-                return chai.request(server)
-                    .get('/api/user/follow/12345')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.not.have.property('local');
-                    });
+		describe('PATCH /api/user', () => {
+			it('should update the authenticated users profile', () => {
+				return chai.request(server)
+					.patch('/api/user')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.send({
+						alias: 'test2',
+						profile: {
+							bio: 'test',
+						},
+					})
+					.then(res => {
+						expect(res).to.have.status(204);
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.patch('/api/user')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/follow/' + testUser2.id)
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+		describe('GET /api/user/profile', () => {
+			it('should respond with authenticated users profile info', () => {
+				return chai.request(server)
+					.get('/api/user/profile')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('id');
+						expect(res.body).to.have.property('bio');
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/profile/')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
+
+
+		// Come back to this test when the functionality is done
+
+		/*
+		describe('DELETE /api/user/profile/social/{type}', () => {
+			it('should return 200 and unlink the twitter account from the authd user', () => {
+				return chai.request(server)
+				.delete('/api/user/profile/social/' + 'twitter')
+				.set('Authorization', 'Bearer ' + accessToken)
+				.then(res => {
+					expect(res).to.have.status(200);
+					expect(res).to.be.json;
+				});
+			});
+			 it('should return 200 and unlink the discord account from the authd user', () => {
+				return chai.request(server)
+				.delete('/api/user/profile/social/' + 'discord')
+				.set('Authorization', 'Bearer ' + accessToken)
+				.then(res => {
+					expect(res).to.have.status(200);
+					expect(res).to.be.json;
+				});
+			});
+			 it('should return 200 and unlink the twitch account from the authd user', () => {
+				return chai.request(server)
+				.delete('/api/user/profile/social/' + 'twitch')
+				.set('Authorization', 'Bearer ' + accessToken)
+				.then(res => {
+					expect(res).to.have.status(200);
+					expect(res).to.be.json;
+				});
+			});
+		});
+		*/
+
+		describe('GET /api/user/follow/{userID}', () => {
+			it('should check the relationship of the given and local user', () => {
+				return chai.request(server)
+					.post('/api/user/follow')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.send({
+						userID: testUser2.id
+					})
+					.then(res => {
+						return chai.request(server)
+							.get('/api/user/follow/' + testUser2.id)
+							.set('Authorization', 'Bearer ' + accessToken)
+							.then(res2 => {
+								expect(res).to.have.status(200);
+								expect(res).to.be.json;
+								expect(res2).to.have.status(200);
+								expect(res2).to.be.json;
+								expect(res2.body).to.have.property('local');
+								expect(res2.body.local).to.have.property('followeeID');
+							});
+					});
+			});
+
+			it('should only respond with the 200 code since the followed relationship does not exist', () => {
+				return chai.request(server)
+					.get('/api/user/follow/12345')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.not.have.property('local');
+					});
+
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/follow/' + testUser2.id)
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
 
 
 
-        describe('POST /api/user/follow', () => {
-            it('should add user to authenticated users follow list', () => {
-                return chai.request(server)
-                    .post('/api/user/follow')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .send({
-                        userID: testUser3.id
-                    })
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/follow')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+		describe('POST /api/user/follow', () => {
+			it('should add user to authenticated users follow list', () => {
+				return chai.request(server)
+					.post('/api/user/follow')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.send({
+						userID: testUser3.id
+					})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/maps/follow')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
-        describe('PATCH /api/user/follow/{userID}', () => {
-            it('should update the following status of the local user and the followed user', () => {
-                return chai.request(server)
-                    .patch('/api/user/follow/' + testUser2.id)
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .send({
-                        notifyOn: activity.ACTIVITY_TYPES.ALL
-                    })
-                    .then(res => {
-                        expect(res).to.have.status(204);
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/follow/' + testUser2.id)
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+		describe('PATCH /api/user/follow/{userID}', () => {
+			it('should update the following status of the local user and the followed user', () => {
+				return chai.request(server)
+					.patch('/api/user/follow/' + testUser2.id)
+					.set('Authorization', 'Bearer ' + accessToken)
+					.send({
+						notifyOn: activity.ACTIVITY_TYPES.ALL
+					})
+					.then(res => {
+						expect(res).to.have.status(204);
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/follow/' + testUser2.id)
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
-        describe('DELETE /api/user/follow/{userID}', () => {
-            it('should remove the user from the local users follow list', () => {
-                return chai.request(server)
-                    .post('/api/user/follow')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .send({
-                        userID: testUser3.id
-                    })
-                    .then(res => {
-                        return chai.request(server)
-                            .get('/api/user/follow/' + testUser3.id)
-                            .set('Authorization', 'Bearer ' + accessToken)
-                            .then(res2 => {
-                                return chai.request(server)
-                                    .delete('/api/user/follow/' + testUser3.id )
-                                    .set('Authorization', 'Bearer ' + accessToken)
-                                    .then(res3 => {
-                                        expect(res).to.have.status(200);
-                                        expect(res).to.be.json;
-                                        expect(res2).to.have.status(200);
-                                        expect(res2).to.be.json;
-                                        expect(res2.body).to.have.property('local');
-                                        expect(res2.body.local).to.have.property('followeeID');
-                                        expect(res3).to.have.status(200);
-                                    });
-                            });
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/follow/' + testUser3.id)
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+		describe('DELETE /api/user/follow/{userID}', () => {
+			it('should remove the user from the local users follow list', () => {
+				return chai.request(server)
+					.post('/api/user/follow')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.send({
+						userID: testUser3.id
+					})
+					.then(res => {
+						return chai.request(server)
+							.get('/api/user/follow/' + testUser3.id)
+							.set('Authorization', 'Bearer ' + accessToken)
+							.then(res2 => {
+								return chai.request(server)
+									.delete('/api/user/follow/' + testUser3.id )
+									.set('Authorization', 'Bearer ' + accessToken)
+									.then(res3 => {
+										expect(res).to.have.status(200);
+										expect(res).to.be.json;
+										expect(res2).to.have.status(200);
+										expect(res2).to.be.json;
+										expect(res2.body).to.have.property('local');
+										expect(res2.body.local).to.have.property('followeeID');
+										expect(res3).to.have.status(200);
+									});
+							});
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/follow/' + testUser3.id)
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
 		describe('PUT /api/user/notifyMap/{mapID}', () => {
 			it('should update map notification status or create new map notification status if no existing notifcations', () => {
@@ -657,71 +657,71 @@ describe('user', () => {
 
 		describe('GET /api/user/notifications', () => {
 			it('should respond with notification data', async function() {
-                const serv = chai.request(server).keepOpen();
+				const serv = chai.request(server).keepOpen();
 
-                // testUser follows testUser2
-                const res1 = await serv.post('/api/user/follow')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .send({
-                        userID: testUser2.id
-                    });
+				// testUser follows testUser2
+				const res1 = await serv.post('/api/user/follow')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.send({
+						userID: testUser2.id
+					});
 
-                // changes the follow relationship between testUser and testUser2 to notify when a map is approved
-                const res2 = await serv.patch('/api/user/follow/' + testUser2.id)
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .send({
-                        notifyOn: 1 << activity.ACTIVITY_TYPES.MAP_APPROVED
-                    });
+				// changes the follow relationship between testUser and testUser2 to notify when a map is approved
+				const res2 = await serv.patch('/api/user/follow/' + testUser2.id)
+					.set('Authorization', 'Bearer ' + accessToken)
+					.send({
+						notifyOn: 1 << activity.ACTIVITY_TYPES.MAP_APPROVED
+					});
 
-                // testUser2 creates a map
-                const res3 = await serv.post('/api/maps')
-                    .set('Authorization', 'Bearer ' + accessToken2)
-                    .send({
-                        name: 'test_map_notif',
-                        type: map.MAP_TYPE.SURF,
-                        info: {
-                            description: 'newmap_5',
-                            numTracks: 1,
-                            creationDate: new Date(),
-                        },
-                        tracks: [{
-                            trackNum: 0,
-                            numZones: 1,
-                            isLinear: false,
-                            difficulty: 5,
-                        }],
-                        credits: [{
-                            userID: testUser2.id,
-                            type: map.CreditType.AUTHOR,
-                        }]
-                    });
+				// testUser2 creates a map
+				const res3 = await serv.post('/api/maps')
+					.set('Authorization', 'Bearer ' + accessToken2)
+					.send({
+						name: 'test_map_notif',
+						type: map.MAP_TYPE.SURF,
+						info: {
+							description: 'newmap_5',
+							numTracks: 1,
+							creationDate: new Date(),
+						},
+						tracks: [{
+							trackNum: 0,
+							numZones: 1,
+							isLinear: false,
+							difficulty: 5,
+						}],
+						credits: [{
+							userID: testUser2.id,
+							type: map.CreditType.AUTHOR,
+						}]
+					});
 
-                // upload the map
-                const res4 = await serv.post(new URL( res3.header.location ).pathname)
-                    .set('Authorization', 'Bearer ' + accessToken2)
-                    .attach('mapFile', fs.readFileSync('test/testMap.bsp'), 'testMap.bsp');
+				// upload the map
+				const res4 = await serv.post(new URL( res3.header.location ).pathname)
+					.set('Authorization', 'Bearer ' + accessToken2)
+					.attach('mapFile', fs.readFileSync('test/testMap.bsp'), 'testMap.bsp');
 
-                // testadmin approves the map
-                const res5 = await serv.patch('/api/admin/maps/' + res3.body.id)
-                    .set('Authorization', 'Bearer ' + adminAccessToken)
-                    .send({ statusFlag: map.STATUS.APPROVED });
+				// testadmin approves the map
+				const res5 = await serv.patch('/api/admin/maps/' + res3.body.id)
+					.set('Authorization', 'Bearer ' + adminAccessToken)
+					.send({ statusFlag: map.STATUS.APPROVED });
 
-                // should get the notification that testUser2's map was approved
-                const res6 = await serv.get('/api/user/notifications')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res6 => {
-                        expect(res1).to.have.status(200);
-                        expect(res2).to.have.status(204);
-                        expect(res3).to.have.status(200);
-                        expect(res4).to.have.status(200);
-                        expect(res5).to.have.status(204);
-                        expect(res6).to.have.status(200);
-                        expect(res6.body).to.have.property('notifications');
-                        expect(res6.body.notifications).to.be.an('array');
-                        expect(res6.body.notifications).to.have.length(1);
-                    }).finally(() => {});
+				// should get the notification that testUser2's map was approved
+				const res6 = await serv.get('/api/user/notifications')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res6 => {
+						expect(res1).to.have.status(200);
+						expect(res2).to.have.status(204);
+						expect(res3).to.have.status(200);
+						expect(res4).to.have.status(200);
+						expect(res5).to.have.status(204);
+						expect(res6).to.have.status(200);
+						expect(res6.body).to.have.property('notifications');
+						expect(res6.body.notifications).to.be.an('array');
+						expect(res6.body.notifications).to.have.length(1);
+					}).finally(() => {});
 
-                serv.close();
+				serv.close();
 			});
 		});
 		// Commented out until the 0.10.0 replay refactor
@@ -827,459 +827,459 @@ describe('user', () => {
 			});
 		});
 
-        describe('PUT /api/user/maps/library/{mapID}', () => {
-            it('should add a new map to the local users library', () => {
-                return chai.request(server)
-                    .put('/api/user/maps/library/' + testMap2.id)
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('id');
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .post('/api/user/maps/library')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+		describe('PUT /api/user/maps/library/{mapID}', () => {
+			it('should add a new map to the local users library', () => {
+				return chai.request(server)
+					.put('/api/user/maps/library/' + testMap2.id)
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('id');
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.post('/api/user/maps/library')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
-        describe('GET /api/user/maps/library', () => {
-            it('should retrieve the list of maps in the local users library', ()=> {
-                return chai.request(server)
-                    .put('/api/user/maps/library/' + testMap.id)
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        return chai.request(server)
-                            .get('/api/user/maps/library')
-                            .set('Authorization', 'Bearer ' + accessToken)
-                            .then(res2 => {
-                                expect(res).to.have.status(200);
-                                expect(res2).to.have.status(200);
-                                expect(res2).to.be.json;
-                                expect(res2.body.entries).to.be.an('array');
-                                expect(res2.body.entries).to.have.length(2);
-                                expect(res2.body.entries[0]).to.have.property('userID');
-                                expect(res2.body.entries[0]).to.have.property('map');
-                            })
+		describe('GET /api/user/maps/library', () => {
+			it('should retrieve the list of maps in the local users library', ()=> {
+				return chai.request(server)
+					.put('/api/user/maps/library/' + testMap.id)
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						return chai.request(server)
+							.get('/api/user/maps/library')
+							.set('Authorization', 'Bearer ' + accessToken)
+							.then(res2 => {
+								expect(res).to.have.status(200);
+								expect(res2).to.have.status(200);
+								expect(res2).to.be.json;
+								expect(res2.body.entries).to.be.an('array');
+								expect(res2.body.entries).to.have.length(2);
+								expect(res2.body.entries[0]).to.have.property('userID');
+								expect(res2.body.entries[0]).to.have.property('map');
+							})
 
-                    });
-            });
+					});
+			});
 
-            it('should retrieve a filtered list of maps in the local users library using the limit query', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/library')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({limit: 1})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body.entries).to.be.an('array');
-                        expect(res.body.entries).to.have.length(1);
-                        expect(res.body.entries[0]).to.have.property('userID');
-                        expect(res.body.entries[0]).to.have.property('map');
-                    })
-            });
-            it('should retrieve a filtered list of maps in the local users library using the offset query', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/library')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({offset: 1})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body.entries).to.be.an('array');
-                        expect(res.body.entries).to.have.length(1);
-                        expect(res.body.entries[0]).to.have.property('userID');
-                        expect(res.body.entries[0]).to.have.property('map');
-                    })
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/library/')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+			it('should retrieve a filtered list of maps in the local users library using the limit query', () => {
+				return chai.request(server)
+					.get('/api/user/maps/library')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({limit: 1})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body.entries).to.be.an('array');
+						expect(res.body.entries).to.have.length(1);
+						expect(res.body.entries[0]).to.have.property('userID');
+						expect(res.body.entries[0]).to.have.property('map');
+					})
+			});
+			it('should retrieve a filtered list of maps in the local users library using the offset query', () => {
+				return chai.request(server)
+					.get('/api/user/maps/library')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({offset: 1})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body.entries).to.be.an('array');
+						expect(res.body.entries).to.have.length(1);
+						expect(res.body.entries[0]).to.have.property('userID');
+						expect(res.body.entries[0]).to.have.property('map');
+					})
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/maps/library/')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
-        describe('GET /api/user/maps/library/{mapID}', () => {
-            it('should check if a map exists in the local users library', () => {
-                return chai.request(server)
-                    .put('/api/user/maps/library/' + testMap3.id)
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        return chai.request(server)
-                            .get('/api/user/maps/library/' + testMap3.id)
-                            .set('Authorization', 'Bearer ' + accessToken)
-                            .then(res2 => {
-                                expect(res).to.have.status(200);
-                                expect(res).to.be.json;
-                                expect(res2).to.have.status(200);
-                            });
-                    });
-            });
+		describe('GET /api/user/maps/library/{mapID}', () => {
+			it('should check if a map exists in the local users library', () => {
+				return chai.request(server)
+					.put('/api/user/maps/library/' + testMap3.id)
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						return chai.request(server)
+							.get('/api/user/maps/library/' + testMap3.id)
+							.set('Authorization', 'Bearer ' + accessToken)
+							.then(res2 => {
+								expect(res).to.have.status(200);
+								expect(res).to.be.json;
+								expect(res2).to.have.status(200);
+							});
+					});
+			});
 
-            it('should return 404 since the map is not in the local users library', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/library/89898')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        expect(res).to.have.status(404);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(404);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
+			it('should return 404 since the map is not in the local users library', () => {
+				return chai.request(server)
+					.get('/api/user/maps/library/89898')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						expect(res).to.have.status(404);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(404);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
 
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/library/' + testMap3.id)
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/maps/library/' + testMap3.id)
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
 
-        });
+		});
 
-        describe('DELETE /api/user/maps/library/{mapID}', () => {
-            it('should delete a library entry from the local users library', () => {
-                return chai.request(server)
-                    .delete('/api/user/maps/library/' + testMap.id)
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        return chai.request(server)
-                            .get('/api/user/maps/library/' + testMap.id)
-                            .set('Authorization', 'Bearer ' + accessToken)
-                            .then(res2 => {
-                                expect(res).to.have.status(200);
-                                expect(res2).to.have.status(404);
-                                expect(res2).to.be.json;
-                                expect(res2.body).to.have.property('error');
-                                expect(res2.body.error.code).equal(404);
-                                expect(res2.body.error.message).to.be.a('string');
-                            });
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .delete('/api/user/maps/library/' + testMap.id)
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+		describe('DELETE /api/user/maps/library/{mapID}', () => {
+			it('should delete a library entry from the local users library', () => {
+				return chai.request(server)
+					.delete('/api/user/maps/library/' + testMap.id)
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						return chai.request(server)
+							.get('/api/user/maps/library/' + testMap.id)
+							.set('Authorization', 'Bearer ' + accessToken)
+							.then(res2 => {
+								expect(res).to.have.status(200);
+								expect(res2).to.have.status(404);
+								expect(res2).to.be.json;
+								expect(res2.body).to.have.property('error');
+								expect(res2.body.error.code).equal(404);
+								expect(res2.body.error.message).to.be.a('string');
+							});
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.delete('/api/user/maps/library/' + testMap.id)
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
-        describe('GET /api/user/maps/submitted', () => {
-            it('should retrieve a list of maps submitted by the local user', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/submitted')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('count');
-                        expect(res.body).to.have.property('maps');
-                        expect(res.body.maps).to.be.an('array');
-                        expect(res.body.maps).to.have.length(3);
-                    });
-            });
+		describe('GET /api/user/maps/submitted', () => {
+			it('should retrieve a list of maps submitted by the local user', () => {
+				return chai.request(server)
+					.get('/api/user/maps/submitted')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('count');
+						expect(res.body).to.have.property('maps');
+						expect(res.body.maps).to.be.an('array');
+						expect(res.body.maps).to.have.length(3);
+					});
+			});
 
-            it('should should retrieve a list of maps submitted by the local user filtered with the limit query', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/submitted')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({limit: 1})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('count');
-                        expect(res.body).to.have.property('maps');
-                        expect(res.body.maps).to.be.an('array');
-                        expect(res.body.maps).to.have.length(1);
-                    });
-            });
+			it('should should retrieve a list of maps submitted by the local user filtered with the limit query', () => {
+				return chai.request(server)
+					.get('/api/user/maps/submitted')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({limit: 1})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('count');
+						expect(res.body).to.have.property('maps');
+						expect(res.body.maps).to.be.an('array');
+						expect(res.body.maps).to.have.length(1);
+					});
+			});
 
-            it('should should retrieve a list of maps submitted by the local user filtered with the offset query', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/submitted')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({offset: 1})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('count');
-                        expect(res.body).to.have.property('maps');
-                        expect(res.body.maps).to.be.an('array');
-                        expect(res.body.maps).to.have.length(2);
-                    });
-            });
-            it('should should retrieve a list of maps submitted by the local user filtered with the search query', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/submitted')
-                    .set('Authorization', 'Bearer ' + accessToken2)
-                    .query({search: testMap3.name})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('count');
-                        expect(res.body).to.have.property('maps');
-                        expect(res.body.maps).to.be.an('array');
-                        expect(res.body.maps).to.have.length(1);
-                    });
-            });
-            it('should should retrieve a list of maps submitted by the local user filtered with the expand query', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/submitted')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({expand: 'info'})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('count');
-                        expect(res.body).to.have.property('maps');
-                        expect(res.body.maps).to.be.an('array');
-                        expect(res.body.maps).to.have.length(3);
-                        expect(res.body.maps[0].info).to.have.property('description');
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/submitted')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+			it('should should retrieve a list of maps submitted by the local user filtered with the offset query', () => {
+				return chai.request(server)
+					.get('/api/user/maps/submitted')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({offset: 1})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('count');
+						expect(res.body).to.have.property('maps');
+						expect(res.body.maps).to.be.an('array');
+						expect(res.body.maps).to.have.length(2);
+					});
+			});
+			it('should should retrieve a list of maps submitted by the local user filtered with the search query', () => {
+				return chai.request(server)
+					.get('/api/user/maps/submitted')
+					.set('Authorization', 'Bearer ' + accessToken2)
+					.query({search: testMap3.name})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('count');
+						expect(res.body).to.have.property('maps');
+						expect(res.body.maps).to.be.an('array');
+						expect(res.body.maps).to.have.length(1);
+					});
+			});
+			it('should should retrieve a list of maps submitted by the local user filtered with the expand query', () => {
+				return chai.request(server)
+					.get('/api/user/maps/submitted')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({expand: 'info'})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('count');
+						expect(res.body).to.have.property('maps');
+						expect(res.body.maps).to.be.an('array');
+						expect(res.body.maps).to.have.length(3);
+						expect(res.body.maps[0].info).to.have.property('description');
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/maps/submitted')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
-        describe('/user/maps/submitted/summary', () => {
-           it('should return a summary of maps submitted by the user', () => {
-               return chai.request(server)
-                   .get('/api/user/maps/submitted/summary')
-                   .set('Authorization', 'Bearer ' + accessToken)
-                   .then(res => {
-                       expect(res).to.have.status(200);
-                       expect(res).to.be.json;
-                       expect(res.body).to.be.an('array');
-                     //  expect(res.body).to.have.property('statusFlag');
-                       // not sure how to get the statusFlag data since the array doesn't have a name?
-                   });
-           });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/maps/submitted/summary')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
+		describe('/user/maps/submitted/summary', () => {
+		   it('should return a summary of maps submitted by the user', () => {
+			   return chai.request(server)
+				   .get('/api/user/maps/submitted/summary')
+				   .set('Authorization', 'Bearer ' + accessToken)
+				   .then(res => {
+					   expect(res).to.have.status(200);
+					   expect(res).to.be.json;
+					   expect(res.body).to.be.an('array');
+					 //  expect(res.body).to.have.property('statusFlag');
+					   // not sure how to get the statusFlag data since the array doesn't have a name?
+				   });
+		   });
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/maps/submitted/summary')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
 
-        describe('GET /api/user/activities', () => {
-            it('should retrieve the local users activities', () => {
-                return chai.request(server)
-                    .get('/api/user/activities')
-                    .set('Authorization', 'Bearer ' + accessToken2)
-                    .then(res => {
-                       expect(res).to.have.status(200);
-                       expect(res.body.activities).to.be.an('array');
+		describe('GET /api/user/activities', () => {
+			it('should retrieve the local users activities', () => {
+				return chai.request(server)
+					.get('/api/user/activities')
+					.set('Authorization', 'Bearer ' + accessToken2)
+					.then(res => {
+					   expect(res).to.have.status(200);
+					   expect(res.body.activities).to.be.an('array');
 						expect(res.body.activities).to.have.length(4);
-                       expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
+					   expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
 
-            it('should retrieve the filtered local users activities using the limit parameter', () => {
-                return chai.request(server)
-                    .get('/api/user/activities')
-                    .set('Authorization', 'Bearer ' + accessToken2)
-                    .query({limit: 1})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
-                        expect(res.body.activities).to.have.length(1);
-                        expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
-            it('should retrieve the filtered local users activities using the offset parameter', () => {
-                return chai.request(server)
-                    .get('/api/user/activities')
-                    .set('Authorization', 'Bearer ' + accessToken2)
-                    .query({offset: 1})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
+			it('should retrieve the filtered local users activities using the limit parameter', () => {
+				return chai.request(server)
+					.get('/api/user/activities')
+					.set('Authorization', 'Bearer ' + accessToken2)
+					.query({limit: 1})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
+						expect(res.body.activities).to.have.length(1);
+						expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
+			it('should retrieve the filtered local users activities using the offset parameter', () => {
+				return chai.request(server)
+					.get('/api/user/activities')
+					.set('Authorization', 'Bearer ' + accessToken2)
+					.query({offset: 1})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
 						expect(res.body.activities).to.have.length(3);
-                        expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
-            it('should retrieve the filtered local users activities using the type parameter', () => {
-                return chai.request(server)
-                    .get('/api/user/activities')
-                    .set('Authorization', 'Bearer ' + accessToken2)
-                    .query({type: activity.ACTIVITY_TYPES.MAP_APPROVED})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
+						expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
+			it('should retrieve the filtered local users activities using the type parameter', () => {
+				return chai.request(server)
+					.get('/api/user/activities')
+					.set('Authorization', 'Bearer ' + accessToken2)
+					.query({type: activity.ACTIVITY_TYPES.MAP_APPROVED})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
 						expect(res.body.activities).to.have.length(2);
-                        expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
-            it('should retrieve the filtered local users activities using the data parameter', () => {
-                return chai.request(server)
-                    .get('/api/user/activities')
-                    .set('Authorization', 'Bearer ' + accessToken2)
-                    .query({data: 1337})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
-                        expect(res.body.activities).to.have.length(2);
-                        expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
-            it('should retrieve the local users activities along with an expand (user) parameter', () => {
-                return chai.request(server)
-                    .get('/api/user/activities')
-                    .set('Authorization', 'Bearer ' + accessToken2)
-                    .query({expand: 'user'})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
-						expect(res.body.activities).to.have.length(4);
-                        expect(res.body.activities[0]).to.have.property('id');
-                        expect(res.body.activities[0].user).to.have.property('roles');
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/activities')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
-        });
-
-        describe('GET /api/user/activities/followed', () => {
-            it('should add user to authenticated users follow list', () => {
-                return chai.request(server)
-                    .post('/api/user/follow')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .send({
-                        userID: testUser2.id
-                    })
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res).to.be.json;
-                    });
-            });
-            it('should retrieve a list of activities from the local users followed users', () => {
-                return chai.request(server)
-                    .get('/api/user/activities/followed')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
-						expect(res.body.activities).to.have.length(4);
-                        expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
-
-            it('should retrieve a filtered list of activities from the local users followed users using the limit parameter', () => {
-                return chai.request(server)
-                // limit... is the limit I set -1. limit three returns 2 and limit two returns 1
-                    .get('/api/user/activities/followed')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({limit: 2})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
-                   //     expect(res.body.activities).to.have.length(1);
-                        expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
-            it('should retrieve a filtered list of activities from the local users followed users using the offset parameter', () => {
-                return chai.request(server)
-                    // same problem as offset i think
-                    // length issue
-                    .get('/api/user/activities/followed')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({offset: 1})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
-                   //     expect(res.body.activities).to.have.length(1);
-                        expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
-            it('should retrieve a filtered list of activities from the local users followed users using the type parameter', () => {
-                return chai.request(server)
-                    .get('/api/user/activities/followed')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({type: activity.ACTIVITY_TYPES.MAP_APPROVED})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
+						expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
+			it('should retrieve the filtered local users activities using the data parameter', () => {
+				return chai.request(server)
+					.get('/api/user/activities')
+					.set('Authorization', 'Bearer ' + accessToken2)
+					.query({data: 1337})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
 						expect(res.body.activities).to.have.length(2);
-                        expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
-            it('should retrieve a filtered list of activities from the local users followed users using the data parameter', () => {
-                return chai.request(server)
-                    .get('/api/user/activities/followed')
-                    .set('Authorization', 'Bearer ' + accessToken)
-                    .query({data: 1337})
-                    .then(res => {
-                        expect(res).to.have.status(200);
-                        expect(res.body.activities).to.be.an('array');
-                        expect(res.body.activities).to.have.length(2);
-                        expect(res.body.activities[0]).to.have.property('id');
-                    });
-            });
-            it('should respond with 401 when no access token is provided', () => {
-                return chai.request(server)
-                    .get('/api/user/activities/followed')
-                    .then(res => {
-                        expect(res).to.have.status(401);
-                        expect(res).to.be.json;
-                        expect(res.body).to.have.property('error');
-                        expect(res.body.error.code).equal(401);
-                        expect(res.body.error.message).to.be.a('string');
-                    });
-            });
+						expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
+			it('should retrieve the local users activities along with an expand (user) parameter', () => {
+				return chai.request(server)
+					.get('/api/user/activities')
+					.set('Authorization', 'Bearer ' + accessToken2)
+					.query({expand: 'user'})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
+						expect(res.body.activities).to.have.length(4);
+						expect(res.body.activities[0]).to.have.property('id');
+						expect(res.body.activities[0].user).to.have.property('roles');
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/activities')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+		});
 
-        });
+		describe('GET /api/user/activities/followed', () => {
+			it('should add user to authenticated users follow list', () => {
+				return chai.request(server)
+					.post('/api/user/follow')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.send({
+						userID: testUser2.id
+					})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res).to.be.json;
+					});
+			});
+			it('should retrieve a list of activities from the local users followed users', () => {
+				return chai.request(server)
+					.get('/api/user/activities/followed')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
+						expect(res.body.activities).to.have.length(4);
+						expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
 
-    });
+			it('should retrieve a filtered list of activities from the local users followed users using the limit parameter', () => {
+				return chai.request(server)
+				// limit... is the limit I set -1. limit three returns 2 and limit two returns 1
+					.get('/api/user/activities/followed')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({limit: 2})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
+				   //     expect(res.body.activities).to.have.length(1);
+						expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
+			it('should retrieve a filtered list of activities from the local users followed users using the offset parameter', () => {
+				return chai.request(server)
+					// same problem as offset i think
+					// length issue
+					.get('/api/user/activities/followed')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({offset: 1})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
+				   //     expect(res.body.activities).to.have.length(1);
+						expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
+			it('should retrieve a filtered list of activities from the local users followed users using the type parameter', () => {
+				return chai.request(server)
+					.get('/api/user/activities/followed')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({type: activity.ACTIVITY_TYPES.MAP_APPROVED})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
+						expect(res.body.activities).to.have.length(2);
+						expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
+			it('should retrieve a filtered list of activities from the local users followed users using the data parameter', () => {
+				return chai.request(server)
+					.get('/api/user/activities/followed')
+					.set('Authorization', 'Bearer ' + accessToken)
+					.query({data: 1337})
+					.then(res => {
+						expect(res).to.have.status(200);
+						expect(res.body.activities).to.be.an('array');
+						expect(res.body.activities).to.have.length(2);
+						expect(res.body.activities[0]).to.have.property('id');
+					});
+			});
+			it('should respond with 401 when no access token is provided', () => {
+				return chai.request(server)
+					.get('/api/user/activities/followed')
+					.then(res => {
+						expect(res).to.have.status(401);
+						expect(res).to.be.json;
+						expect(res.body).to.have.property('error');
+						expect(res.body.error.code).equal(401);
+						expect(res.body.error.message).to.be.a('string');
+					});
+			});
+
+		});
+
+	});
 
 });

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -42,6 +42,16 @@
     passport-oauth2 "^1.4.0"
     pkginfo "0.2.x"
 
+"@doctormckay/stdlib@^1.6.0":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@doctormckay/stdlib/-/stdlib-1.14.1.tgz#a8e7920e059062f3eb7a88d56dded55778427b15"
+  integrity sha512-jGuJydIo2JB6IgOkOPNRr6fTJH9IdJCGH9yfVoEWzBjH0ptn22KsvOuJW+BG96O1eI1jSQ5C5myZr5Rj4gZ+Qw==
+
+"@doctormckay/steam-crypto@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@doctormckay/steam-crypto/-/steam-crypto-1.2.0.tgz#2b123c1e98034f3c8c6b90109e35fc4276e086b0"
+  integrity sha1-KxI8HpgDTzyMa5AQnjX8QnbghrA=
+
 "@hapi/address@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-4.0.1.tgz#267301ddf7bc453718377a6fb3832a2f04a721dd"
@@ -99,6 +109,59 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@passport-next/passport-strategy/-/passport-strategy-1.1.0.tgz#4c0df069e2ec9262791b9ef1e23320c1d73bdb74"
   integrity sha512-2KhFjtPueJG6xVj2HnqXt9BlANOfYCVLyu+pXYjPGBDT8yk+vQwc/6tsceIj+mayKcoxMau2JimggXRPHgoc8w==
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -168,6 +231,11 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
 "@types/mime@*":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
@@ -177,6 +245,11 @@
   version "10.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
   integrity sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==
+
+"@types/node@>=13.7.0":
+  version "16.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
+  integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
 
 "@types/qs@*":
   version "6.9.4"
@@ -490,6 +563,13 @@ busboy@^0.3.1:
   integrity sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==
   dependencies:
     dicer "0.3.0"
+
+bytebuffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
+  integrity sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=
+  dependencies:
+    long "~3"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -833,6 +913,11 @@ crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
+cuint@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -1973,6 +2058,11 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+long@~3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
+  integrity sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=
+
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -2567,6 +2657,25 @@ promise.allsettled@1.0.2:
     function-bind "^1.1.1"
     iterate-value "^1.0.0"
 
+protobufjs@^6.8.8:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
+  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
+
 proxy-addr@~2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
@@ -2963,12 +3072,30 @@ sshpk@^1.7.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+steam-appticket@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/steam-appticket/-/steam-appticket-1.0.1.tgz#4d0f827dbbd5d252a74ae4610fec209eab2c4991"
+  integrity sha512-oYVInCvJlPPaQPYW1+iGcVP0N0ZvwtWiCDM1Z353XJ8l4DXQI/N+R5yyaRQcHRH5oQv3+BY6gPF40lu7gwEiJw==
+  dependencies:
+    "@doctormckay/stdlib" "^1.6.0"
+    "@doctormckay/steam-crypto" "^1.2.0"
+    bytebuffer "^5.0.1"
+    protobufjs "^6.8.8"
+    steamid "^1.1.0"
+
 steam-web@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/steam-web/-/steam-web-0.4.0.tgz#9333b5843ff7ebd77945fe09a0d5d5b28694b331"
   integrity sha1-kzO1hD/369d5Rf4JoNXVsoaUszE=
   dependencies:
     qs "^6.1.0"
+
+steamid@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/steamid/-/steamid-1.1.3.tgz#bd3327aa240cdcc55551bcc42be6b79f26d318c4"
+  integrity sha512-t86YjtP1LtPt8D+TaIARm6PtC9tBnF1FhxQeLFs6ohG7vDUfQuy/M8II14rx1TTUkVuYoWHP/7DlvTtoCGULcw==
+  dependencies:
+    cuint "^0.2.1"
 
 streamsearch@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Closes #303 

The tradeoff with using this method is no need to do a server sided URL request to Steam, instead making that on the game client's end to get the encrypted ticket. Much better for the long run, in my opinion. We can even pass data through these tickets and parse them here, but currently it goes unused.

Controlled by env vars:
`STEAM_USE_ENCRYPTED_TICKETS` - when "true" it will enable it, otherwise falls back to old auth session ticket code
`STEAM_TICKETS_SECRET` - if above is true, this is the shared secret in Steamworks settings