### PR TITLE
🎨 - Remove trailing commas from Prettier

### DIFF
--- a/server/.prettierrc.js
+++ b/server/.prettierrc.js
@@ -1,6 +1,6 @@
 module.exports = {
     printWidth: 120,
-    trailingComma: 'es5',
+    trailingComma: 'none',
     tabWidth: 4,
     semi: true,
     singleQuote: true,

--- a/server/src/@common/enums/activity.enum.ts
+++ b/server/src/@common/enums/activity.enum.ts
@@ -6,5 +6,5 @@ export enum EActivityTypes {
     PB_ACHIEVED,
     WR_ACHIEVED,
     REPORT_FILED,
-    USER_JOINED,
+    USER_JOINED
 }

--- a/server/src/@common/enums/map.enum.ts
+++ b/server/src/@common/enums/map.enum.ts
@@ -9,7 +9,7 @@ export enum EMapType {
     AHOP = 7,
     PARKOUR = 8,
     CONC = 9,
-    DEFRAG = 10,
+    DEFRAG = 10
 }
 
 export enum EMapStatus {
@@ -20,17 +20,17 @@ export enum EMapStatus {
     PUBLIC_TESTING = 4,
     READY_FOR_RELEASE = 5,
     REJECTED = 6,
-    REMOVED = 7,
+    REMOVED = 7
 }
 
 export enum EMapCreditType {
     AUTHOR = 0,
     COAUTHOR = 1,
     TESTER = 2,
-    SPECIAL_THANKS = 3,
+    SPECIAL_THANKS = 3
 }
 
 // TODO: Finish enum
 export enum EMapTriggerType {
-    UNKNOWN = 0,
+    UNKNOWN = 0
 }

--- a/server/src/@common/enums/report.enum.ts
+++ b/server/src/@common/enums/report.enum.ts
@@ -2,11 +2,11 @@ export enum EReportCategory {
     OTHER = 0,
     INAPPROPRIATE_CONTENT = 1,
     PLAGIARSIM = 2,
-    SPAM = 3,
+    SPAM = 3
 }
 
 export enum EReportType {
     USER_PROFILE_REPORT = 0,
     MAP_REPORT = 1,
-    MAP_COMMENT_REPORT = 2,
+    MAP_COMMENT_REPORT = 2
 }

--- a/server/src/@common/enums/user.enum.ts
+++ b/server/src/@common/enums/user.enum.ts
@@ -3,12 +3,12 @@ export enum ERole {
     MAPPER = 1 << 1,
     MODERATOR = 1 << 2,
     ADMIN = 1 << 3,
-    PLACEHOLDER = 1 << 4,
+    PLACEHOLDER = 1 << 4
 }
 
 export enum EBan {
     BANNED_LEADERBOARDS = 1 << 0,
     BANNED_ALIAS = 1 << 1,
     BANNED_AVATAR = 1 << 2,
-    BANNED_BIO = 1 << 3,
+    BANNED_BIO = 1 << 3
 }

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -10,7 +10,7 @@ import { MetricsModule } from './modules/metrics/metrics.module';
 import { UserModule } from './modules/user/user.module';
 
 @Module({
-    imports: [UsersModule, MapsModule, UserModule, AuthModule, HealthModule, MetricsModule],
+    imports: [UsersModule, MapsModule, UserModule, AuthModule, HealthModule, MetricsModule]
 })
 export class AppModule implements NestModule {
     public configure(consumer: MiddlewareConsumer): void {
@@ -18,7 +18,7 @@ export class AppModule implements NestModule {
             .apply(RawBodyMiddleware)
             .forRoutes({
                 path: '/auth/steam/user',
-                method: RequestMethod.POST,
+                method: RequestMethod.POST
             })
             .apply(JsonBodyMiddleware)
             .forRoutes('*');

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -14,7 +14,7 @@ async function bootstrap() {
     };
 
     const options: NestApplicationOptions = {
-        bodyParser: false,
+        bodyParser: false
     };
 
     const app = await NestFactory.create(AppModule, options);

--- a/server/src/modules/auth/auth.module.ts
+++ b/server/src/modules/auth/auth.module.ts
@@ -16,19 +16,19 @@ import { UsersModule } from '../users/users.module';
 @Module({
     imports: [
         PassportModule.register({
-            defaultStrategy: 'jwt',
+            defaultStrategy: 'jwt'
         }),
         JwtModule.register({
             secret: appConfig.accessToken.secret,
             signOptions: {
-                expiresIn: appConfig.accessToken.expTime,
-            },
+                expiresIn: appConfig.accessToken.expTime
+            }
         }),
         UsersModule,
-        HttpModule,
+        HttpModule
     ],
     controllers: [AuthController],
     providers: [AuthService, SteamAuthService, JwtAuthGuard, JwtStrategy, SteamWebStrategy],
-    exports: [AuthService, SteamAuthService, JwtAuthGuard, JwtStrategy, SteamWebStrategy],
+    exports: [AuthService, SteamAuthService, JwtAuthGuard, JwtStrategy, SteamWebStrategy]
 })
 export class AuthModule {}

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -22,7 +22,7 @@ export class AuthService {
             access_token: token,
             expires_in: appConfig.accessToken.expTime,
             refresh_token: refreshToken,
-            token_type: 'JWT',
+            token_type: 'JWT'
         };
 
         this.loggedInUser = user;
@@ -41,22 +41,22 @@ export class AuthService {
             steamID: usr.steamID,
             roles: usr.roles,
             bans: usr.bans,
-            gameAuth: !!gameAuth,
+            gameAuth: !!gameAuth
         };
         const options = {
             issuer: appConfig.domain,
-            expiresIn: gameAuth ? appConfig.accessToken.gameExpTime : appConfig.accessToken.expTime,
+            expiresIn: gameAuth ? appConfig.accessToken.gameExpTime : appConfig.accessToken.expTime
         };
         return await this.jwtService.sign(payload, options);
     }
 
     private async GenRefreshToken(userID: number, gameAuth?: boolean): Promise<string> {
         const payload = {
-            id: userID,
+            id: userID
         };
         const options = {
             issuer: appConfig.domain,
-            expiresIn: gameAuth ? appConfig.accessToken.gameRefreshExpTime : appConfig.accessToken.refreshExpTime,
+            expiresIn: gameAuth ? appConfig.accessToken.gameRefreshExpTime : appConfig.accessToken.refreshExpTime
         };
         return await this.jwtService.sign(payload, options);
     }

--- a/server/src/modules/auth/jwt/jwt-auth.guard.ts
+++ b/server/src/modules/auth/jwt/jwt-auth.guard.ts
@@ -12,7 +12,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     canActivate(context: ExecutionContext) {
         const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
             context.getHandler(),
-            context.getClass(),
+            context.getClass()
         ]);
         if (isPublic) {
             return true;

--- a/server/src/modules/auth/jwt/jwt.strategy.ts
+++ b/server/src/modules/auth/jwt/jwt.strategy.ts
@@ -11,7 +11,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         super({
             jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
             ignoreExpiration: false,
-            secretOrKey: appConfig.accessToken.secret,
+            secretOrKey: appConfig.accessToken.secret
         });
     }
 

--- a/server/src/modules/auth/steam/steam-auth.service.ts
+++ b/server/src/modules/auth/steam/steam-auth.service.ts
@@ -50,8 +50,8 @@ export class SteamAuthService {
             params: {
                 key: appConfig.steam.webAPIKey,
                 appid: appConfig.appID,
-                ticket: userTicket,
-            },
+                ticket: userTicket
+            }
         };
 
         const sres = await lastValueFrom(

--- a/server/src/modules/auth/steam/steam-web-auth.guard.ts
+++ b/server/src/modules/auth/steam/steam-web-auth.guard.ts
@@ -12,7 +12,7 @@ export class SteamWebAuthGuard extends AuthGuard('steam') {
     canActivate(context: ExecutionContext) {
         const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
             context.getHandler(),
-            context.getClass(),
+            context.getClass()
         ]);
         if (isPublic) {
             return true;

--- a/server/src/modules/auth/steam/steam-web.strategy.ts
+++ b/server/src/modules/auth/steam/steam-web.strategy.ts
@@ -10,7 +10,7 @@ export class SteamWebStrategy extends PassportStrategy(Strategy, 'steam') {
         super({
             returnURL: appConfig.baseURL_Auth + '/auth/steam/return',
             realm: appConfig.baseURL_Auth,
-            apiKey: appConfig.steam.webAPIKey,
+            apiKey: appConfig.steam.webAPIKey
         });
     }
 

--- a/server/src/modules/health/health.controller.spec.ts
+++ b/server/src/modules/health/health.controller.spec.ts
@@ -6,7 +6,7 @@ describe('HealthController', () => {
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
-            controllers: [HealthController],
+            controllers: [HealthController]
         }).compile();
 
         controller = module.get<HealthController>(HealthController);

--- a/server/src/modules/health/health.module.ts
+++ b/server/src/modules/health/health.module.ts
@@ -8,6 +8,6 @@ import { PrometheusModule } from '../prometheus/prometheus.module';
     imports: [TerminusModule, PrometheusModule],
     controllers: [HealthController],
     providers: [HealthService],
-    exports: [HealthService],
+    exports: [HealthService]
 })
 export class HealthModule {}

--- a/server/src/modules/health/health.service.spec.ts
+++ b/server/src/modules/health/health.service.spec.ts
@@ -6,7 +6,7 @@ describe('HealthService', () => {
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
-            providers: [HealthService],
+            providers: [HealthService]
         }).compile();
 
         service = module.get<HealthService>(HealthService);

--- a/server/src/modules/health/health.service.ts
+++ b/server/src/modules/health/health.service.ts
@@ -26,7 +26,7 @@ export class HealthService {
                 this.httpIndicator,
                 appConfig.baseURL_API + '/auth', // needs to be a endpoint that is always avaliable and public
                 this.promClientService
-            ),
+            )
         ];
     }
 

