### PR TITLE
More maps endpoints

### DIFF
--- a/server/src/@common/dto/map/map-credit.dto.ts
+++ b/server/src/@common/dto/map/map-credit.dto.ts
@@ -2,7 +2,7 @@ import { MapCredit } from '@prisma/client';
 import { UserDto } from '../user/user.dto';
 import { MapDto } from './map.dto';
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsEnum, IsInt, ValidateNested } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, ValidateNested } from 'class-validator';
 import { MapCreditType } from '../../enums/map.enum';
 import { DtoFactory } from '../../utils/dto.utility';
 import { Exclude, Transform } from 'class-transformer';
@@ -42,3 +42,15 @@ export class MapCreditDto implements MapCredit {
 }
 
 export class CreateMapCreditDto extends PickType(MapCreditDto, ['userID', 'type'] as const) {}
+
+export class UpdateMapCreditDto {
+    @ApiProperty({ description: 'The new user ID to set', type: Number })
+    @IsInt()
+    @IsOptional()
+    userID?: number;
+
+    @ApiProperty({ description: 'The new map credit type to set', enum: MapCreditType })
+    @IsEnum(MapCreditType)
+    @IsOptional()
+    type?: number;
+}

--- a/server/src/@common/dto/map/map-info.dto.ts
+++ b/server/src/@common/dto/map/map-info.dto.ts
@@ -1,6 +1,6 @@
 ﻿import { MapInfo } from '@prisma/client';
 import { Exclude, Transform, Type } from 'class-transformer';
-import { ApiProperty, PickType } from '@nestjs/swagger';
+import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
 import { IsDate, IsDateString, IsDefined, IsInt, IsOptional, IsString, Matches } from 'class-validator';
 
 export class MapInfoDto implements MapInfo {
@@ -45,3 +45,5 @@ export class CreateMapInfoDto extends PickType(MapInfoDto, [
     'numTracks',
     'creationDate'
 ] as const) {}
+
+export class UpdateMapInfoDto extends PartialType(PickType(MapInfoDto, ['description', 'youtubeID', 'creationDate'] as const)) {}

--- a/server/src/@common/dto/query/map-queries.dto.ts
+++ b/server/src/@common/dto/query/map-queries.dto.ts
@@ -127,3 +127,8 @@ export class MapsGetQuery {
     ])
     expand: string[];
 }
+
+export class MapCreditsGetQuery {
+    @ExpandQueryDecorators(['user'])
+    expand: string[];
+}

