### PR TITLE
Enable editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
This PR provides a configuration file for [EditorConfig](https://editorconfig.org/).

tl;dr it's a standard file to allow most IDE/text editors (through an extension) to set-up style-related settings like size of indents, and more. It's opt-in (you need the extension for your IDE to use it) and it would allow everyone to have proper tabs (my VSCode uses 4 by default and its auto-indent doesn't always work).

Note to reviewers:
- I've set-up a general indent size of 2 since most `.scss`, `.ts` and `.html` files I've delved in were using such size, but if there are other sizes for different file types in can be provided