### PR TITLE
GET maps/:mapID/download

### DIFF
--- a/server/src/modules/maps/maps.controller.ts
+++ b/server/src/modules/maps/maps.controller.ts
@@ -15,7 +15,9 @@ import {
     Patch,
     Delete,
     Put,
-    UseGuards
+    UseGuards,
+    Header,
+    StreamableFile
 } from '@nestjs/common';
 import {
     ApiBearerAuth,
@@ -197,6 +199,22 @@ export class MapsController {
         if (!file || !file.buffer || !Buffer.isBuffer(file.buffer)) throw new BadRequestException('Map is not valid');
 
         return this.mapsService.upload(mapID, userID, file.buffer);
+    }
+
+    @Get('/:mapID/download')
+    @ApiOperation({ summary: "Download the map's BSP file" })
+    @Header('Content-Type', 'application/octet-stream')
+    @ApiOkResponse({ description: "The map's BSP file" })
+    @ApiNotFoundResponse({ description: 'Map was not found' })
+    @ApiNotFoundResponse({ description: "Map's BSP file could not be found" })
+    @ApiParam({
+        name: 'mapID',
+        type: Number,
+        description: 'Target Map ID',
+        required: true
+    })
+    downloadMap(@Param('mapID', ParseIntPipe) mapID: number): Promise<StreamableFile> {
+        return this.mapsService.download(mapID);
     }
 
     //#endregion


### PR DESCRIPTION
There are some things I'd like to get input about, which I was very unsure of while writing the changes

1.  I didn't know if I should log a failed download, I decided to do so and include the error message, since an invalid key or bucket can  throw different errors
1.  I included the response type from express to pass the object to the service, I think I could have gotten away with the `any` type but did so for clarity
1.  If `maps.service.ts` LN: 330 fails, the download won't start. I thought about catching and ignoring the potential error there so that a failed downloadCounter increment doesn't stop a download, alternatively I could have created a service function to increment the counter after writing to the response