### PR TITLE
🩹 - Rename exception filter

### DIFF
--- a/server/src/@common/filters/all-exceptions.filter.ts
+++ b/server/src/@common/filters/all-exceptions.filter.ts
@@ -3,19 +3,19 @@ import { HttpAdapterHost } from '@nestjs/core';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 
 @Catch()
-export class PrismaClientExceptionFilter implements ExceptionFilter {
+export class AllExceptionsFilter implements ExceptionFilter {
     constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
 
     catch(e: any, host: ArgumentsHost): void {
         const { httpAdapter } = this.httpAdapterHost;
         const ctx = host.switchToHttp();
 
-        const errorCode = PrismaClientExceptionFilter.GenerateErrorCode();
+        const errorCode = AllExceptionsFilter.GenerateErrorCode();
 
         const responseBody = {
             statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
             // Don't send database-related errors
-            message: e instanceof PrismaClientKnownRequestError ? e.message : 'Database Error',
+            message: e instanceof PrismaClientKnownRequestError ? 'Database Error' : e.message,
             errorCode: errorCode
         };
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -4,7 +4,7 @@ import { PrismaRepo } from './modules/prisma/prisma.repo';
 import { AppModule } from './app.module';
 import { appConfig } from '../config/config';
 import { NestApplicationOptions } from '@nestjs/common';
-import { PrismaClientExceptionFilter } from './@common/filters/prisma-client-exception.filter';
+import { AllExceptionsFilter } from './@common/filters/all-exceptions.filter';
 
 async function bootstrap() {
     // MDN recommended hack override for BigInt
@@ -32,7 +32,7 @@ async function bootstrap() {
     const prismaDalc: PrismaRepo = app.get(PrismaRepo);
     prismaDalc.enableShutdownHooks(app);
     const httpAdapterHost = app.get(HttpAdapterHost);
-    app.useGlobalFilters(new PrismaClientExceptionFilter(httpAdapterHost));
+    app.useGlobalFilters(new AllExceptionsFilter(httpAdapterHost));
 
     await app.listen(appConfig.port);
 }


### PR DESCRIPTION
I'm an idiot. Forget to update the filter name, we're catching everything with this now. Also, the ternary was the wrong way round, forget to revert back after changing to test stuff.

In the future if we're both working on stuff together and it's late, let's review the following day with fresh eyes.