--- a/server/src/modules/maps/maps.controller.ts
+++ b/server/src/modules/maps/maps.controller.ts
@@ -19,13 +19,13 @@ export class MapsController {
         name: 'skip',
         type: Number,
         description: 'Offset this many records',
-        required: false,
+        required: false
     })
     @ApiQuery({
         name: 'take',
         type: Number,
         description: 'Take this many records',
-        required: false,
+        required: false
     })
     public async GetAllMaps(
         @Query('skip') skip?: number,
@@ -40,7 +40,7 @@ export class MapsController {
         name: 'mapID',
         type: Number,
         description: 'Target Map ID',
-        required: true,
+        required: true
     })
     public async GetMap(@Param('mapID') mapID: number): Promise<MapDto> {
         return this.mapsService.Get(mapID);
@@ -51,7 +51,7 @@ export class MapsController {
     @ApiBody({
         type: CreateMapDto,
         description: 'Create map data transfer object',
-        required: true,
+        required: true
     })
     public async CreateMap(@Body() mapCreateObj: CreateMapDto): Promise<MapDto> {
         return this.mapsService.Insert(mapCreateObj);

--- a/server/src/modules/maps/maps.module.ts
+++ b/server/src/modules/maps/maps.module.ts
@@ -9,6 +9,6 @@ import { AuthModule } from '../auth/auth.module';
     imports: [PrismaModule, AuthModule],
     controllers: [MapsController],
     providers: [MapsService, MapsRepo],
-    exports: [MapsService, MapsRepo],
+    exports: [MapsService, MapsRepo]
 })
 export class MapsModule {}

--- a/server/src/modules/maps/maps.repo.ts
+++ b/server/src/modules/maps/maps.repo.ts
@@ -12,7 +12,7 @@ export class MapsRepo {
      */
     async Insert(newMap: Prisma.MapCreateInput): Promise<number> {
         const result = await this.prisma.map.create({
-            data: newMap,
+            data: newMap
         });
 
         return result.id;
@@ -24,7 +24,7 @@ export class MapsRepo {
      */
     async GetAll(where?: Prisma.MapWhereInput, skip?: number, take?: number): Promise<[Map[], number]> {
         const count = await this.prisma.map.count({
-            where: where,
+            where: where
         });
         const maps = await this.prisma.map.findMany({
             where: where,
@@ -32,8 +32,8 @@ export class MapsRepo {
             take: take != null ? +take : undefined,
             include: {
                 users: true,
-                mapimages: true,
-            },
+                mapimages: true
+            }
         });
         return [maps, count];
     }
@@ -50,8 +50,8 @@ export class MapsRepo {
             where: where,
             include: {
                 users: true,
-                mapimages: true,
-            },
+                mapimages: true
+            }
         });
     }
 }

