### PR TITLE
Implement /api/runs/:runID/download route

### DIFF
--- a/server/src/routes/api/runs.js
+++ b/server/src/routes/api/runs.js
@@ -4,7 +4,8 @@ const express = require('express'),
 	{ celebrate } = require('celebrate'),
 	runsValidation = require('../../validations/runs'),
 	errorCtrl = require('../../controllers/error'),
-	runCtrl = require('../../controllers/runs');
+	runCtrl = require('../../controllers/runs'),
+	authMiddleware = require("../../middlewares/auth");
 
 router.route('/')
 	.get(celebrate(runsValidation.getAll), runCtrl.getAll)
@@ -15,6 +16,7 @@ router.route('/:runID')
 	.all(errorCtrl.send405);
 
 router.route('/:runID/download')
+	.get(authMiddleware.requireAdmin, runCtrl.download)
 	.all(errorCtrl.send405);
 
 router.param('runID', celebrate(runsValidation.urlParamID));


### PR DESCRIPTION
Closes #476 

Started with a simple one. ~~I looked into adding a button on the frontend briefly, however it would require some kind of js file download or serverside generation of an authenticated/authorised temporary link, and decided it wasn't worth the effort unless specifically required.~~ I remembered its possible to submit the jwt as a get query param.

Tested:
- `roles` column on db for user = 0
  - Server returned a 403 forbidden
- `roles` column on db for user = 8
  - Server returned the file from `/app/server/public/runs/<run id>`