### PR TITLE
⚡ Increase request limits for certain map data

### DIFF
--- a/server/src/models/map-favorite.js
+++ b/server/src/models/map-favorite.js
@@ -20,7 +20,7 @@ module.exports = {
 		const queryOptions = {
 			distinct: true,
 			where: { userID: userID },
-			limit: 20,
+			limit: 100,
 			order: [['createdAt', 'DESC']],
 			include: [
 				{

--- a/server/src/models/map-library.js
+++ b/server/src/models/map-library.js
@@ -10,7 +10,7 @@ module.exports = {
 		const queryOptions = {
 			distinct: true,
 			where: {userID: userID},
-			limit: 20,
+			limit: 100,
 			order: [['createdAt', 'DESC']],
 			include: [
 				{

--- a/server/src/models/map.js
+++ b/server/src/models/map.js
@@ -160,7 +160,7 @@ module.exports = {
 				{model: MapInfo, as: 'info', where: {}},
 			],
 			where: {},
-			limit: 20,
+			limit: 100,
 			order: [['createdAt', 'DESC']]
 		};
 		if (queryParams.limit)


### PR DESCRIPTION
As Goc had mentioned and further suggested\*, this PR is for increasing the query limit for map info and the user's own library info from 20 to 100

\*suggested in the sense that he had said 100 requests and I figured I'd go with that

I'm pretty sure that there's no other places defined limiting this specific data, but I'm not 100% tho I did look