### PR TITLE
Remove forced scroll overflow on entire HTML

### DIFF
--- a/client/src/app/@theme/styles/styles.scss
+++ b/client/src/app/@theme/styles/styles.scss
@@ -38,7 +38,6 @@
 
 html {
   scroll-behavior: smooth;
-  overflow-y: scroll;
 }
 
 body {


### PR DESCRIPTION
The scrollbar is visible at all times, even if there is nothing to scroll. Removing this property reverts it back to default behaviour.

| Before | After |
| - | - |
![overflow scroll preview](https://user-images.githubusercontent.com/13366049/145680276-f345cc9d-01ad-4ad2-b310-6b7d04bf295c.gif) | ![overflow auto preview](https://user-images.githubusercontent.com/13366049/145680279-f54eb7d0-2f7e-48b3-bb9b-ba6b504e7307.gif)