--- a/server/src/modules/admin/admin.service.ts
+++ b/server/src/modules/admin/admin.service.ts
@@ -50,7 +50,7 @@ export class AdminService {
         if (!user) throw new BadRequestException('Merging user not found');
 
         // Update credits to point to new ID
-        await this.mapRepo.updateCredit(
+        await this.mapRepo.updateCredits(
             {
                 userID: placeholderID
             },

--- a/server/src/modules/maps/maps.controller.ts
+++ b/server/src/modules/maps/maps.controller.ts
@@ -40,6 +40,7 @@ import { Roles as RolesEnum } from '../../@common/enums/user.enum';
 import { LoggedInUser } from '../../@common/decorators/logged-in-user.decorator';
 import { CreateMapCreditDto, MapCreditDto, UpdateMapCreditDto } from '../../@common/dto/map/map-credit.dto';
 import { MapInfoDto, UpdateMapInfoDto } from '../../@common/dto/map/map-info.dto';
+import { MapTrackDto } from '../../@common/dto/map/map-track.dto';
 
 @ApiBearerAuth()
 @Controller('api/v1/maps')
@@ -330,6 +331,22 @@ export class MapsController {
         return this.mapsService.updateInfo(mapID, updateDto, userID);
     }
 
+    //#endregion
+
+    //#Zones
+    @Get('/:mapID/zones')
+    @ApiOperation({ summary: "Gets a single map's zones" })
+    @ApiParam({
+        name: 'mapID',
+        type: Number,
+        description: 'Target Map ID',
+        required: true
+    })
+    @ApiOkResponse({ description: "The found map's zones" })
+    @ApiNotFoundResponse({ description: 'Map not found' })
+    getZones(@Param('mapID', ParseIntPipe) mapID: number): Promise<MapTrackDto[]> {
+        return this.mapsService.getZones(mapID);
+    }
     //#endregion
 
     //#region Private

--- a/server/src/modules/maps/maps.controller.ts
+++ b/server/src/modules/maps/maps.controller.ts
@@ -39,6 +39,7 @@ import { Roles } from '../../@common/decorators/roles.decorator';
 import { Roles as RolesEnum } from '../../@common/enums/user.enum';
 import { LoggedInUser } from '../../@common/decorators/logged-in-user.decorator';
 import { CreateMapCreditDto, MapCreditDto, UpdateMapCreditDto } from '../../@common/dto/map/map-credit.dto';
+import { MapInfoDto, UpdateMapInfoDto } from '../../@common/dto/map/map-info.dto';
 
 @ApiBearerAuth()
 @Controller('api/v1/maps')
@@ -290,6 +291,43 @@ export class MapsController {
         @LoggedInUser('id') userID: number
     ): Promise<void> {
         return this.mapsService.deleteCredit(mapCredID, userID);
+    }
+
+    @Get('/:mapID/info')
+    @ApiOperation({ summary: "Gets a single map's info" })
+    @ApiParam({
+        name: 'mapID',
+        type: Number,
+        description: 'Target Map ID',
+        required: true
+    })
+    @ApiOkResponse({ description: "The found map's info" })
+    @ApiNotFoundResponse({ description: 'Map not found' })
+    getInfo(@Param('mapID', ParseIntPipe) mapID: number): Promise<MapInfoDto> {
+        return this.mapsService.getInfo(mapID);
+    }
+
+    @Patch('/:mapID/info')
+    @Roles(RolesEnum.MAPPER)
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Update the map info' })
+    @ApiBody({
+        type: UpdateMapInfoDto,
+        description: 'Update map info data transfer object',
+        required: true
+    })
+    @ApiNoContentResponse({ description: 'The map info was successfully updated' })
+    @ApiBadRequestResponse({ description: 'Invalid update data' })
+    @ApiForbiddenResponse({ description: 'Map is not in NEEDS_REVISION state' })
+    @ApiForbiddenResponse({ description: 'User does not have the mapper role' })
+    @ApiForbiddenResponse({ description: 'User is not the submitter of this map' })
+    @ApiNotFoundResponse({ description: 'Map not found' })
+    updateUser(
+        @LoggedInUser('id') userID: number,
+        @Body() updateDto: UpdateMapInfoDto,
+        @Param('mapID', ParseIntPipe) mapID: number
+    ): Promise<void> {
+        return this.mapsService.updateInfo(mapID, updateDto, userID);
     }
 
     //#endregion

--- a/server/src/modules/repo/maps-repo.service.ts
+++ b/server/src/modules/repo/maps-repo.service.ts
@@ -92,7 +92,7 @@ export class MapsRepoService {
         return this.prisma.mapCredit.findFirst({ where: where });
     }
 
-    async updateCredit(
+    async updateCredits(
         where: Prisma.MapCreditWhereInput,
         input: Prisma.MapCreditUncheckedUpdateManyInput
     ): Promise<void> {

--- a/server/src/modules/repo/maps-repo.service.ts
+++ b/server/src/modules/repo/maps-repo.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
-import { Map, MapCredit, MapZone, MapZoneTrigger, Prisma } from '@prisma/client';
+import { Map, MapCredit, MapInfo, MapZone, MapZoneTrigger, Prisma } from '@prisma/client';
 
 @Injectable()
 export class MapsRepoService {
@@ -138,6 +138,23 @@ export class MapsRepoService {
         await this.prisma.mapCredit.delete({ where: where });
     }
 
+    //#endregion
+
+    //#region MapInfo
+    async getInfo(mapId: number): Promise<MapInfo> {
+        const mapInfo = await this.prisma.mapInfo.findUnique({ where: { mapID: mapId } });
+
+        return mapInfo;
+    }
+
+    async updateInfo(mapID: number, data: Prisma.MapInfoUpdateInput): Promise<MapInfo> {
+        return this.prisma.mapInfo.update({
+            where: {
+                mapID: mapID
+            },
+            data: data
+        });
+    }
     //#endregion
 
     //#region MapTrack

--- a/server/src/modules/repo/maps-repo.service.ts
+++ b/server/src/modules/repo/maps-repo.service.ts
@@ -102,6 +102,18 @@ export class MapsRepoService {
         });
     }
 
+    async updateCredit(
+        credID: number,
+        input: Prisma.MapCreditUpdateInput
+    ): Promise<MapCredit> {
+        return this.prisma.mapCredit.update({
+            where: {
+                id: credID
+            },
+            data: input
+        });
+    }
+
     async getCredits(
         where: Prisma.MapCreditWhereInput,
         include?: Prisma.MapCreditInclude
@@ -116,6 +128,14 @@ export class MapsRepoService {
                 map: true
             }
         });
+    }
+
+    async getCredit(id: number, include?: Prisma.MapCreditInclude): Promise<MapCredit> {
+        return this.prisma.mapCredit.findUnique({ where: { id: id }, include: include });
+    }
+
+    async deleteCredit(where: Prisma.MapCreditWhereUniqueInput): Promise<void> {
+        await this.prisma.mapCredit.delete({ where: where });
     }
 
     //#endregion

--- a/server/src/modules/repo/maps-repo.service.ts
+++ b/server/src/modules/repo/maps-repo.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
-import { Map, MapZone, MapZoneTrigger, Prisma } from '@prisma/client';
+import { Map, MapCredit, MapZone, MapZoneTrigger, Prisma } from '@prisma/client';
 
 @Injectable()
 export class MapsRepoService {
@@ -88,6 +88,9 @@ export class MapsRepoService {
     }
 
     //#region MapCredit
+    async findCredit(where: Prisma.MapCreditWhereInput): Promise<MapCredit> {
+        return this.prisma.mapCredit.findFirst({ where: where });
+    }
 
     async updateCredit(
         where: Prisma.MapCreditWhereInput,
@@ -96,6 +99,22 @@ export class MapsRepoService {
         await this.prisma.mapCredit.updateMany({
             where: where,
             data: input
+        });
+    }
+
+    async getCredits(
+        where: Prisma.MapCreditWhereInput,
+        include?: Prisma.MapCreditInclude
+    ): Promise<MapCredit[]> {
+        return this.prisma.mapCredit.findMany({ where: where, include: include });
+    }
+
+    async createCredit(input: Prisma.MapCreditCreateInput): Promise<MapCredit> {
+        return this.prisma.mapCredit.create({
+            data: input,
+            include: {
+                map: true
+            }
         });
     }
 

--- a/server/src/modules/repo/maps-repo.service.ts
+++ b/server/src/modules/repo/maps-repo.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
-import { Map, MapCredit, MapInfo, MapZone, MapZoneTrigger, Prisma } from '@prisma/client';
+import { Map, MapCredit, MapInfo, MapStats, MapTrack, MapZone, MapZoneTrigger, Prisma } from '@prisma/client';
 
 @Injectable()
 export class MapsRepoService {
@@ -157,7 +157,26 @@ export class MapsRepoService {
     }
     //#endregion
 
+    //#region Map Stats
+    async updateMapStats(mapID: number, data: Prisma.MapStatsUpdateInput): Promise<MapStats> {
+        return this.prisma.mapStats.update({
+            where: {
+                mapID: mapID
+            },
+            data: data
+        });
+    }
+    //#endregion
+
     //#region MapTrack
+    async getMapTracks(mapID: number, include: Prisma.MapTrackInclude): Promise<MapTrack[]> {
+        return this.prisma.mapTrack.findMany({
+            where: {
+                mapID: mapID
+            },
+            include: include
+        });
+    }
     // TODO: I assume we'll do more here in the future, I just need this rn
 
     async updateMapTrack(where: Prisma.MapTrackWhereUniqueInput, input: Prisma.MapTrackUpdateInput): Promise<void> {

--- a/server/src/modules/repo/users-repo.service.ts
+++ b/server/src/modules/repo/users-repo.service.ts
@@ -143,6 +143,10 @@ export class UsersRepoService {
         return [activities, count];
     }
 
+    async deleteActivities(where: Prisma.ActivityWhereInput): Promise<void> {
+        await this.prisma.activity.deleteMany({ where: where });
+    }
+
     async updateActivities(where: Prisma.ActivityWhereInput, update: Prisma.ActivityUncheckedUpdateManyInput) {
         await this.prisma.activity.updateMany({
             where: where,


### PR DESCRIPTION
We got the following endpoints:
- maps/:mapID/credits GET, POST  
- maps/credits/:mapCredID GET, PATCH, DEL  
- maps/:mapID/info GET, PATCH  
- maps/:mapID/zones GET  

I decided not to bother messing around moving any service logic, imo it's probably best to do all of that in one go anyways