### PR TITLE
Site refresh token expiration

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -16,6 +16,9 @@ const config = {
 			expTime: '15m',
 			gameExpTime: '24h'
 		},
+		refreshToken: {
+			expTime: '7d',
+		},
 		discord: {
 			clientID: 'discord1234',
 			clientSecret: 'shhhhh!',
@@ -70,6 +73,9 @@ const config = {
 			expTime: '15m',
 			gameExpTime: '24h'
 		},
+		refreshToken: {
+			expTime: '7d',
+		},
 		discord: {
 			clientID: process.env.DISCORD_CLIENT_ID,
 			clientSecret: process.env.DISCORD_CLIENT_SECRET,
@@ -123,6 +129,9 @@ const config = {
 			secret: process.env.JWT_SECRET,
 			expTime: '15m',
 			gameExpTime: '24h'
+		},
+		refreshToken: {
+			expTime: '7d',
 		},
 		discord: {
 			clientID: process.env.DISCORD_CLIENT_ID,

--- a/server/src/models/auth.js
+++ b/server/src/models/auth.js
@@ -62,6 +62,7 @@ module.exports = {
 		}
 		const options = {
 			issuer: config.domain,
+			expiresIn: config.refreshToken.expTime,
 		}
 		return createJWT(payload, config.accessToken.secret, options);
 	},

--- a/server/test/auth.js
+++ b/server/test/auth.js
@@ -52,6 +52,25 @@ describe('auth', () => {
 				expect(decodedToken).to.have.property('roles');
 			});
 		});
+
+		it('should generate a refresh token that expires in a week', () => {
+			return auth.createRefreshToken({
+				id: testUser.id,
+				roles: testUser.roles,
+				bans: testUser.bans,
+			}, false).then(refreshToken => {
+				return verifyJWT(refreshToken, config.accessToken.secret);
+			}).then(decodedRefreshToken => {
+				expect(decodedRefreshToken).to.have.property('iat');
+				expect(decodedRefreshToken).to.have.property('exp');
+
+				// week (7d) in vercel/ms -> 6.048e+8 / 1000
+				const ms = 604800;
+
+				// iat+ms should equal exp
+				expect(decodedRefreshToken.iat+ms).to.equal(decodedRefreshToken.exp);
+			});
+		})
 	});
 
 	describe('endpoints', () => {


### PR DESCRIPTION
Added configuration options for refreshToken.expTime.
Updated models/auth.genRefreshToken options to inlcude 'expiresIn' field.
Update test/auth to validate that a refresh token expires in 1 week.

Proposal to close #573