### PR TITLE
fix: Exception filter changed all errors to 500

### DIFF
--- a/server/src/@common/filters/all-exceptions.filter.ts
+++ b/server/src/@common/filters/all-exceptions.filter.ts
@@ -18,24 +18,24 @@ export class AllExceptionsFilter implements ExceptionFilter {
         const { httpAdapter } = this.httpAdapterHost;
         const ctx = host.switchToHttp();
 
-        const responseBody = new CustomHTTPError(
+        const httpError = new CustomHTTPError(
             e instanceof HttpException ? (e as HttpException).getStatus() : HttpStatus.INTERNAL_SERVER_ERROR,
             // Don't send database-releted errors
             e instanceof PrismaClientKnownRequestError ? 'Database Error' : e.message
         );
 
         if (!(e instanceof UnauthorizedException)) {
-            responseBody.GenerateErrorCode();
+            httpError.GenerateErrorCode();
 
             Logger.error(
-                `Error - Code [${responseBody.errorCode}]\n` +
+                `Error - Code [${httpError.errorCode}]\n` +
                     `Exception Code: ${e.code}\n` +
                     `Message: ${e.message}\n` +
                     `Stack: ${e.stack}`
             );
         }
 
-        httpAdapter.reply(ctx.getResponse(), responseBody, responseBody.statusCode);
+        httpAdapter.reply(ctx.getResponse(), httpError, httpError.statusCode);
     }
 }
 

--- a/server/src/@common/filters/all-exceptions.filter.ts
+++ b/server/src/@common/filters/all-exceptions.filter.ts
@@ -1,4 +1,12 @@
-import { ExceptionFilter, Catch, ArgumentsHost, HttpStatus, Logger } from '@nestjs/common';
+import {
+    ExceptionFilter,
+    Catch,
+    ArgumentsHost,
+    HttpStatus,
+    Logger,
+    UnauthorizedException,
+    HttpException
+} from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 
@@ -10,26 +18,38 @@ export class AllExceptionsFilter implements ExceptionFilter {
         const { httpAdapter } = this.httpAdapterHost;
         const ctx = host.switchToHttp();
 
-        const errorCode = AllExceptionsFilter.GenerateErrorCode();
-
-        const responseBody = {
-            statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
-            // Don't send database-related errors
-            message: e instanceof PrismaClientKnownRequestError ? 'Database Error' : e.message,
-            errorCode: errorCode
-        };
-
-        Logger.error(
-            `Error - Code [${errorCode}]\n` +
-                `Exception Code: ${e.code}\n` +
-                `Message: ${e.message}\n` +
-                `Stack: ${e.stack}`
+        const responseBody = new CustomHTTPError(
+            e instanceof HttpException ? (e as HttpException).getStatus() : HttpStatus.INTERNAL_SERVER_ERROR,
+            // Don't send database-releted errors
+            e instanceof PrismaClientKnownRequestError ? 'Database Error' : e.message
         );
 
-        httpAdapter.reply(ctx.getResponse(), responseBody, HttpStatus.INTERNAL_SERVER_ERROR);
+        if (!(e instanceof UnauthorizedException)) {
+            responseBody.GenerateErrorCode();
+
+            Logger.error(
+                `Error - Code [${responseBody.errorCode}]\n` +
+                    `Exception Code: ${e.code}\n` +
+                    `Message: ${e.message}\n` +
+                    `Stack: ${e.stack}`
+            );
+        }
+
+        httpAdapter.reply(ctx.getResponse(), responseBody, responseBody.statusCode);
+    }
+}
+
+class CustomHTTPError {
+    statusCode: number;
+    message: string;
+    errorCode: string;
+
+    constructor(_statusCode: number, _message: string) {
+        this.statusCode = _statusCode;
+        this.message = _message;
     }
 
-    private static GenerateErrorCode(): string {
-        return Math.random().toString(36).toString().slice(2).toUpperCase();
+    GenerateErrorCode() {
+        this.errorCode = Math.random().toString(36).toString().slice(2).toUpperCase();
     }
 }


### PR DESCRIPTION
Found this when I should have got an unauthorized error but instead was returned a 500. A quick spruse up of Tom's exsisting work and we have something that fits all HTTP errors a bit better while retaining the functionality of hiding the details of DB errors from clients and having easily lookup able logs with the error codes.