### PR TITLE
Sentry should only send if in production

### DIFF
--- a/server/config/config.template.ts
+++ b/server/config/config.template.ts
@@ -262,3 +262,4 @@ export interface IConfig {
 }
 
 export const appConfig: IConfig = configs[env];
+export const environment: string = env;

--- a/server/config/config.ts
+++ b/server/config/config.ts
@@ -266,3 +266,4 @@ export interface IConfig {
 }
 
 export const appConfig: IConfig = configs[env];
+export const environment: string = env;

--- a/server/src/@common/sentry/sentry-exception/sentry-exception.service.ts
+++ b/server/src/@common/sentry/sentry-exception/sentry-exception.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Scope } from '@nestjs/common';
 import '@sentry/tracing'; // https://github.com/getsentry/sentry-javascript/issues/4731#issuecomment-1075410543
 import * as Sentry from '@sentry/node';
+import { environment } from '../../../../config/config';
 
 @Injectable({ scope: Scope.TRANSIENT })
 export class SentryExceptionService {
@@ -11,6 +12,11 @@ export class SentryExceptionService {
      * @returns Sentry Event ID for easy searching
      */
     sendError(error: any): string {
+
+        if (environment !== 'production') {
+            return 'DEV-ERROR';
+        }
+
         const transaction = Sentry.startTransaction({
             op: 'API Error',
             name: error
@@ -24,7 +30,7 @@ export class SentryExceptionService {
             scope.setContext(`API Error`, null);
         });
 
-        const result = Sentry.captureException(error);
+        const result: string = Sentry.captureException(error);
         transaction.finish();
         return result;
     }

--- a/server/src/@common/sentry/sentry.module.ts
+++ b/server/src/@common/sentry/sentry.module.ts
@@ -4,6 +4,7 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { SentryPerformanceService } from './sentry-performance/sentry-performance.service';
 import { SentryInterceptor } from './sentry.interceptor';
 import { SentryExceptionService } from './sentry-exception/sentry-exception.service';
+import { environment } from '../../../config/config';
 
 export const SENTRY_OPTIONS = 'SENTRY_OPTIONS';
 
@@ -12,6 +13,11 @@ export const SENTRY_OPTIONS = 'SENTRY_OPTIONS';
 })
 export class SentryModule {
     static forRoot(options: Sentry.NodeOptions) {
+        if (environment !== 'production') {
+            Logger.log(`Environment not production, no sentry please`, 'SentryModule');
+            options.dsn = null;
+        }
+
         if (options.dsn === 'undefined') {
             Logger.warn(`Sentry DSN not set`, 'SentryModule');
             options.dsn = null;


### PR DESCRIPTION
This will stop any accidental errors from spamming up sentry, it will also show pretty clearly in logs when there is a dev error vs a production error