### PR TITLE
chore(meta): add scope used by Dependabot to commitlint config

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -29,6 +29,7 @@ module.exports = {
         'back-e2e',
         'shared',
         'meta',
+        'deps',
         'db',
         'utils',
         'discord',


### PR DESCRIPTION
Dependabot PRs fail linting checks currently, this should fix.