### PR TITLE
ci: always run prisma generate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,14 @@ jobs:
           path: node_modules
           key: modules-${{ hashFiles('package-lock.json') }}
       - uses: actions/setup-node@v3
-        if: steps.cache.outputs.cache-hit != 'true'
         with:
           node-version: 18.x
           cache: 'npm'
       - name: npm install
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci --no-scripts
+      - name: prisma generate
+        run: npx nx run db:generate
   lint:
     name: Linting and Formatting
     runs-on: ubuntu-latest


### PR DESCRIPTION
This workflow can sometimes fail if the Prisma schema changes, but nothing has changed in the package.json, since the Prisma client generation is only run as the `postinstall` step of `npm install`, which won't run if the runner successfully hits the node_modules cache.

~~Note: don't merge immediately, want to check CI runs correctly.~~ Okay all good