--- a/server/src/modules/maps/maps.service.ts
+++ b/server/src/modules/maps/maps.service.ts
@@ -35,7 +35,7 @@ export class MapsService {
         return {
             totalCount: totalCount,
             returnCount: mapsDtos.length,
-            response: mapsDtos,
+            response: mapsDtos
         };
     }
 
@@ -65,8 +65,8 @@ export class MapsService {
         const createPrisma: Prisma.MapCreateInput = {
             users: {
                 connect: {
-                    id: this.authService.loggedInUser.id,
-                },
+                    id: this.authService.loggedInUser.id
+                }
             },
             name: mapCreateObj.name,
             type: mapCreateObj.type,
@@ -77,8 +77,8 @@ export class MapsService {
                     creationDate: mapCreateObj.info.creationDate,
                     youtubeID: mapCreateObj.info.youtubeID,
                     createdAt: new Date(),
-                    updatedAt: new Date(),
-                },
+                    updatedAt: new Date()
+                }
             },
             maptracks: {
                 createMany: {
@@ -89,10 +89,10 @@ export class MapsService {
                             trackNum: track.trackNum,
                             difficulty: track.difficulty,
                             createdAt: new Date(),
-                            updatedAt: new Date(),
+                            updatedAt: new Date()
                         };
-                    }),
-                },
+                    })
+                }
             },
             mapcredits: {
                 createMany: {
@@ -101,13 +101,13 @@ export class MapsService {
                             type: credit.type,
                             userID: credit.userID,
                             createdAt: new Date(),
-                            updatedAt: new Date(),
+                            updatedAt: new Date()
                         };
-                    }),
-                },
+                    })
+                }
             },
             createdAt: new Date(),
