### PR TITLE
chore: Refactor method names and access

### DIFF
--- a/server/src/modules/activities/activities.controller.ts
+++ b/server/src/modules/activities/activities.controller.ts
@@ -14,7 +14,7 @@ export class ActivitiesController {
     @Get()
     @ApiOperation({ summary: 'Returns a list of activities' })
     @ApiOkPaginatedResponse(ActivityDto, { description: 'Paginated list of activities' })
-    public async GetActivities(@Query() query?: ActivitiesGetQuery): Promise<PaginatedResponseDto<ActivityDto>> {
+    async getActivities(@Query() query?: ActivitiesGetQuery): Promise<PaginatedResponseDto<ActivityDto>> {
         return void 0;
     }
 }

--- a/server/src/modules/admin/admin.controller.ts
+++ b/server/src/modules/admin/admin.controller.ts
@@ -46,8 +46,8 @@ export class AdminController {
     })
     @ApiOperation({ summary: 'Create a placeholder user' })
     @ApiOkResponse({ type: UserDto, description: 'The newly created user' })
-    public CreatePlaceholderUser(@Body() body: CreateUserDto): Promise<UserDto> {
-        return this.adminService.CreatePlaceholderUser(body.alias);
+    createPlaceholderUser(@Body() body: CreateUserDto): Promise<UserDto> {
+        return this.adminService.createPlaceholderUser(body.alias);
     }
 
     @Post('/users/merge')
@@ -59,8 +59,8 @@ export class AdminController {
     @ApiOkResponse({ type: UserDto, description: 'The merged user' })
     @ApiNotFoundResponse({ description: 'If either ID does not correspond to a user' })
     @ApiBadRequestResponse({ description: 'If the placeholder ID is not a placeholder' })
-    public MergeUsers(@Body() body: MergeUserDto): Promise<UserDto> {
-        return this.adminService.MergeUsers(body.placeholderID, body.userID);
+    mergeUsers(@Body() body: MergeUserDto): Promise<UserDto> {
+        return this.adminService.mergeUsers(body.placeholderID, body.userID);
     }
 
     @Patch('/users/:userID')
@@ -80,12 +80,12 @@ export class AdminController {
     })
     @ApiNoContentResponse({ description: 'The user was updated successfully' })
     @ApiBadRequestResponse({ description: 'Invalid user update data' })
-    public UpdateUser(
+    updateUser(
         @LoggedInUser('id') adminID: number,
         @Param('userID', ParseIntPipe) userID: number,
         @Body() body: AdminUpdateUserDto
     ) {
-        return this.adminService.UpdateUser(adminID, userID, body);
+        return this.adminService.updateUser(adminID, userID, body);
     }
 
     @Delete('/users/:userID')
@@ -98,15 +98,15 @@ export class AdminController {
         required: true
     })
     @ApiNoContentResponse({ description: 'The user was deleted successfully' })
-    public DeleteUser(@Param('userID', ParseIntPipe) userID: number) {
-        return this.adminService.DeleteUser(userID);
+    deleteUser(@Param('userID', ParseIntPipe) userID: number) {
+        return this.adminService.deleteUser(userID);
     }
 
     // This seems to only be used to reset all cosmetic or ranked XP.
     // Such a thing terrifies me, so lets leave it for now.
     @Patch('/user-stats')
     @ApiOperation({ summary: "Update every user's stats" })
-    public UpdateUserStats() {
+    updateUserStats() {
         return void 0;
     }
 
@@ -114,7 +114,7 @@ export class AdminController {
     @ApiOperation({ description: 'Retrieve a list of maps' })
     @ApiOkPaginatedResponse(MapDto, { description: 'Paginated list of maps' })
     @ApiBadRequestResponse({ description: 'Invalid query data' })
-    public GetMaps(@Query() query: MapsGetAllQuery): Promise<PaginatedResponseDto<MapDto>> {
+    getMaps(@Query() query: MapsGetAllQuery): Promise<PaginatedResponseDto<MapDto>> {
         return void 0;
     }
 
@@ -134,7 +134,7 @@ export class AdminController {
     })
     @ApiNoContentResponse({ description: 'The map was updated successfully' })
     @ApiBadRequestResponse({ description: 'Invalid map update data' })
-    public UpdateMap(@Param('mapID', ParseIntPipe) mapID: number, @Body() body: UpdateMapDto) {
+    updateMap(@Param('mapID', ParseIntPipe) mapID: number, @Body() body: UpdateMapDto) {
         return void 0;
     }
 
@@ -149,7 +149,7 @@ export class AdminController {
         required: true
     })
     @ApiNoContentResponse({ description: 'The map was deleted successfully' })
-    public DeleteMap(@Param('mapID', ParseIntPipe) mapID: number) {
+    deleteMap(@Param('mapID', ParseIntPipe) mapID: number) {
         return void 0;
     }
 
@@ -158,7 +158,7 @@ export class AdminController {
     @ApiOperation({ description: 'Retrieve a list of reports' })
     @ApiOkPaginatedResponse(ReportDto, { description: 'Paginated list of reports' })
     @ApiBadRequestResponse({ description: 'Invalid query data' })
-    public GetReports(/* @Query() query: some query, check old API */): Promise<PaginatedResponseDto<ReportDto>> {
+    getReports(/* @Query() query: some query, check old API */): Promise<PaginatedResponseDto<ReportDto>> {
         return void 0;
     }
 
@@ -178,7 +178,7 @@ export class AdminController {
         required: true
     })
     @ApiNoContentResponse({ description: 'The report was updated successfully' })
-    public UpdateReport(@Param('reportID', ParseIntPipe) reportID: number, @Body() body: ReportDto) {
+    updateReport(@Param('reportID', ParseIntPipe) reportID: number, @Body() body: ReportDto) {
         return void 0;
     }
 

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -17,27 +17,27 @@ export class AuthController {
     @ApiOperation({ summary: 'Authenticates using steam' })
     @Get('/steam')
     @Public()
-    public AuthSteam(@Req() req, @Res() res): void {
+    authSteam(@Req() req, @Res() res): void {
         passport.authenticate('steam', { session: false })(req, res);
     }
 
     @ApiOperation({ summary: 'Return url from steam, validate and return valid JWT' })
     @Get('/steam/return')
     @UseGuards(SteamWebAuthGuard)
-    public async ReturnFromSteam(@Req() req: Request): Promise<JWTResponseDto> {
+    async returnFromSteam(@Req() req: Request): Promise<JWTResponseDto> {
         return this.authService.login(req.user as User, false);
     }
 
     @ApiOperation({ summary: 'Gets the JWT using a steam user ticket' })
     @Post('/steam/user')
     @Public()
-    public async GetUserFromSteam(@Req() req: Request): Promise<JWTResponseDto> {
+    async getUserFromSteam(@Req() req: Request): Promise<JWTResponseDto> {
         const userID = req.headers['id'] as string;
         if (!req.body) {
             throw new HttpException('Missing userTicket', 400);
         }
 
-        const user = await this.steamAuthService.ValidateFromInGame(req.body, userID);
+        const user = await this.steamAuthService.validateFromInGame(req.body, userID);
         return await this.authService.login(user as User, true);
     }
 }

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -16,8 +16,8 @@ export class AuthService {
             throw new UnauthorizedException();
         }
 
-        const token = await this.GenAccessToken(user, gameAuth);
-        const refreshToken = await this.GenRefreshToken(user.id, gameAuth);
+        const token = await this.genAccessToken(user, gameAuth);
+        const refreshToken = await this.genRefreshToken(user.id, gameAuth);
         const response: JWTResponseDto = {
             access_token: token,
             expires_in: appConfig.accessToken.expTime,
@@ -30,20 +30,20 @@ export class AuthService {
         return response;
     }
 
-    async RevokeToken(userID: number): Promise<void> {
+    async revokeToken(userID: number): Promise<void> {
         this.loggedInUser = null;
-        await this.UpdateRefreshToken(userID, '');
+        await this.updateRefreshToken(userID, '');
     }
 
-    async UpdateRefreshToken(userID: number, refreshToken: string): Promise<UserAuth> {
+    async updateRefreshToken(userID: number, refreshToken: string): Promise<UserAuth> {
         const updateInput: Prisma.UserAuthUpdateInput = {};
         updateInput.refreshToken = refreshToken;
         const whereInput: Prisma.UserAuthWhereUniqueInput = {};
         whereInput.id = userID;
-        return await this.userRepo.UpdateAuth(whereInput, updateInput);
+        return await this.userRepo.updateAuth(whereInput, updateInput);
     }
 
-    private async GenAccessToken(usr: User, gameAuth?: boolean): Promise<string> {
+    private async genAccessToken(usr: User, gameAuth?: boolean): Promise<string> {
         const payload: JWTPayload = {
             id: usr.id,
             steamID: usr.steamID,
@@ -58,7 +58,7 @@ export class AuthService {
         return this.jwtService.sign(payload, options);
     }
 
-    private async GenRefreshToken(userID: number, gameAuth?: boolean): Promise<string> {
+    private async genRefreshToken(userID: number, gameAuth?: boolean): Promise<string> {
         const payload = {
             id: userID
         };

--- a/server/src/modules/auth/guard/roles.guard.ts
+++ b/server/src/modules/auth/guard/roles.guard.ts
@@ -18,7 +18,7 @@ export class RolesGuard implements CanActivate {
 
         const request = context.switchToHttp().getRequest();
 
-        const user = await this.userRepo.Get(request.user.id);
+        const user = await this.userRepo.get(request.user.id);
         return requiredRoles.every((role) => user.roles & role);
     }
 }

--- a/server/src/modules/auth/steam-auth.service.ts
+++ b/server/src/modules/auth/steam-auth.service.ts
@@ -22,7 +22,8 @@ export class SteamAuthService {
     ) {}
 
     //#region Public
-    async ValidateFromInGame(userTicketRaw: any, steamIDToVerify: string): Promise<User> {
+
+    async validateFromInGame(userTicketRaw: any, steamIDToVerify: string): Promise<User> {
         const userTicket = Buffer.from(userTicketRaw, 'utf8').toString('hex');
 
         if (!userTicket && !steamIDToVerify) {
@@ -37,7 +38,7 @@ export class SteamAuthService {
         }
     }
 
-    async ValidateFromSteamWeb(openID: any, profile: any): Promise<User> {
+    async validateFromSteamWeb(openID: any, profile: any): Promise<User> {
         if (profile._json.profilestate !== 1) {
             throw new HttpException(
                 'We do not authenticate Steam accounts without a profile. Set up your community profile on Steam!',
@@ -45,7 +46,7 @@ export class SteamAuthService {
             );
         }
 
-        const user = await this.userService.FindOrCreateFromWeb(openID);
+        const user = await this.userService.findOrCreateFromWeb(openID);
 
         if (!user) {
             throw new HttpException('Could not get or create user', 500);
@@ -57,7 +58,8 @@ export class SteamAuthService {
     //#endregion
 
     //#region Private
-    async verifyUserTicketOnlineAPI(userTicket: string, steamIDToVerify: string) {
+
+    private async verifyUserTicketOnlineAPI(userTicket: string, steamIDToVerify: string) {
         const requestConfig = {
             params: {
                 key: appConfig.steam.webAPIKey,
@@ -93,7 +95,7 @@ export class SteamAuthService {
             throw new UnauthorizedException();
         } // Generate an error here
 
-        const user = await this.userService.FindOrCreateFromGame(steamIDToVerify);
+        const user = await this.userService.findOrCreateFromGame(steamIDToVerify);
 
         if (!user) {
             throw new HttpException('Could not get or create user', 500);
@@ -102,7 +104,7 @@ export class SteamAuthService {
         return user;
     }
 
-    async verifyUserTicketLocalLibrary(userTicketRaw: any, steamIDToVerify: string) {
+    private async verifyUserTicketLocalLibrary(userTicketRaw: any, steamIDToVerify: string) {
         let decrypted;
         if (appConfig.steam.useEncryptedTickets) {
             Logger.log('Using encrypted tickets');
@@ -125,7 +127,7 @@ export class SteamAuthService {
             throw new UnauthorizedException();
         }
 
-        const user = await this.userService.FindOrCreateFromGame(steamIDToVerify);
+        const user = await this.userService.findOrCreateFromGame(steamIDToVerify);
 
         if (!user) {
             throw new HttpException('Could not get or create user', 500);

--- a/server/src/modules/auth/strategy/jwt.strategy.ts
+++ b/server/src/modules/auth/strategy/jwt.strategy.ts
@@ -20,6 +20,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
      */
     async validate(validationPayload: JWTPayload) {
         // TODO: move after repo refactor
-        return this.userRepo.Get(validationPayload.id);
+        return this.userRepo.get(validationPayload.id);
     }
 }

--- a/server/src/modules/auth/strategy/steam-web.strategy.ts
+++ b/server/src/modules/auth/strategy/steam-web.strategy.ts
@@ -15,7 +15,7 @@ export class SteamWebStrategy extends PassportStrategy(Strategy, 'steam') {
     }
 
     async validate(openID, profile) {
-        const jwtToken = await this.steamAuthService.ValidateFromSteamWeb(openID, profile);
+        const jwtToken = await this.steamAuthService.validateFromSteamWeb(openID, profile);
 
         if (!jwtToken) throw new HttpException('Could not find or create user profile', 500);
 

--- a/server/src/modules/filestore/file-store-cloud.service.ts
+++ b/server/src/modules/filestore/file-store-cloud.service.ts
@@ -18,7 +18,7 @@ export class FileStoreCloudService {
         });
     }
 
-    public async storeFileCloud(fileBuffer: Buffer, fileKey: string): Promise<IFileStoreCloudFile> {
+    async storeFileCloud(fileBuffer: Buffer, fileKey: string): Promise<IFileStoreCloudFile> {
         const results = await this.s3Client.send(
             new PutObjectCommand({
                 Bucket: appConfig.storage.bucketName,
@@ -40,7 +40,7 @@ export class FileStoreCloudService {
         };
     }
 
-    public async deleteFileCloud(fileKey: string): Promise<void> {
+    async deleteFileCloud(fileKey: string): Promise<void> {
         const results = await this.s3Client.send(
             new DeleteObjectCommand({
                 Bucket: appConfig.storage.bucketName,

--- a/server/src/modules/filestore/file-store-utils.service.ts
+++ b/server/src/modules/filestore/file-store-utils.service.ts
@@ -4,7 +4,7 @@ import { createReadStream } from 'fs';
 
 @Injectable()
 export class FileStoreUtilsService {
-    public getFileHash(filePath): Promise<string> {
+    getFileHash(filePath): Promise<string> {
         return new Promise((resolve, reject) => {
             const hash = createHash('sha1').setEncoding('hex');
             createReadStream(filePath)
@@ -16,7 +16,7 @@ export class FileStoreUtilsService {
         });
     }
 
-    public getBufferHash(buf): string {
+    getBufferHash(buf): string {
         const hash = createHash('sha1');
         hash.update(buf);
         return hash.digest('hex');

--- a/server/src/modules/maps/maps.controller.ts
+++ b/server/src/modules/maps/maps.controller.ts
@@ -27,11 +27,11 @@ export class MapsController {
     @Get()
     @ApiOperation({ summary: 'Returns all maps' })
     @ApiOkPaginatedResponse(MapDto, { description: 'Paginated list of maps' })
-    public GetAllMaps(
+    getAllMaps(
         @LoggedInUser('id') userID: number,
         @Query() query?: MapsGetAllQuery
     ): Promise<PaginatedResponseDto<MapDto>> {
-        return this.mapsService.GetAll(
+        return this.mapsService.getAll(
             userID,
             query.skip,
             query.take,
@@ -53,8 +53,8 @@ export class MapsController {
         description: 'Create map data transfer object',
         required: true
     })
-    public CreateMap(@Body() body: CreateMapDto): Promise<MapDto> {
-        return this.mapsService.Insert(body);
+    createMap(@Body() body: CreateMapDto): Promise<MapDto> {
+        return this.mapsService.insert(body);
     }
 
     @Get('/:mapID')
@@ -67,12 +67,12 @@ export class MapsController {
     })
     @ApiOkResponse({ description: 'The found map' })
     @ApiNotFoundResponse({ description: 'Map was not found' })
-    public GetMap(
+    getMap(
         @LoggedInUser('id') userID: number,
         @Param('mapID', ParseIntPipe) mapID: number,
         @Query() query?: MapsGetQuery
     ): Promise<MapDto> {
-        return this.mapsService.Get(mapID, userID, query.expand);
+        return this.mapsService.get(mapID, userID, query.expand);
     }
 
     @Post('/:mapID/upload')
@@ -96,9 +96,9 @@ export class MapsController {
         }
     })
     @UseInterceptors(FileInterceptor('file'))
-    public UploadMap(@Param('mapID') mapID: number, @UploadedFile() mapFile: Express.Multer.File): Promise<MapDto> {
+    uploadMap(@Param('mapID') mapID: number, @UploadedFile() mapFile: Express.Multer.File): Promise<MapDto> {
         // see https://stackoverflow.com/questions/66605192/file-uploading-along-with-other-data-in-swagger-nestjs
         // for swagger shit
-        return this.mapsService.Upload(+mapID, mapFile.buffer);
+        return this.mapsService.upload(+mapID, mapFile.buffer);
     }
 }

--- a/server/src/modules/repo/maps-repo.service.ts
+++ b/server/src/modules/repo/maps-repo.service.ts
@@ -10,13 +10,13 @@ export class MapsRepoService {
      * @summary Insert map into database
      * @returns New DB record ID
      */
-    async Insert(input: Prisma.MapCreateInput): Promise<Map> {
+    async insert(input: Prisma.MapCreateInput): Promise<Map> {
         return await this.prisma.map.create({
             data: input
         });
     }
 
-    async Update(mapId: number, data: Prisma.MapUpdateInput): Promise<Map> {
+    async update(mapId: number, data: Prisma.MapUpdateInput): Promise<Map> {
         return await this.prisma.map.update({
             where: { id: mapId },
             data: data
@@ -27,7 +27,7 @@ export class MapsRepoService {
      * @summary Gets all from database
      * @returns All maps
      */
-    async GetAll(
+    async getAll(
         where: Prisma.MapWhereInput,
         include?: Prisma.MapInclude,
         order?: Prisma.MapOrderByWithRelationInput,
@@ -52,14 +52,14 @@ export class MapsRepoService {
      * @summary Gets single map from database
      * @returns A map
      */
-    async Get(id: number, include?: Prisma.MapInclude): Promise<Map> {
+    async get(id: number, include?: Prisma.MapInclude): Promise<Map> {
         return await this.prisma.map.findFirst({
             where: { id: id },
             include: include
         });
     }
 
-    async UpdateCredit(where: Prisma.MapCreditWhereInput, input: Prisma.MapCreditUpdateInput) {
+    async updateCredit(where: Prisma.MapCreditWhereInput, input: Prisma.MapCreditUpdateInput) {
         this.prisma.mapCredit.updateMany({ where: where, data: input });
     }
 }

--- a/server/src/modules/repo/users-repo.service.ts
+++ b/server/src/modules/repo/users-repo.service.ts
@@ -24,7 +24,7 @@ export class UsersRepoService {
      * @summary Inserts to database
      * @returns New db record ID
      */
-    async Insert(newUser: Prisma.UserCreateInput): Promise<User> {
+    async insert(newUser: Prisma.UserCreateInput): Promise<User> {
         return await this.prisma.user.create({
             data: newUser
         });
@@ -34,7 +34,7 @@ export class UsersRepoService {
      * @summary Count the number of users in the database
      * @returns Number of matches
      */
-    async Count(where: Prisma.UserWhereInput): Promise<number> {
+    async count(where: Prisma.UserWhereInput): Promise<number> {
         return await this.prisma.user.count({
             where: where
         });
@@ -44,7 +44,7 @@ export class UsersRepoService {
      * @summary Gets all from database
      * @returns All users
      */
-    async GetAll(
+    async getAll(
         where: Prisma.UserWhereInput,
         include: Prisma.UserInclude,
         skip?: number,
@@ -68,7 +68,7 @@ export class UsersRepoService {
      * @summary Gets single user from database
      * @returns Target user or null
      */
-    async Get(userID: number, include?: Prisma.UserInclude): Promise<User> {
+    async get(userID: number, include?: Prisma.UserInclude): Promise<User> {
         const where: Prisma.UserWhereUniqueInput = { id: userID };
 
         return await this.prisma.user.findUnique({
@@ -81,7 +81,7 @@ export class UsersRepoService {
      * @summary Gets single user from database
      * @returns Target user or null
      */
-    async GetBySteamID(steamID: string): Promise<User> {
+    async getBySteamID(steamID: string): Promise<User> {
         const where: Prisma.UserWhereUniqueInput = {};
         where.steamID = steamID;
 
@@ -94,7 +94,7 @@ export class UsersRepoService {
      * @summary Update a single user in database
      * @returns Target user or null
      */
-    async Update(userID: number, update: Prisma.UserUpdateInput): Promise<User> {
+    async update(userID: number, update: Prisma.UserUpdateInput): Promise<User> {
         const where: Prisma.UserWhereUniqueInput = { id: userID };
 
         return await this.prisma.user.update({
@@ -103,11 +103,11 @@ export class UsersRepoService {
         });
     }
 
-    async Create(input: Prisma.UserCreateInput): Promise<User> {
+    async create(input: Prisma.UserCreateInput): Promise<User> {
         return await this.prisma.user.create({ data: input });
     }
 
-    async Delete(userID: number): Promise<User> {
+    async delete(userID: number): Promise<User> {
         return await this.prisma.user.delete({
             where: {
                 id: userID
@@ -118,11 +118,11 @@ export class UsersRepoService {
     //#endregion
 
     //#region User Auth functions
-    async GetAuth(whereInput: Prisma.UserAuthWhereUniqueInput): Promise<UserAuth> {
+    async getAuth(whereInput: Prisma.UserAuthWhereUniqueInput): Promise<UserAuth> {
         return await this.prisma.userAuth.findFirst({ where: whereInput });
     }
 
-    async UpdateAuth(user: Prisma.UserAuthWhereUniqueInput, update: Prisma.UserAuthUpdateInput): Promise<UserAuth> {
+    async updateAuth(user: Prisma.UserAuthWhereUniqueInput, update: Prisma.UserAuthUpdateInput): Promise<UserAuth> {
         return await this.prisma.userAuth.update({
             where: user,
             data: update
@@ -133,7 +133,7 @@ export class UsersRepoService {
 
     //#region Profile
 
-    async GetProfile(userID: number): Promise<Profile> {
+    async getProfile(userID: number): Promise<Profile> {
         const where: Prisma.ProfileWhereInput = { userID: userID };
 
         return await this.prisma.profile.findFirst({
@@ -145,7 +145,7 @@ export class UsersRepoService {
 
     //#region Activites
 
-    async GetActivities(where: Prisma.ActivityWhereInput, skip?: number, take?: number): Promise<[Activity[], number]> {
+    async getActivities(where: Prisma.ActivityWhereInput, skip?: number, take?: number): Promise<[Activity[], number]> {
         const count = await this.prisma.activity.count({
             where: where
         });
@@ -166,7 +166,7 @@ export class UsersRepoService {
         return [activities, count];
     }
 
-    async UpdateActivities(where: Prisma.ActivityWhereInput, update: Prisma.ActivityUncheckedUpdateManyInput) {
+    async updateActivities(where: Prisma.ActivityWhereInput, update: Prisma.ActivityUncheckedUpdateManyInput) {
         await this.prisma.activity.updateMany({
             where: where,
             data: update
@@ -177,7 +177,7 @@ export class UsersRepoService {
 
     //#region Followers
 
-    async GetFollowers(userID: number, skip?: number, take?: number): Promise<[Follow[], number]> {
+    async getFollowers(userID: number, skip?: number, take?: number): Promise<[Follow[], number]> {
         const where: Prisma.FollowWhereInput = {
             followedID: userID
         };
@@ -207,7 +207,7 @@ export class UsersRepoService {
         return [follows, count];
     }
 
-    async GetFollowing(userID: number, skip?: number, take?: number): Promise<[Follow[], number]> {
+    async getFollowing(userID: number, skip?: number, take?: number): Promise<[Follow[], number]> {
         const where: Prisma.FollowWhereInput = {
             followee: {
                 id: userID
@@ -239,7 +239,7 @@ export class UsersRepoService {
         return [follows, count];
     }
 
-    async GetFollower(followeeID: number, followedID: number): Promise<Follow> {
+    async getFollower(followeeID: number, followedID: number): Promise<Follow> {
         return await this.prisma.follow.findUnique({
             where: {
                 followeeID_followedID: {
@@ -254,7 +254,7 @@ export class UsersRepoService {
         });
     }
 
-    async CreateFollow(followeeID: number, followedID: number) {
+    async createFollow(followeeID: number, followedID: number) {
         await this.prisma.follow.create({
             data: {
                 followedID: followedID,
@@ -263,7 +263,7 @@ export class UsersRepoService {
         });
     }
 
-    async UpdateFollow(followeeID: number, followedID: number, input: Prisma.FollowUpdateInput) {
+    async updateFollow(followeeID: number, followedID: number, input: Prisma.FollowUpdateInput) {
         await this.prisma.follow.update({
             where: {
                 followeeID_followedID: {
@@ -275,7 +275,7 @@ export class UsersRepoService {
         });
     }
 
-    async DeleteFollow(followeeID: number, followedID: number) {
+    async deleteFollow(followeeID: number, followedID: number) {
         await this.prisma.follow.delete({
             where: {
                 followeeID_followedID: {
@@ -290,7 +290,7 @@ export class UsersRepoService {
 
     //#region Map Library
 
-    async GetMapLibraryEntry(userID: number, skip: number, take: number): Promise<[MapLibraryEntry[], number]> {
+    async getMapLibraryEntry(userID: number, skip: number, take: number): Promise<[MapLibraryEntry[], number]> {
         const where: Prisma.MapLibraryEntryWhereInput = {
             userID: userID
         };
@@ -317,7 +317,7 @@ export class UsersRepoService {
 
     //#region Map Favorites
 
-    async GetFavoritedMaps(
+    async getFavoritedMaps(
         where: Prisma.MapFavoriteWhereInput,
         include?: Prisma.MapFavoriteInclude,
         skip?: number,
@@ -341,7 +341,7 @@ export class UsersRepoService {
 
     //#region Notications
 
-    async GetNotification(notificationID: number): Promise<Notification> {
+    async getNotification(notificationID: number): Promise<Notification> {
         return await this.prisma.notification.findUnique({
             where: {
                 id: notificationID
@@ -349,7 +349,7 @@ export class UsersRepoService {
         });
     }
 
-    async GetNotifications(userID: number, skip?: number, take?: number): Promise<[Notification[], number]> {
+    async getNotifications(userID: number, skip?: number, take?: number): Promise<[Notification[], number]> {
         const count = await this.prisma.notification.count({
             where: {
                 userID: userID
@@ -375,7 +375,7 @@ export class UsersRepoService {
         return [notifications, count];
     }
 
-    async UpdateNotification(notificationID: number, read: boolean) {
+    async updateNotification(notificationID: number, read: boolean) {
         await this.prisma.notification.update({
             where: {
                 id: notificationID
@@ -386,7 +386,7 @@ export class UsersRepoService {
         });
     }
 
-    async DeleteNotification(notificationID: number) {
+    async deleteNotification(notificationID: number) {
         await this.prisma.notification.delete({
             where: {
                 id: notificationID
@@ -398,7 +398,7 @@ export class UsersRepoService {
 
     //#region Map Notify
 
-    async GetMapNotify(userID: number, mapID: number): Promise<MapNotify> {
+    async getMapNotify(userID: number, mapID: number): Promise<MapNotify> {
         return await this.prisma.mapNotify.findUnique({
             where: {
                 userID_mapID: {
@@ -409,7 +409,7 @@ export class UsersRepoService {
         });
     }
 
-    async UpsertMapNotify(userID: number, mapID: number, notifyOn: number) {
+    async upsertMapNotify(userID: number, mapID: number, notifyOn: number) {
         await this.prisma.mapNotify.upsert({
             where: {
                 userID_mapID: {
@@ -428,7 +428,7 @@ export class UsersRepoService {
         });
     }
 
-    async DeleteMapNotify(userID: number, mapID: number) {
+    async deleteMapNotify(userID: number, mapID: number) {
         await this.prisma.mapNotify.delete({
             where: {
                 userID_mapID: {
@@ -443,7 +443,7 @@ export class UsersRepoService {
 
     //#region Credits
 
-    async GetMapCredits(userID: number, skip?: number, take?: number): Promise<[MapCredit[], number]> {
+    async getMapCredits(userID: number, skip?: number, take?: number): Promise<[MapCredit[], number]> {
         const where: Prisma.MapCreditWhereInput = { userID: userID };
 
         const count = await this.prisma.mapCredit.count({
@@ -477,7 +477,7 @@ export class UsersRepoService {
     //#region Runs
 
     // TODO: Move to Runs module!!
-    async GetRuns(userID: number, skip?: number, take?: number): Promise<[Run[], number]> {
+    async getRuns(userID: number, skip?: number, take?: number): Promise<[Run[], number]> {
         const where: Prisma.RunWhereInput = {
             playerID: userID
         };

--- a/server/src/modules/reports/reports.controller.ts
+++ b/server/src/modules/reports/reports.controller.ts
@@ -13,7 +13,7 @@ export class ReportsController {
     @Post()
     @ApiOperation({ summary: 'Create a report' })
     @ApiOkResponse({ type: ReportDto, description: 'The newly created report' })
-    public CreateReport(@LoggedInUser('id') submitter: number, @Query() query: CreateReportDto): Promise<ReportDto> {
+    createReport(@LoggedInUser('id') submitter: number, @Query() query: CreateReportDto): Promise<ReportDto> {
         return void 0;
     }
 }

--- a/server/src/modules/runs/runs.controller.ts
+++ b/server/src/modules/runs/runs.controller.ts
@@ -14,7 +14,7 @@ export class RunsController {
     @Get()
     @ApiOperation({ summary: 'Returns a list of runs' })
     @ApiOkPaginatedResponse(RunDto, { description: 'Paginated list of runs' })
-    public GetRuns(@Query() query?: RunsGetAllQuery): Promise<PaginatedResponseDto<RunDto>> {
+    getRuns(@Query() query?: RunsGetAllQuery): Promise<PaginatedResponseDto<RunDto>> {
         return void 0;
     }
 
@@ -28,7 +28,7 @@ export class RunsController {
     })
     @ApiOkResponse({ type: RunDto, description: 'The found run' })
     @ApiNotFoundResponse({ description: 'Run was not found' })
-    public GetRun(@Param('runID', ParseIntPipe) runID: number): Promise<RunDto> {
+    getRun(@Param('runID', ParseIntPipe) runID: number): Promise<RunDto> {
         return void 0;
     }
 
@@ -42,7 +42,7 @@ export class RunsController {
     })
     @ApiOkResponse({ description: 'A run replay file in binary format' })
     @ApiNotFoundResponse({ description: 'Run replay was not found' })
-    public DownloadRun(@Param('runID', ParseIntPipe) runID: number): Promise<any> {
+    downloadRun(@Param('runID', ParseIntPipe) runID: number): Promise<any> {
         return void 0;
     }
 }

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -55,8 +55,8 @@ export class UserController {
     @Get()
     @ApiOperation({ summary: 'Get local user, based on JWT' })
     @ApiOkResponse({ type: UserDto, description: 'The logged in user data' })
-    public GetUser(@LoggedInUser('id') userID: number, @Query() query?: UsersGetQuery): Promise<UserDto> {
-        return this.usersService.Get(userID, query.expand);
+    getUser(@LoggedInUser('id') userID: number, @Query() query?: UsersGetQuery): Promise<UserDto> {
+        return this.usersService.get(userID, query.expand);
     }
 
     @Patch()
@@ -69,8 +69,8 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'The user was successfully updated' })
     @ApiBadRequestResponse({ description: 'Invalid update data' })
-    public UpdateUser(@LoggedInUser('id') userID: number, @Body() updateDto: UpdateUserDto) {
-        return this.usersService.Update(userID, updateDto);
+    updateUser(@LoggedInUser('id') userID: number, @Body() updateDto: UpdateUserDto) {
+        return this.usersService.update(userID, updateDto);
     }
 
     //#endregion
@@ -81,8 +81,8 @@ export class UserController {
     @ApiOperation({ summary: 'Get local user, based on JWT' })
     @ApiOkResponse({ type: ProfileDto, description: "The logged in user's profile data" })
     @ApiNotFoundResponse({ description: 'Profile does not exist' })
-    public GetProfile(@LoggedInUser('id') userID: number): Promise<ProfileDto> {
-        return this.usersService.GetProfile(userID);
+    getProfile(@LoggedInUser('id') userID: number): Promise<ProfileDto> {
+        return this.usersService.getProfile(userID);
     }
 
     @Delete('/profile/:type')
@@ -96,8 +96,8 @@ export class UserController {
     })
     @ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'The account was successfully unlinked' })
     @ApiBadRequestResponse({ description: 'Invalid social account' })
-    public UnlinkSocial(@LoggedInUser('id') userID: number, @Param('type') type: string) {
-        return this.usersService.UnlinkSocial(userID, type);
+    unlinkSocial(@LoggedInUser('id') userID: number, @Param('type') type: string) {
+        return this.usersService.unlinkSocial(userID, type);
     }
 
     //#endregion
@@ -114,11 +114,11 @@ export class UserController {
     })
     @ApiOkResponse({ type: FollowStatusDto, description: 'Follow status of the local user to the target user' })
     @ApiNotFoundResponse({ description: 'Target user does not exist' })
-    public GetFollowStatus(
+    getFollowStatus(
         @LoggedInUser('id') localUserID: number,
         @Param('userID', ParseIntPipe) targetUserID: number
     ): Promise<FollowStatusDto> {
-        return this.usersService.GetFollowStatus(localUserID, targetUserID);
+        return this.usersService.getFollowStatus(localUserID, targetUserID);
     }
 
     @Post('/follow/:userID')
@@ -132,8 +132,8 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'The user was successfully followed' })
     @ApiNotFoundResponse({ description: 'Target user does not exist' })
-    public FollowUser(@LoggedInUser('id') localUserID: number, @Param('userID', ParseIntPipe) targetUserID: number) {
-        return this.usersService.FollowUser(localUserID, targetUserID);
+    followUser(@LoggedInUser('id') localUserID: number, @Param('userID', ParseIntPipe) targetUserID: number) {
+        return this.usersService.followUser(localUserID, targetUserID);
     }
 
     @Patch('/follow/:userID')
@@ -152,12 +152,12 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'The follow activity flags were successfully updated' })
     @ApiNotFoundResponse({ description: 'Target user does not exist' })
-    public UpdateFollow(
+    updateFollow(
         @LoggedInUser('id') localUserID: number,
         @Param('userID', ParseIntPipe) targetUserID: number,
         @Body() updateDto: UpdateFollowStatusDto
     ) {
-        return this.usersService.UpdateFollow(localUserID, targetUserID, updateDto);
+        return this.usersService.updateFollow(localUserID, targetUserID, updateDto);
     }
 
     @Delete('/follow/:userID')
@@ -171,8 +171,8 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'The user was successfully unfollowed' })
     @ApiNotFoundResponse({ description: 'Target user or follow does not exist' })
-    public UnfollowUser(@LoggedInUser('id') localUserID: number, @Param('userID', ParseIntPipe) targetUserID: number) {
-        return this.usersService.UnfollowUser(localUserID, targetUserID);
+    unfollowUser(@LoggedInUser('id') localUserID: number, @Param('userID', ParseIntPipe) targetUserID: number) {
+        return this.usersService.unfollowUser(localUserID, targetUserID);
     }
 
     //#endregion
@@ -189,11 +189,11 @@ export class UserController {
     })
     @ApiOkResponse({ type: MapNotifyDto, description: 'MapNotifyDTO if map notify was found, empty if not' })
     @ApiNotFoundResponse({ description: 'The map does not exist' })
-    public GetMapNotifyStatus(
+    getMapNotifyStatus(
         @LoggedInUser('id') userID: number,
         @Param('mapID', ParseIntPipe) mapID: number
     ): Promise<MapNotifyDto> {
-        return this.usersService.GetMapNotifyStatus(userID, mapID);
+        return this.usersService.getMapNotifyStatus(userID, mapID);
     }
 
     @Put('/notifyMap/:mapID')
@@ -213,12 +213,12 @@ export class UserController {
     @ApiNoContentResponse({ description: 'The map notify flags were successfully updated' })
     @ApiBadRequestResponse({ description: 'Invalid notifyOn data' })
     @ApiNotFoundResponse({ description: 'The map does not exist' })
-    public UpdateMapNotify(
+    updateMapNotify(
         @LoggedInUser('id') userID: number,
         @Param('mapID', ParseIntPipe) mapID: number,
         @Body() updateDto: UpdateMapNotifyDto
     ) {
-        return this.usersService.UpdateMapNotify(userID, mapID, updateDto);
+        return this.usersService.updateMapNotify(userID, mapID, updateDto);
     }
 
     @Delete('/notifyMap/:mapID')
@@ -232,8 +232,8 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'Map notification was deleted successfully' })
     @ApiNotFoundResponse({ description: 'The map does not exist' })
-    public RemoveMapNotify(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
-        return this.usersService.RemoveMapNotify(userID, mapID);
+    removeMapNotify(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
+        return this.usersService.removeMapNotify(userID, mapID);
     }
 
     //#endregion
@@ -243,11 +243,11 @@ export class UserController {
     @Get('/activities')
     @ApiOperation({ summary: "Returns all of the local user's activities" })
     @ApiOkPaginatedResponse(UserDto, { description: "Paginated list of the local user's activites" })
-    public GetActivities(
+    getActivities(
         @LoggedInUser('id') userID: number,
         @Query() query?: UsersGetActivitiesQuery
     ): Promise<PaginatedResponseDto<ActivityDto>> {
-        return this.usersService.GetActivities(userID, query.skip, query.take, query.type, query.data);
+        return this.usersService.getActivities(userID, query.skip, query.take, query.type, query.data);
     }
 
     @Get('/activities/followed')
@@ -259,11 +259,11 @@ export class UserController {
         required: true
     })
     @ApiOkPaginatedResponse(UserDto, { description: "Paginated list of the activities of the user's followers" })
-    public GetFollowedActivities(
+    getFollowedActivities(
         @LoggedInUser('id') userID: number,
         @Query() query?: UsersGetActivitiesQuery
     ): Promise<PaginatedResponseDto<ActivityDto>> {
-        return this.usersService.GetFollowedActivities(userID, query.skip, query.take, query.type, query.data);
+        return this.usersService.getFollowedActivities(userID, query.skip, query.take, query.type, query.data);
     }
 
     //#endregion
@@ -273,11 +273,11 @@ export class UserController {
     @Get('/notifications')
     @ApiOperation({ summary: "Returns all of the local user's notifications" })
     @ApiOkPaginatedResponse(NotificationDto, { description: "Paginated list of the local user's notifications" })
-    public GetNotifications(
+    getNotifications(
         @LoggedInUser('id') userID: number,
         @Query() query?: PaginationQuery
     ): Promise<PaginatedResponseDto<NotificationDto>> {
-        return this.usersService.GetNotifications(userID, query.skip, query.take);
+        return this.usersService.getNotifications(userID, query.skip, query.take);
     }
 
     @Patch('/notifications/:notificationID')
@@ -291,12 +291,12 @@ export class UserController {
     @ApiNoContentResponse({ description: 'Notification was updated successfully' })
     @ApiBadRequestResponse({ description: 'Invalid read data' })
     @ApiNotFoundResponse({ description: 'The notification does not exist' })
-    public UpdateNotification(
+    updateNotification(
         @LoggedInUser('id') userID: number,
         @Param('notificationID', ParseIntPipe) notificationID: number,
         @Body() updateDto: UpdateNotificationDto
     ) {
-        return this.usersService.UpdateNotification(userID, notificationID, updateDto);
+        return this.usersService.updateNotification(userID, notificationID, updateDto);
     }
 
     @Delete('/notifications/:notificationID')
@@ -304,11 +304,11 @@ export class UserController {
     @ApiNoContentResponse({ description: 'Notification was deleted successfully' })
     @ApiOperation({ summary: 'Deletes the given notification' })
     @ApiNotFoundResponse({ description: 'The notification does not exist' })
-    public DeleteNotification(
+    deleteNotification(
         @LoggedInUser('id') userID: number,
         @Param('notificationID', ParseIntPipe) notificationID: number
     ) {
-        return this.usersService.DeleteNotification(userID, notificationID);
+        return this.usersService.deleteNotification(userID, notificationID);
     }
 
     //#endregion
@@ -318,11 +318,11 @@ export class UserController {
     @Get('/maps/library')
     @ApiOperation({ summary: "Returns the maps in the local user's library" })
     @ApiOkPaginatedResponse(MapLibraryEntryDto, { description: 'Paginated list of the library entries' })
-    public GetMapLibraryEntry(
+    getMapLibraryEntry(
         @LoggedInUser('id') userID: number,
         @Query() query?: UserMapLibraryGetQuery
     ): Promise<PaginatedResponseDto<MapLibraryEntryDto>> {
-        return this.usersService.GetMapLibraryEntry(userID, query.skip, query.take, query.search, query.expand);
+        return this.usersService.getMapLibraryEntry(userID, query.skip, query.take, query.search, query.expand);
     }
 
     @Get('/maps/library/:mapID')
@@ -335,7 +335,7 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'Map is in the library' })
     @ApiNotFoundResponse({ description: 'Map is not in the library' })
-    public CheckMapLibraryEntry(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
+    checkMapLibraryEntry(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
         return void 0;
         //return this.usersService.CheckMapLibraryEntry(userID, mapID);
     }
@@ -350,7 +350,7 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'Map was added to the library' })
     @ApiNotFoundResponse({ description: 'The map does not exist' })
-    public AddMapLibraryEntry(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
+    addMapLibraryEntry(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
         return void 0;
         //return this.usersService.AddMapLibraryEntry(userID, mapID);
     }
@@ -365,7 +365,7 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'Map was removed from the library' })
     @ApiNotFoundResponse({ description: 'The map does not exist' })
-    public RemoveMapLibraryEntry(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
+    removeMapLibraryEntry(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
         return void 0;
         //return this.usersService.RemoveMapLibraryEntry(userID, mapID);
     }
@@ -377,11 +377,11 @@ export class UserController {
     @Get('/maps/favorites')
     @ApiOperation({ summary: "Returns the maps in the local user's favorites" })
     @ApiOkPaginatedResponse(MapFavoriteDto, { description: 'Paginated list of favorited maps' })
-    public GetFavoritedMaps(
+    getFavoritedMaps(
         @LoggedInUser('id') userID: number,
         @Query() query?: UserMapLibraryGetQuery
     ): Promise<PaginatedResponseDto<MapFavoriteDto>> {
-        return this.usersService.GetFavoritedMaps(userID, query.skip, query.take, query.search, query.expand);
+        return this.usersService.getFavoritedMaps(userID, query.skip, query.take, query.search, query.expand);
     }
 
     @Get('/maps/favorites/:mapID')
@@ -394,7 +394,7 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'Map is in the favorites' })
     @ApiNotFoundResponse({ description: 'Map is not in the favorites' })
-    public CheckFavoritedMap(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
+    checkFavoritedMap(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
         return void 0;
         //return this.usersService.CheckFavoritedMap(userID, mapID);
     }
@@ -409,7 +409,7 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'Map was added to the favorites' })
     @ApiNotFoundResponse({ description: 'The map does not exist' })
-    public AddFavoritedMap(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
+    addFavoritedMap(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
         return void 0;
         //return this.usersService.AddFavoritedMap(userID, mapID);
     }
@@ -424,7 +424,7 @@ export class UserController {
     })
     @ApiNoContentResponse({ description: 'Map was removed from the favorites' })
     @ApiNotFoundResponse({ description: 'The map does not exist' })
-    public RemoveFavoritedMap(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
+    removeFavoritedMap(@LoggedInUser('id') userID: number, @Param('mapID', ParseIntPipe) mapID: number) {
         return void 0;
         //return this.usersService.RemoveFavoritedMap(userID, mapID);
     }
@@ -436,7 +436,7 @@ export class UserController {
     @Get('/maps/submitted')
     @ApiOperation({ summary: 'Returns the maps submitted by the local user' })
     @ApiOkPaginatedResponse(MapDto, { description: 'Paginated list of submitted maps' })
-    public GetSubmittedMaps(
+    getSubmittedMaps(
         @LoggedInUser('id') userID: number,
         @Query() query?: UserMapSubmittedGetQuery
     ): Promise<PaginatedResponseDto<MapDto>> {
@@ -448,7 +448,7 @@ export class UserController {
     @Get('/maps/submitted/summary')
     @ApiOperation({ summary: 'Returns the summary of maps submitted by the local user' })
     @ApiOkResponse({ description: 'Summary of maps submitted by the local user' })
-    public GetSubmittedMapsSummary(@LoggedInUser('id') userID: number) /*: Promise<who knows???> */ {
+    getSubmittedMapsSummary(@LoggedInUser('id') userID: number) /*: Promise<who knows???> */ {
         return void 0;
     }
 

--- a/server/src/modules/users/users.controller.ts
+++ b/server/src/modules/users/users.controller.ts
@@ -31,8 +31,8 @@ export class UsersController {
     @ApiOperation({ summary: 'Returns all users' })
     @ApiOkPaginatedResponse(UserDto, { description: 'Paginated list of users' })
     @ApiBadRequestResponse({ description: 'The query contained conflicting parameters' })
-    public GetAll(@Query() query?: UsersGetAllQuery): Promise<PaginatedResponseDto<UserDto>> {
-        return this.usersService.GetAll(
+    getAll(@Query() query?: UsersGetAllQuery): Promise<PaginatedResponseDto<UserDto>> {
+        return this.usersService.getAll(
             query.skip,
             query.take,
             query.expand,
@@ -53,8 +53,8 @@ export class UsersController {
     })
     @ApiOkResponse({ type: UserDto, description: 'The found user' })
     @ApiNotFoundResponse({ description: 'User was not found' })
-    public GetUser(@Param('userID', ParseIntPipe) userID: number, @Query() query?: UsersGetQuery): Promise<UserDto> {
-        return this.usersService.Get(userID, query.expand, query.mapRank);
+    getUser(@Param('userID', ParseIntPipe) userID: number, @Query() query?: UsersGetQuery): Promise<UserDto> {
+        return this.usersService.get(userID, query.expand, query.mapRank);
     }
 
     @Get('/:userID/profile')
@@ -67,8 +67,8 @@ export class UsersController {
         description: 'Target User ID',
         required: true
     })
-    public GetProfile(@Param('userID', ParseIntPipe) userID: number): Promise<ProfileDto> {
-        return this.usersService.GetProfile(userID);
+    getProfile(@Param('userID', ParseIntPipe) userID: number): Promise<ProfileDto> {
+        return this.usersService.getProfile(userID);
     }
 
     @Get('/:userID/activities')
@@ -80,11 +80,11 @@ export class UsersController {
         required: true
     })
     @ApiOkPaginatedResponse(UserDto, { description: "Paginated list of the user's activites" })
-    public GetActivities(
+    getActivities(
         @Param('userID', ParseIntPipe) userID: number,
         @Query() query?: UsersGetActivitiesQuery
     ): Promise<PaginatedResponseDto<ActivityDto>> {
-        return this.usersService.GetActivities(userID, query.skip, query.take, query.type, query.data);
+        return this.usersService.getActivities(userID, query.skip, query.take, query.type, query.data);
     }
 
     @Get('/:userID/followers')
@@ -96,11 +96,11 @@ export class UsersController {
         required: true
     })
     @ApiOkPaginatedResponse(UserDto, { description: 'Paginated list of the follows targeting the user' })
-    public GetFollowers(
+    getFollowers(
         @Param('userID', ParseIntPipe) userID: number,
         @Query() query?: PaginationQuery
     ): Promise<PaginatedResponseDto<FollowDto>> {
-        return this.usersService.GetFollowers(userID, query.skip, query.take);
+        return this.usersService.getFollowers(userID, query.skip, query.take);
     }
 
     @Get('/:userID/follows')
@@ -112,11 +112,11 @@ export class UsersController {
         required: true
     })
     @ApiOkPaginatedResponse(UserDto, { description: 'Paginated list of the follows for the user' })
-    public GetFollowed(
+    getFollowed(
         @Param('userID', ParseIntPipe) userID: number,
         @Query() query: PaginationQuery
     ): Promise<PaginatedResponseDto<FollowDto>> {
-        return this.usersService.GetFollowing(userID, query.skip, query.take);
+        return this.usersService.getFollowing(userID, query.skip, query.take);
     }
 
     @Get('/:userID/credits')
@@ -128,11 +128,11 @@ export class UsersController {
         required: true
     })
     @ApiOkPaginatedResponse(UserDto, { description: 'Paginated list of map credits attributed to the user' })
-    public GetMapCredits(
+    getMapCredits(
         @Param('userID', ParseIntPipe) userID: number,
         @Query() query: PaginationQuery
     ): Promise<PaginatedResponseDto<MapCreditDto>> {
-        return this.usersService.GetMapCredits(userID, query.skip, query.take);
+        return this.usersService.getMapCredits(userID, query.skip, query.take);
     }
 
     @Get('/:userID/runs')
@@ -144,12 +144,12 @@ export class UsersController {
         required: true
     })
     @ApiOkPaginatedResponse(UserDto, { description: "Paginated list of the user's runs" })
-    public GetRuns(
+    getRuns(
         @Param('userID', ParseIntPipe) userID: number,
         @Query() query: PaginationQuery
     ): Promise<PaginatedResponseDto<RunDto>> {
         // TODO: The old API calls the runs model here. We should do the same, this functionality
         // doesn't need to exist in the users service.
-        return this.usersService.GetRuns(userID, query.skip, query.take);
+        return this.usersService.getRuns(userID, query.skip, query.take);
     }
 }


### PR DESCRIPTION
Another sweeping refactor, I'm sorry. I just strongly feel we should be following a consistent naming style, meaning lowerCamelCase for method names. I plan on enforcing https://ts.dev/style/#naming-style from now on.

Also, using `public` on the front of methods everywhere is just silly (and we weren't even applying it consistently). It has no programmatic purpose, seems to just be there for the sake of looking like C++/C#/Java. More than anything I worry it'll confuse contributors into thinking it has actual practical purpose.