### PR TITLE
Safer app bootstrapping

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -3,26 +3,41 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { PrismaRepo } from './modules/prisma/prisma.repo';
 import { AppModule } from './app.module';
 import { appConfig } from '../config/config';
-import { ClassSerializerInterceptor, NestApplicationOptions, ValidationPipe } from '@nestjs/common';
+import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
 import { join } from 'path';
 import { NestExpressApplication } from '@nestjs/platform-express';
 
 async function bootstrap() {
+    const app: NestExpressApplication = await NestFactory.create(AppModule, {
+        bodyParser: false
+    });
+
+    bigIntFix();
+    await setPrismaSettings(app);
+    enableGlobalNestElements(app);
+
+    // bootstrap that is only needed for prod build and not needed for tests
+    exposePublicAssets(app);
+    enableSwagger(app);
+
+    await app.listen(appConfig.port);
+}
+
+export function bigIntFix(){
     // MDN recommended hack override for BigInt
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
     // https://github.com/GoogleChromeLabs/jsbi/issues/30#issuecomment-1006088574
     BigInt.prototype['toJSON'] = function () {
         return this.toString();
     };
+}
 
-    const options: NestApplicationOptions = {
-        bodyParser: false
-    };
-
-    const app: NestExpressApplication = await NestFactory.create(AppModule, options);
-
+export function exposePublicAssets(app: any) {
     app.useStaticAssets(join(__dirname, '..', 'public/assets'));
+    return app;
+}
 
+export function enableSwagger(app: any) {
     const config = new DocumentBuilder()
         .setTitle('Momentum Mod API')
         .setDescription('The Momentum Mod API - https://github.com/momentum-mod/website')
@@ -35,14 +50,18 @@ async function bootstrap() {
         customSiteTitle: 'Momentum Mod API Docs',
         customfavIcon: '../favicon.ico'
     });
-
+}    
+    
+export async function setPrismaSettings(app: any) {
     const prismaDalc: PrismaRepo = app.get(PrismaRepo);
     await prismaDalc.enableShutdownHooks(app);
+    return app;
+}
 
+export function enableGlobalNestElements(app: any){    
     app.useGlobalPipes(new ValidationPipe({ transform: true }));
     app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
-
-    await app.listen(appConfig.port);
+    return app;
 }
 
 bootstrap();

--- a/server/tests/e2e-environment.ts
+++ b/server/tests/e2e-environment.ts
@@ -1,18 +1,13 @@
 ﻿import NodeEnvironment from 'jest-environment-node';
 import { Test } from '@nestjs/testing';
 import { AppModule } from '../src/app.module';
-import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
 import { PrismaRepo } from '../src/modules/prisma/prisma.repo';
-import { PrismaPromise, User } from '@prisma/client';
+import {  User } from '@prisma/client';
 import { AuthService } from '../src/modules/auth/auth.service';
 import { ERole } from '../src/@common/enums/user.enum';
-import { Reflector } from '@nestjs/core';
-
-const prismaBinary = './node_modules/.bin/prisma2';
+import { bigIntFix, enableGlobalNestElements, setPrismaSettings } from '../src/main';
 
 export default class E2ETestEnvironment extends NodeEnvironment {
-    private schema: string;
-
     constructor(config, context) {
         super(config, context);
     }
@@ -24,14 +19,11 @@ export default class E2ETestEnvironment extends NodeEnvironment {
             imports: [AppModule]
         }).compile();
 
-        BigInt.prototype['toJSON'] = function () {
-            return this.toString();
-        };
-
         const app = moduleRef.createNestApplication();
 
-        app.useGlobalPipes(new ValidationPipe({ transform: true }));
-        app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
+        bigIntFix();
+        await setPrismaSettings(app);
+        enableGlobalNestElements(app);
 
         await app.init();
 


### PR DESCRIPTION
This allows our bootstrapping of the app to be as similar as possible
between production and jest testing. 

It should lower risk of errors showing in on version of a build (eg in test but not production) by properly enabling settings in predefined functions.