-            updatedAt: new Date(),
+            updatedAt: new Date()
         };
         const dbResponse = await this.mapRepo.Insert(createPrisma);
 
@@ -142,9 +142,9 @@ export class MapsService {
             NOT: {
                 statusFlag: EMapStatus.REJECTED,
                 OR: {
-                    statusFlag: EMapStatus.REMOVED,
-                },
-            },
+                    statusFlag: EMapStatus.REMOVED
+                }
+            }
         };
 
         const whereResult = await this.mapRepo.GetAll(where);
@@ -161,7 +161,7 @@ export class MapsService {
 
         const where: Prisma.MapWhereInput = {
             submitterID: submitterID,
-            statusFlag: EMapStatus.PENDING,
+            statusFlag: EMapStatus.PENDING
         };
 
         const whereResult = await this.mapRepo.GetAll(where);

--- a/server/src/modules/metrics/metrics.controller.spec.ts
+++ b/server/src/modules/metrics/metrics.controller.spec.ts
@@ -6,7 +6,7 @@ describe('MetricsController', () => {
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
-            controllers: [MetricsController],
+            controllers: [MetricsController]
         }).compile();
 
         controller = module.get<MetricsController>(MetricsController);

--- a/server/src/modules/metrics/metrics.module.ts
+++ b/server/src/modules/metrics/metrics.module.ts
@@ -7,6 +7,6 @@ import { HealthModule } from '../health/health.module';
 @Module({
     imports: [PrometheusModule, HealthModule],
     providers: [MetricsService],
-    controllers: [MetricsController],
+    controllers: [MetricsController]
 })
 export class MetricsModule {}

--- a/server/src/modules/metrics/metrics.service.spec.ts
+++ b/server/src/modules/metrics/metrics.service.spec.ts
@@ -6,7 +6,7 @@ describe('MetricsService', () => {
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
-            providers: [MetricsService],
+            providers: [MetricsService]
         }).compile();
 
         service = module.get<MetricsService>(MetricsService);

--- a/server/src/modules/prisma/prisma.module.ts
+++ b/server/src/modules/prisma/prisma.module.ts
@@ -3,6 +3,6 @@ import { PrismaRepo } from './prisma.repo';
 
 @Module({
     providers: [PrismaRepo],
-    exports: [PrismaRepo],
+    exports: [PrismaRepo]
 })
 export class PrismaModule {}

--- a/server/src/modules/prometheus/prometheus.module.ts
+++ b/server/src/modules/prometheus/prometheus.module.ts
@@ -3,6 +3,6 @@ import { PrometheusService } from './prometheus.service';
 
 @Module({
     providers: [PrometheusService],
-    exports: [PrometheusService],
+    exports: [PrometheusService]
 })
 export class PrometheusModule {}

--- a/server/src/modules/prometheus/prometheus.service.spec.ts
+++ b/server/src/modules/prometheus/prometheus.service.spec.ts
@@ -6,7 +6,7 @@ describe('PrometheusService', () => {
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
-            providers: [PrometheusService],
+            providers: [PrometheusService]
         }).compile();
 
         service = module.get<PrometheusService>(PrometheusService);

--- a/server/src/modules/prometheus/prometheus.service.ts
+++ b/server/src/modules/prometheus/prometheus.service.ts
@@ -26,7 +26,7 @@ export class PrometheusService {
     constructor() {
         this.registry = new Registry();
         this.registry.setDefaultLabels({
-            app: this.serviceTitle,
+            app: this.serviceTitle
         });
         collectDefaultMetrics({ register: this.registry, prefix: this.servicePrefix });
     }
@@ -44,7 +44,7 @@ export class PrometheusService {
         if (this.registeredGauges[name] === undefined) {
             const gauge = (this.registeredGauges[name] = new Gauge({
                 name: this.servicePrefix + name,
-                help,
+                help
             }));
             this.registry.registerMetric(gauge);
             this.registeredGauges[name] = gauge;

--- a/server/src/modules/user/user.controller.spec.ts
+++ b/server/src/modules/user/user.controller.spec.ts
@@ -2,17 +2,17 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
 
 describe('UserController', () => {
-  let controller: UserController;
+    let controller: UserController;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      controllers: [UserController],
-    }).compile();
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [UserController]
+        }).compile();
 
-    controller = module.get<UserController>(UserController);
-  });
+        controller = module.get<UserController>(UserController);
+    });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
-  });
+    it('should be defined', () => {
+        expect(controller).toBeDefined();
+    });
 });

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -9,7 +9,6 @@ import { UserDto } from '../../@common/dto/user/user.dto';
 @ApiTags('User')
 @UseGuards(JwtAuthGuard)
 export class UserController {
-
     constructor(private readonly userService: UserService) {}
 
     @Get()
@@ -18,4 +17,3 @@ export class UserController {
         return this.userService.Get();
     }
 }
