### PR TITLE
Fix API versioning

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -32,8 +32,7 @@ export async function setupNestApplication(app: INestApplication, validationOpti
     app.useGlobalPipes(new ValidationPipe(validationOptions));
     app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
-    // For some reason this doesn't exclude 'auth' properly. Messed with it a while and got nowhere.
-    // app.setGlobalPrefix('api', { exclude: ['auth'] });
+    app.setGlobalPrefix('api', { exclude: ['auth(.*)'] });
 
     const prismaDalc: PrismaService = app.get(PrismaService);
     await prismaDalc.enableShutdownHooks(app);

--- a/server/src/modules/activities/activities.controller.ts
+++ b/server/src/modules/activities/activities.controller.ts
@@ -5,7 +5,7 @@ import { ApiOkPaginatedResponse, PaginatedResponseDto } from '@common/dto/pagina
 import { ActivityDto } from '@common/dto/user/activity.dto';
 import { ActivitiesGetQuery } from '@common/dto/query/activity-queries.dto';
 
-@Controller('api/activities')
+@Controller('activities')
 @ApiTags('Activities')
 @ApiBearerAuth()
 export class ActivitiesController {

--- a/server/src/modules/admin/admin.controller.ts
+++ b/server/src/modules/admin/admin.controller.ts
@@ -39,7 +39,7 @@ import { UpdateXpSystemsDto, XpSystemsDto } from '@common/dto/xp-systems/xp-syst
 import { RolesGuard } from '@modules/auth/guards/roles.guard';
 import { NonGameAuthGuard } from '@modules/auth/guards/game-auth.guard';
 
-@Controller('api/admin')
+@Controller('admin')
 @UseGuards(RolesGuard)
 @UseGuards(NonGameAuthGuard)
 @Roles(RolesEnum.ADMIN)

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -17,9 +17,9 @@ import { ConfigService } from '@nestjs/config';
 import { RefreshTokenDto } from '@common/dto/auth/refresh-token.dto';
 import { SteamWebAuthGuard } from '@modules/auth/guards/steam-web-auth.guard';
 
+@Controller('auth')
 @ApiTags('Auth')
 @ApiBearerAuth()
-@Controller({ path: 'auth' })
 export class AuthController {
     constructor(
         private readonly authService: AuthService,

--- a/server/src/modules/maps/maps.controller.ts
+++ b/server/src/modules/maps/maps.controller.ts
@@ -49,7 +49,7 @@ import { RunsService } from '../runs/runs.service';
 import { MapImageDto } from '../../common/dto/map/map-image.dto';
 import { RolesGuard } from '@modules/auth/guards/roles.guard';
 
-@Controller('api/maps')
+@Controller('maps')
 @UseGuards(RolesGuard)
 @ApiTags('Maps')
 @ApiBearerAuth()

--- a/server/src/modules/reports/reports.controller.ts
+++ b/server/src/modules/reports/reports.controller.ts
@@ -4,7 +4,7 @@ import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swa
 import { CreateReportDto, ReportDto } from '@common/dto/report/report.dto';
 import { LoggedInUser } from '@common/decorators/logged-in-user.decorator';
 
-@Controller('api/reports')
+@Controller('reports')
 @ApiTags('Reports')
 @ApiBearerAuth()
 export class ReportsController {

--- a/server/src/modules/runs/runs.controller.ts
+++ b/server/src/modules/runs/runs.controller.ts
@@ -5,7 +5,7 @@ import { ApiOkPaginatedResponse, PaginatedResponseDto } from '@common/dto/pagina
 import { RunDto } from '@common/dto/run/run.dto';
 import { RunsGetAllQuery, RunsGetQuery } from '@common/dto/query/run-queries.dto';
 
-@Controller('api/runs')
+@Controller('runs')
 @ApiTags('Runs')
 @ApiBearerAuth()
 export class RunsController {

--- a/server/src/modules/session/session.controller.ts
+++ b/server/src/modules/session/session.controller.ts
@@ -33,7 +33,7 @@ import { CompletedRunDto } from '@common/dto/run/completed-run.dto';
 import { RunSessionService } from './run/run-session.service';
 import { GameAuthGuard } from '@modules/auth/guards/game-auth.guard';
 
-@Controller('api/session')
+@Controller('session')
 @UseGuards(GameAuthGuard)
 @ApiTags('Session')
 @ApiBearerAuth()

--- a/server/src/modules/stats/stats.controller.ts
+++ b/server/src/modules/stats/stats.controller.ts
@@ -2,7 +2,7 @@ import { Controller } from '@nestjs/common';
 import { StatsService } from './stats.service';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 
-@Controller('api/stats')
+@Controller('stats')
 @ApiTags('Stats')
 @ApiBearerAuth()
 export class StatsController {

--- a/server/src/modules/user/user.controller.ts
+++ b/server/src/modules/user/user.controller.ts
@@ -46,7 +46,7 @@ import { MapFavoriteDto } from '@common/dto/map/map-favorite.dto';
 import { MapLibraryService } from '@modules/maps/map-library.service';
 import { MapSummaryDto } from '@common/dto/user/user-maps-summary.dto';
 
-@Controller('api/user')
+@Controller('user')
 @ApiTags('User')
 @ApiBearerAuth()
 export class UserController {

--- a/server/src/modules/users/users.controller.ts
+++ b/server/src/modules/users/users.controller.ts
@@ -20,7 +20,7 @@ import { PaginationQuery } from '@common/dto/query/pagination.dto';
 import { RunDto } from '@common/dto/run/run.dto';
 import { UsersGetActivitiesQuery, UsersGetAllQuery, UsersGetQuery } from '@common/dto/query/user-queries.dto';
 
-@Controller('api/users')
+@Controller('users')
 @ApiTags('Users')
 @ApiBearerAuth()
 @ApiExtraModels(PaginatedResponseDto)


### PR DESCRIPTION
`auth.*` doesn't get parsed as a regular expression when trying to exclude paths from `setGlobalPrefix`, and instead uses wildcards provided by path-to-regexp. `auth(.*)` is parsed as a regular expression so it properly excludes auth. Hooray