### PR TITLE
fix: Temp fix for openid user creation

### DIFF
--- a/server/src/modules/users/users.service.ts
+++ b/server/src/modules/users/users.service.ts
@@ -491,6 +491,8 @@ export class UsersService {
 
         const profile = new UserDto();
         profile.steamID = steamID;
+        // TODO: Remove when reworking this method!
+        profile.alias ??= 'temp';
 
         return profile;
     }


### PR DESCRIPTION
This was already broken but it didn't really matter, until I made it so aliases are non-nullable. Fixes that error for now, I'll rework this method in the near future.