### PR TITLE
Global map stats echarts styling

### DIFF
--- a/client/src/app/pages/dashboard/stats/global-stats/global-stats-maps/global-stats-maps.component.ts
+++ b/client/src/app/pages/dashboard/stats/global-stats/global-stats-maps/global-stats-maps.component.ts
@@ -38,9 +38,7 @@ export class GlobalStatsMapsComponent implements OnInit, OnChanges {
                 },
               },
               {
-                value:
-                  this.globalMapStats.totalMaps -
-                  this.globalMapStats.totalCompletedMaps,
+                value: this.globalMapStats.totalMaps - this.globalMapStats.totalCompletedMaps,
                 name: "Not Completed",
                 label: {
                   color: '#fff',

--- a/client/src/app/pages/dashboard/stats/global-stats/global-stats-maps/global-stats-maps.component.ts
+++ b/client/src/app/pages/dashboard/stats/global-stats/global-stats-maps/global-stats-maps.component.ts
@@ -20,17 +20,37 @@ export class GlobalStatsMapsComponent implements OnInit, OnChanges {
     if (changes.globalMapStats.currentValue) {
       this.mapCompletionPieChartOptions = {
         legend: {
-          orient: 'vertical',
-          left: 'left',
-          data: ['Completed', 'Not Completed'],
+          orient: "vertical",
+          left: "left",
+          data: ["Completed", "Not Completed"],
+          textStyle: {
+            color: "#fff",
+          },
         },
-        series: [{
-          data: [
-            { value: this.globalMapStats.totalCompletedMaps, name: 'Completed' },
-            { value: this.globalMapStats.totalMaps - this.globalMapStats.totalCompletedMaps, name: 'Not Completed' },
-          ],
-          type: 'pie',
-        }],
+        series: [
+          {
+            data: [
+              {
+                value: this.globalMapStats.totalCompletedMaps,
+                name: "Completed",
+                label: {
+                  color: '#fff',
+                },
+              },
+              {
+                value:
+                  this.globalMapStats.totalMaps -
+                  this.globalMapStats.totalCompletedMaps,
+                name: "Not Completed",
+                label: {
+                  color: '#fff',
+                },
+              },
+              
+            ],
+            type: "pie",
+          },
+        ],
       };
     }
   }


### PR DESCRIPTION
FIX: Changed echarts legend color (so you can see it...) and changed data point name color to white so it gets rid of the weird border

![image](https://user-images.githubusercontent.com/12698908/145656824-e420ef2d-cb5e-4c81-a1e2-0461b23644e2.png)
