### PR TITLE
Don't seed after Prisma Migrate

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
         "start:prod": "node dist/main",
         "start:migrate:debug": "npm run seed && npm run start:debug",
         "start:migrate:prod": "prisma migrate dev --name production_deploy && npm run start:prod",
-        "migrate": "prisma migrate dev --name init",
+        "migrate": "prisma migrate dev --name init --skip-seed",
         "seed": "npm run migrate && prisma db seed",
         "reset": "prisma migrate reset --force --skip-generate --skip-seed",
         "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",


### PR DESCRIPTION
This screws up tests and is generally unnecessary, better to just have the seed command do this.