### PR TITLE
Add "STEAM_PREVENT_LIMITED" env var + fixup tests workflow file

### DIFF
--- a/.github/workflows/angularbuild.yml
+++ b/.github/workflows/angularbuild.yml
@@ -1,7 +1,5 @@
 name: AngularBuild 
 on:
-  # Trigger the workflow on pull request,
-  # but only for the staging branch
   pull_request:
     branches:
       - staging
@@ -9,28 +7,39 @@ on:
       - '**.md'
 jobs: 
   build:
+    name: Production Frontend Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Node ${{ matrix.node-version }}
+
+      - name: Get specific changed files
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v12
+        with:
+          files: client\/.*\.(js|ts|scss|html)$
+
+      - name: Setup Node
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+
       - name: Resolve Yarn Cache Directory
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: Cache Yarn Cache Directory
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('./client/yarn.lock') }}
           restore-keys: ${{ runner.os }}-${{ env.NODE_VERSION }}-
-      - name: npm install and npm run build
+
+      - name: Build Prod
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           cd ./client
           npm install -g @angular/cli && yarn install --prefer-offline
           npm run build:prod
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ClientBuild
-          path: ./client/dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,7 @@
-name: Tests
+name: Tests + Lint
 
 on:
   pull_request:
-    branches:
-      - staging
-    paths-ignore:
-      - '**.md'
-  push:
     branches:
       - staging
     paths-ignore:
@@ -17,6 +12,46 @@ env:
   NODE_PORT: 3002
 
 jobs:
+  client-lint:
+    name: Client Lint
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Get specific changed files
+      id: changed-files-specific
+      uses: tj-actions/changed-files@v12
+      with:
+        files: client\/.*\.(js|ts|scss|html)$
+
+    - name: Setup Node
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+
+    - name: Resolve Yarn Cache Directory
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Cache Yarn Cache Directory
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('./client/yarn.lock') }}
+        restore-keys: ${{ runner.os }}-${{ env.NODE_VERSION }}-
+
+    - name: Run Lint
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
+      run: |
+        cd ./client/
+        npm install -g @angular/cli && yarn install --prefer-offline
+        npm run lint:ci
+
   client-tests:
     name: Client Tests
     runs-on: ubuntu-latest
@@ -25,16 +60,25 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Get specific changed files
+      id: changed-files-specific
+      uses: tj-actions/changed-files@v12
+      with:
+        files: .(ts)$
+
     - name: Setup Node
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
       uses: actions/setup-node@v1
       with:
         node-version: '12.x'
 
     - name: Resolve Yarn Cache Directory
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
 
     - name: Cache Yarn Cache Directory
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
       uses: actions/cache@v2
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -42,6 +86,7 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ env.NODE_VERSION }}-
 
     - name: Run Tests
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
       run: |
         cd ./client/
         npm install -g @angular/cli && yarn install --prefer-offline
@@ -53,5 +98,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Get specific changed files
+      id: changed-files-specific
+      uses: tj-actions/changed-files@v12
+      with:
+        files: server\/.*\.(ts|js)$
+
     - name: Execute tests
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
       run: docker compose -f docker-compose.yml -f docker-compose.test.yml up --exit-code-from api