-

--- a/server/src/modules/user/user.module.ts
+++ b/server/src/modules/user/user.module.ts
@@ -10,7 +10,6 @@ import { AuthModule } from '../auth/auth.module';
     imports: [PrismaModule, UsersModule, AuthModule],
     controllers: [UserController],
     providers: [UserService, UserRepo],
-    exports: [UserService, UserRepo],
+    exports: [UserService, UserRepo]
 })
 export class UserModule {}
-

--- a/server/src/modules/user/user.repo.spec.ts
+++ b/server/src/modules/user/user.repo.spec.ts
@@ -2,17 +2,17 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UserRepo } from './user.repo';
 
 describe('UserRepo', () => {
-  let service: UserRepo;
+    let service: UserRepo;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [UserRepo],
-    }).compile();
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [UserRepo]
+        }).compile();
 
-    service = module.get<UserRepo>(UserRepo);
-  });
+        service = module.get<UserRepo>(UserRepo);
+    });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
 });

--- a/server/src/modules/user/user.service.spec.ts
+++ b/server/src/modules/user/user.service.spec.ts
@@ -2,17 +2,17 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
 
 describe('UserService', () => {
-  let service: UserService;
+    let service: UserService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
-    }).compile();
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [UserService]
+        }).compile();
 
-    service = module.get<UserService>(UserService);
-  });
+        service = module.get<UserService>(UserService);
+    });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
+    it('should be defined', () => {
+        expect(service).toBeDefined();
+    });
 });

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -5,7 +5,7 @@ import { AuthService } from '../auth/auth.service';
 
 @Injectable()
 export class UserService {
-    constructor(private readonly usersService: UsersService, private readonly authService: AuthService) { };
+    constructor(private readonly usersService: UsersService, private readonly authService: AuthService) {}
 
     async Get(): Promise<UserDto> {
         return this.usersService.Get(this.authService.loggedInUser.id);

--- a/server/src/modules/users/users.controller.ts
+++ b/server/src/modules/users/users.controller.ts
@@ -25,13 +25,13 @@ export class UsersController {
         name: 'skip',
         type: Number,
         description: 'Offset this many records',
-        required: false,
+        required: false
     })
     @ApiQuery({
         name: 'take',
         type: Number,
         description: 'Take this many records',
-        required: false,
+        required: false
     })
     public async GetAllUsers(
         @Query('skip') skip?: number,
@@ -46,7 +46,7 @@ export class UsersController {
         name: 'userID',
         type: Number,
         description: 'Target User ID',
-        required: true,
+        required: true
     })
     public async GetUser(@Param('userID') userID: number): Promise<UserDto> {
         return this.usersService.Get(userID);
@@ -58,7 +58,7 @@ export class UsersController {
         name: 'userID',
         type: Number,
         description: 'Target User ID',
-        required: true,
+        required: true
     })
     public async GetUserProfile(@Param('userID') userID: number): Promise<UserProfileDto> {
         return this.usersService.GetProfile(userID);
@@ -70,19 +70,19 @@ export class UsersController {
         name: 'userID',
         type: Number,
         description: 'Target User ID',
-        required: true,
+        required: true
     })
     @ApiQuery({
         name: 'skip',
         type: Number,
         description: 'Offset this many records',
-        required: false,
+        required: false
     })
     @ApiQuery({
         name: 'take',
         type: Number,
         description: 'Take this many records',
-        required: false,
+        required: false
     })
     public async GetActivities(
         @Param('userID') userID: number,
@@ -98,19 +98,19 @@ export class UsersController {
         name: 'userID',
         type: Number,
         description: 'Target User ID',
-        required: true,
+        required: true
     })
     @ApiQuery({
         name: 'skip',
         type: Number,
         description: 'Offset this many records',
-        required: false,
+        required: false
     })
     @ApiQuery({
         name: 'take',
         type: Number,
         description: 'Take this many records',
-        required: false,
+        required: false
     })
     public async GetFollowers(
         @Param('userID') userID: number,
@@ -126,19 +126,19 @@ export class UsersController {
         name: 'userID',
         type: Number,
         description: 'Target User ID',
-        required: true,
+        required: true
     })
     @ApiQuery({
         name: 'skip',
         type: Number,
         description: 'Offset this many records',
-        required: false,
+        required: false
     })
     @ApiQuery({
         name: 'take',
         type: Number,
         description: 'Take this many records',
-        required: false,
+        required: false
     })
     public async GetFollowed(
         @Param('userID') userID: number,
@@ -154,19 +154,19 @@ export class UsersController {
         name: 'userID',
         type: Number,
         description: 'Target User ID',
-        required: true,
+        required: true
     })
     @ApiQuery({
         name: 'skip',
         type: Number,
         description: 'Offset this many records',
-        required: false,
+        required: false
     })
     @ApiQuery({
         name: 'take',
         type: Number,
         description: 'Take this many records',
-        required: false,
+        required: false
     })
     public async GetMapCredits(
         @Param('userID') userID: number,
@@ -182,19 +182,19 @@ export class UsersController {
         name: 'userID',
         type: Number,
         description: 'Target User ID',
-        required: true,
+        required: true
     })
     @ApiQuery({
         name: 'skip',
         type: Number,
         description: 'Offset this many records',
-        required: false,
+        required: false
     })
     @ApiQuery({
         name: 'take',
         type: Number,
         description: 'Take this many records',
-        required: false,
+        required: false
     })
     public async GetRuns(
         @Param('userID') userID: number,

--- a/server/src/modules/users/users.module.ts
+++ b/server/src/modules/users/users.module.ts
@@ -9,6 +9,6 @@ import { PrismaModule } from '../prisma/prisma.module';
     imports: [HttpModule, PrismaModule],
     controllers: [UsersController],
     providers: [UsersService, UsersRepo],
-    exports: [UsersService, UsersRepo],
+    exports: [UsersService, UsersRepo]
 })
 export class UsersModule {}

