### PR TITLE
Fix: Broken Nx affected in E2E jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,10 +86,15 @@ jobs:
       - name: Check affected
         run:
           |
-          if npx nx show projects --affected | grep -q backend-e2e; then
-              echo "affected=true" >> $GITHUB_ENV
+          if npx nx show projects \
+            --affected \
+            --base=${{ github.event.pull_request.base.sha }} \
+            --head=${{ github.event.pull_request.head.sha }} |
+            grep -q backend-e2e
+          then
+            echo "affected=true" >> $GITHUB_ENV
           else
-              echo "affected=false" >> $GITHUB_ENV
+            echo "affected=false" >> $GITHUB_ENV
           fi
       - name: Run tests in Docker
         if: env.affected == 'true'
@@ -112,10 +117,15 @@ jobs:
       - name: Check affected
         run:
           |
-          if npx nx show projects --affected | grep -q frontend-e2e; then
-              echo "affected=true" >> $GITHUB_ENV
+          if npx nx show projects \
+            --affected \
+            --base=${{ github.event.pull_request.base.sha }} \
+            --head=${{ github.event.pull_request.head.sha }} |
+            grep -q frontend-e2e
+          then
+            echo "affected=true" >> $GITHUB_ENV
           else
-              echo "affected=false" >> $GITHUB_ENV
+            echo "affected=false" >> $GITHUB_ENV
           fi
       - name: Run tests in Docker
         if: env.affected == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,14 @@ jobs:
     needs: install-deps
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
           path: node_modules
           key: modules-${{ hashFiles('package-lock.json') }}
-      - run: git fetch --no-tags --prune --depth=1 origin main
       - run: npx nx affected --target=test --base=origin/main --parallel=3
   build:
     name: Build
@@ -64,12 +66,14 @@ jobs:
     needs: install-deps
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
           path: node_modules
           key: modules-${{ hashFiles('package-lock.json') }}
-      - run: git fetch --no-tags --prune --depth=1 origin main
       - run: npx nx affected --target=build --base=origin/main --parallel=3
   backend-e2e:
     name: Backend E2E Tests
@@ -77,12 +81,14 @@ jobs:
     needs: install-deps
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
           path: node_modules
           key: modules-${{ hashFiles('package-lock.json') }}
-      - run: git fetch --no-tags --prune --depth=1 origin main
       - name: Check affected
         run:
           |
@@ -108,6 +114,9 @@ jobs:
     needs: install-deps
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - name: Cache node_modules
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
For some jobs the E2E affected checks pass automatically because the command is run with wrong args - we need to explicitly pass in the base and head SHAs.

Also, noticed we were doing a pointless `git fetch` explicitly - `actions/checkout` can handle it for us. The `--no-prune` and `--no-tags` args don't seem that important, other Nx CI setups I've found mostly seem to just use `actions/checkout` with this config.