--- a/client/src/app/pages/dashboard/stats/global-stats/global-stats-maps/global-stats-maps.component.ts
+++ b/client/src/app/pages/dashboard/stats/global-stats/global-stats-maps/global-stats-maps.component.ts
@@ -20,11 +20,11 @@ export class GlobalStatsMapsComponent implements OnInit, OnChanges {
     if (changes.globalMapStats.currentValue) {
       this.mapCompletionPieChartOptions = {
         legend: {
-          orient: "vertical",
-          left: "left",
-          data: ["Completed", "Not Completed"],
+          orient: 'vertical',
+          left: 'left',
+          data: ['Completed', 'Not Completed'],
           textStyle: {
-            color: "#fff",
+            color: '#fff',
           },
         },
         series: [
@@ -32,21 +32,20 @@ export class GlobalStatsMapsComponent implements OnInit, OnChanges {
             data: [
               {
                 value: this.globalMapStats.totalCompletedMaps,
-                name: "Completed",
+                name: 'Completed',
                 label: {
                   color: '#fff',
                 },
               },
               {
                 value: this.globalMapStats.totalMaps - this.globalMapStats.totalCompletedMaps,
-                name: "Not Completed",
+                name: 'Not Completed',
                 label: {
                   color: '#fff',
                 },
               },
-              
             ],
-            type: "pie",
+            type: 'pie',
           },
         ],
       };

--- a/env.TEMPLATE
+++ b/env.TEMPLATE
@@ -13,6 +13,9 @@ STEAM_USE_ENCRYPTED_TICKETS=
 # If the above is true, this value is the secret key to use for decrypting the ticket
 STEAM_TICKETS_SECRET=
 
+# Whether to prevent limited accounts from signing up
+STEAM_PREVENT_LIMITED=
+
 # The database user, password, and root password
 MOM_DATABASE_USER=
 MOM_DATABASE_PW=

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -31,7 +31,7 @@ const config = {
 		steam: {
 			webAPIKey: 'webAPIKey12345',
 			preventLimited: true,
-			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS,
+			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS === 'true',
 			ticketsSecretKey: process.env.STEAM_TICKETS_SECRET,
 		},
 		db: {
@@ -79,7 +79,7 @@ const config = {
 		steam: {
 			webAPIKey: process.env.STEAM_WEB_API_KEY,
 			preventLimited: true,
-			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS,
+			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS === 'true',
 			ticketsSecretKey: process.env.STEAM_TICKETS_SECRET,
 		},
 		db: {
@@ -127,7 +127,7 @@ const config = {
 		steam: {
 			webAPIKey: process.env.STEAM_WEB_API_KEY,
 			preventLimited: true,
-			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS,
+			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS === 'true',
 			ticketsSecretKey: process.env.STEAM_TICKETS_SECRET,
 		},
 		db: {

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -30,7 +30,7 @@ const config = {
 		},
 		steam: {
 			webAPIKey: 'webAPIKey12345',
-			preventLimited: true,
+			preventLimited: process.env.STEAM_PREVENT_LIMITED === 'true',
 			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS === 'true',
 			ticketsSecretKey: process.env.STEAM_TICKETS_SECRET,
 		},
@@ -78,7 +78,7 @@ const config = {
 		},
 		steam: {
 			webAPIKey: process.env.STEAM_WEB_API_KEY,
-			preventLimited: true,
+			preventLimited: process.env.STEAM_PREVENT_LIMITED === 'true',
 			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS === 'true',
 			ticketsSecretKey: process.env.STEAM_TICKETS_SECRET,
 		},
@@ -126,7 +126,7 @@ const config = {
 		},
 		steam: {
 			webAPIKey: process.env.STEAM_WEB_API_KEY,
-			preventLimited: true,
+			preventLimited: process.env.STEAM_PREVENT_LIMITED === 'true',
 			useSteamTicketLibrary: process.env.STEAM_USE_ENCRYPTED_TICKETS === 'true',
 			ticketsSecretKey: process.env.STEAM_TICKETS_SECRET,
 		},

--- a/server/src/controllers/auth.js
+++ b/server/src/controllers/auth.js
@@ -130,7 +130,7 @@ module.exports = {
 		const idToVerify = req.get('id');
 
 		if (userTicket && idToVerify) {
-			if (config.steam.useSteamTicketLibrary === 'true') {
+			if (config.steam.useSteamTicketLibrary) {
 				// We pass the raw body here so it can create the buffer it needs
 				verifyUserTicketLocalLibrary( req.body, idToVerify, res, next );
 			}


### PR DESCRIPTION
Checking STEAM_PREVENT_LIMITED, if it's "true" then it'll prevent limited accounts from connecting

This logic will be refactored to only "disable" limited accounts by flagging them and preventing uploading runs in the future

Updated workflow file to:
1. Only run the appropriate jobs when it detects files to run them against have changed
2. Actually run lint again (it caused some problems with the recent merge...)
3. Only run on pull requests, as direct pushes to staging did not need to be tested again