--- a/server/src/modules/users/users.repo.ts
+++ b/server/src/modules/users/users.repo.ts
@@ -13,7 +13,7 @@ export class UsersRepo {
      */
     async Insert(newUser: Prisma.UserCreateInput): Promise<User> {
         return await this.prisma.user.create({
-            data: newUser,
+            data: newUser
         });
     }
 
@@ -23,12 +23,12 @@ export class UsersRepo {
      */
     async GetAll(where?: Prisma.UserWhereInput, skip?: number, take?: number): Promise<[User[], number]> {
         const count = await this.prisma.user.count({
-            where: where,
+            where: where
         });
         const users = await this.prisma.user.findMany({
             where: where,
             skip: skip != null ? +skip : undefined,
-            take: take != null ? +take : undefined,
+            take: take != null ? +take : undefined
         });
         return [users, count];
     }
@@ -42,7 +42,7 @@ export class UsersRepo {
         where.id = +id;
 
         return await this.prisma.user.findFirst({
-            where: where,
+            where: where
         });
     }
 
@@ -55,14 +55,14 @@ export class UsersRepo {
         where.steamID = steamID;
 
         return await this.prisma.user.findFirst({
-            where: where,
+            where: where
         });
     }
 
     async Update(user: Prisma.UserAuthWhereUniqueInput, update: Prisma.UserUpdateInput): Promise<User> {
         return await this.prisma.user.update({
             where: user,
-            data: update,
+            data: update
         });
     }
     //#endregion
@@ -75,7 +75,7 @@ export class UsersRepo {
     async UpdateAuth(user: Prisma.UserAuthWhereUniqueInput, update: Prisma.UserAuthUpdateInput): Promise<UserAuth> {
         return await this.prisma.userAuth.update({
             where: user,
-            data: update,
+            data: update
         });
     }
     //#endregion
@@ -92,8 +92,8 @@ export class UsersRepo {
         const userProfile = await this.prisma.user.findFirst({
             where: where,
             include: {
-                profiles: true,
-            },
+                profiles: true
+            }
         });
 
         return [userProfile, (userProfile as any).profiles];
@@ -108,7 +108,7 @@ export class UsersRepo {
         where.userID = +userID;
 
         return await this.prisma.profile.findFirst({
-            where: where,
+            where: where
         });
     }
 
@@ -120,7 +120,7 @@ export class UsersRepo {
         where.userID = +userID;
 
         const count = await this.prisma.activity.count({
-            where: where,
+            where: where
         });
         const activities = await this.prisma.activity.findMany({
             where: where,
@@ -129,10 +129,10 @@ export class UsersRepo {
             include: {
                 users: {
                     include: {
-                        profiles: true,
-                    },
-                },
-            },
+                        profiles: true
+                    }
+                }
+            }
         });
 
         return [activities, count];
@@ -143,13 +143,13 @@ export class UsersRepo {
     async GetFollowers(userID: number, skip?: number, take?: number): Promise<[Follow[], number]> {
         const where: Prisma.FollowWhereInput = {};
         const userWhere: Prisma.UserWhereInput = {
-            id: +userID,
+            id: +userID
         };
 
         where.users_follows_followedIDTousers = userWhere;
 
         const count = await this.prisma.follow.count({
-            where: where,
+            where: where
         });
         const followers = await this.prisma.follow.findMany({
             where: where,
@@ -158,15 +158,15 @@ export class UsersRepo {
             include: {
                 users_follows_followeeIDTousers: {
                     include: {
-                        profiles: true,
-                    },
+                        profiles: true
+                    }
                 },
                 users_follows_followedIDTousers: {
                     include: {
-                        profiles: true,
-                    },
-                },
-            },
+                        profiles: true
+                    }
+                }
+            }
         });
 
         return [followers, count];
@@ -175,13 +175,13 @@ export class UsersRepo {
     async GetFollowing(userID: number, skip?: number, take?: number): Promise<[Follow[], number]> {
         const where: Prisma.FollowWhereInput = {};
         const userWhere: Prisma.UserWhereInput = {
-            id: +userID,
+            id: +userID
         };
 
         where.users_follows_followeeIDTousers = userWhere;
 
         const count = await this.prisma.follow.count({
-            where: where,
+            where: where
         });
         const followees = await this.prisma.follow.findMany({
             where: where,
@@ -190,15 +190,15 @@ export class UsersRepo {
             include: {
                 users_follows_followeeIDTousers: {
                     include: {
-                        profiles: true,
-                    },
+                        profiles: true
+                    }
                 },
                 users_follows_followedIDTousers: {
                     include: {
-                        profiles: true,
-                    },
-                },
-            },
+                        profiles: true
+                    }
+                }
+            }
         });
 
         return [followees, count];
@@ -211,7 +211,7 @@ export class UsersRepo {
         where.userID = +userID;
 
         const count = await this.prisma.mapCredit.count({
-            where: where,
+            where: where
         });
         const mapCredit = await this.prisma.mapCredit.findMany({
             where: where,
@@ -220,16 +220,16 @@ export class UsersRepo {
             include: {
                 users: {
                     include: {
-                        profiles: true,
-                    },
+                        profiles: true
+                    }
                 },
                 maps: {
                     include: {
                         users: true,
-                        mapimages: true,
-                    },
-                },
-            },
+                        mapimages: true
+                    }
+                }
+            }
         });
 
         return [mapCredit, count];
@@ -242,7 +242,7 @@ export class UsersRepo {
         where.playerID = +userID;
 
         const count = await this.prisma.run.count({
-            where: where,
+            where: where
         });
         const runs = await this.prisma.run.findMany({
             where: where,
@@ -250,8 +250,8 @@ export class UsersRepo {
             take: take != null ? +take : undefined,
             include: {
                 users: true,
-                mapranks: true,
-            },
+                mapranks: true
+            }
         });
 
         return [runs, count];

--- a/server/src/modules/users/users.service.ts
+++ b/server/src/modules/users/users.service.ts
@@ -34,7 +34,7 @@ export class UsersService {
         return {
             totalCount: totalCount,
             returnCount: userDtos.length,
-            response: userDtos,
+            response: userDtos
         };
     }
 
@@ -80,7 +80,7 @@ export class UsersService {
         const response: PagedResponseDto<ActivityDto[]> = {
             response: activitesDto,
             returnCount: activitesDto.length,
-            totalCount: activitesAndCount[1],
+            totalCount: activitesAndCount[1]
         };
 
         return response;
@@ -110,7 +110,7 @@ export class UsersService {
         const response: PagedResponseDto<FollowerDto[]> = {
             response: followersDto,
             returnCount: followersDto.length,
-            totalCount: followersAndCount[1],
+            totalCount: followersAndCount[1]
         };
 
         return response;
@@ -140,7 +140,7 @@ export class UsersService {
         const response: PagedResponseDto<FollowerDto[]> = {
             response: followersDto,
             returnCount: followersDto.length,
-            totalCount: followersAndCount[1],
+            totalCount: followersAndCount[1]
         };
 
         return response;
@@ -166,7 +166,7 @@ export class UsersService {
         const response: PagedResponseDto<UserMapCreditDto[]> = {
             response: mapCreditsDto,
             returnCount: mapCreditsDto.length,
-            totalCount: mapCreditsAndCount[1],
+            totalCount: mapCreditsAndCount[1]
         };
 
         return response;
@@ -192,7 +192,7 @@ export class UsersService {
         const response: PagedResponseDto<UserRunDto[]> = {
             response: runsDto,
             returnCount: runsDto.length,
-            totalCount: runsAndCount[1],
+            totalCount: runsAndCount[1]
         };
 
         return response;
@@ -250,13 +250,13 @@ export class UsersService {
                 steamid: '',
                 personaname: '',
                 avatarfull: '',
-                locccountrycode: '',
+                locccountrycode: ''
             },
             xmlData: {
                 profile: {
-                    isLimitedAccount: [],
-                },
-            },
+                    isLimitedAccount: []
+                }
+            }
         };
 
         const getPlayerResponse = await lastValueFrom(
@@ -264,8 +264,8 @@ export class UsersService {
                 .get(`https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/`, {
                     params: {
                         key: appConfig.steam.webAPIKey,
-                        steamids: steamID,
-                    },
+                        steamids: steamID
+                    }
                 })
                 .pipe(
                     map((res) => {
@@ -315,8 +315,8 @@ export class UsersService {
     private async GetSteamProfileFromSteamID(steamID: string): Promise<SteamUserData['xmlData']> {
         let result: SteamUserData['xmlData'] = {
             profile: {
-                isLimitedAccount: [],
-            },
+                isLimitedAccount: []
+            }
         };
         const getSteamProfileResponse = await lastValueFrom(
             this.http.get(`https://steamcommunity.com/profiles/${steamID}?xml=1`).pipe(
@@ -352,7 +352,7 @@ export class UsersService {
         } else {
             const createInput: Prisma.UserCreateInput = {
                 createdAt: new Date(),
-                updatedAt: new Date(),
+                updatedAt: new Date()
             };
             createInput.steamID = profile.steamID;
             createInput.alias = profile.alias;

--- a/server/test/app.e2e-spec.ts
+++ b/server/test/app.e2e-spec.ts
@@ -8,7 +8,7 @@ describe('AppController (e2e)', () => {
 
     beforeAll(async () => {
         const moduleFixture = await Test.createTestingModule({
-            imports: [AppModule],
+            imports: [AppModule]
         }).compile();
 
         app = moduleFixture.createNestApplication();


### PR DESCRIPTION
I have no idea why Prettier changed to use 'es5' as default, but for TypeScript it's absolutely horrible, it errors for trailing commas on type params. I don't think anyone's a fan of trailing comma, let's remove. Should be the last thing, after which we'll hopefully never have to touch Prettier config again.