### PR TITLE
Fix/map dto transformation

### DIFF
--- a/apps/backend-e2e/src/user.e2e-spec.ts
+++ b/apps/backend-e2e/src/user.e2e-spec.ts
@@ -1505,7 +1505,7 @@ describe('User', () => {
         req.expandTest({
           url: 'user/maps/favorites',
           expand: 'thumbnail',
-          expectedPropertyName: 'map.thumbnail',
+          expectedPropertyName: 'map.thumbnail.small',
           paged: true,
           validate: MapFavoriteDto,
           token: token

--- a/libs/backend/dto/src/dtos/map/map-credit.dto.ts
+++ b/libs/backend/dto/src/dtos/map/map-credit.dto.ts
@@ -8,7 +8,7 @@ import { MapDto } from './map.dto';
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { EnumProperty, IdProperty, NestedProperty } from '../../decorators';
 import { MapCreditType } from '@momentum/constants';
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, plainToInstance } from 'class-transformer';
 import { IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class MapCreditDto implements MapCredit {
@@ -36,7 +36,7 @@ export class MapCreditDto implements MapCredit {
   @NestedProperty(MapDto, { lazy: true, required: false })
   @Expose()
   get map(): MapDto {
-    return this.mmap;
+    return plainToInstance(MapDto, this.mmap);
   }
 
   @Exclude()

--- a/libs/backend/dto/src/dtos/map/map-favorite.dto.ts
+++ b/libs/backend/dto/src/dtos/map/map-favorite.dto.ts
@@ -7,7 +7,7 @@ import {
 } from '../../decorators';
 import { UserDto } from '../user/user.dto';
 import { MapDto } from './map.dto';
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, plainToInstance } from 'class-transformer';
 
 export class MapFavoriteDto implements MapFavorite {
   @IdProperty()
@@ -19,7 +19,7 @@ export class MapFavoriteDto implements MapFavorite {
   @NestedProperty(MapDto, { lazy: true, required: false })
   @Expose()
   get map(): MapDto {
-    return this.mmap;
+    return plainToInstance(MapDto, this.mmap);
   }
 
   @Exclude()

--- a/libs/backend/dto/src/dtos/map/map-library-entry.ts
+++ b/libs/backend/dto/src/dtos/map/map-library-entry.ts
@@ -7,7 +7,7 @@ import {
 } from '../../decorators';
 import { UserDto } from '../user/user.dto';
 import { MapDto } from './map.dto';
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, plainToInstance } from 'class-transformer';
 
 export class MapLibraryEntryDto implements MapLibraryEntry {
   @IdProperty()
@@ -25,7 +25,7 @@ export class MapLibraryEntryDto implements MapLibraryEntry {
   @NestedProperty(MapDto, { lazy: true, required: false })
   @Expose()
   get map(): MapDto {
-    return this.mmap;
+    return plainToInstance(MapDto, this.mmap);
   }
 
   @Exclude()

--- a/libs/backend/dto/src/dtos/map/map-review.dto.ts
+++ b/libs/backend/dto/src/dtos/map/map-review.dto.ts
@@ -6,7 +6,7 @@ import {
   UpdatedAtProperty
 } from '../../decorators';
 import { UserDto } from '../user/user.dto';
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, plainToInstance } from 'class-transformer';
 import { MapDto } from './map.dto';
 import { MapReviewEditDto } from './map-review-edit.dto';
 import { MapReviewCommentDto } from './map-review-comment.dto';
@@ -39,7 +39,7 @@ export class MapReviewDto {
   @NestedProperty(MapDto, { lazy: true, required: true })
   @Expose()
   get map(): MapDto {
-    return this.mmap;
+    return plainToInstance(MapDto, this.mmap);
   }
 
   @Exclude()

--- a/libs/backend/dto/src/dtos/run/rank.dto.ts
+++ b/libs/backend/dto/src/dtos/run/rank.dto.ts
@@ -12,7 +12,7 @@ import {
   UpdatedAtProperty
 } from '../../decorators';
 import { Gamemode } from '@momentum/constants';
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, plainToInstance } from 'class-transformer';
 
 export class RankDto implements Rank {
   @IdProperty()
@@ -53,7 +53,7 @@ export class RankDto implements Rank {
   @NestedProperty(MapDto, { lazy: true, required: false })
   @Expose()
   get map(): MapDto {
-    return this.mmap;
+    return plainToInstance(MapDto, this.mmap);
   }
 
   @Exclude()

--- a/libs/backend/dto/src/dtos/run/run.dto.ts
+++ b/libs/backend/dto/src/dtos/run/run.dto.ts
@@ -14,7 +14,7 @@ import {
 import { MapDto } from '../map/map.dto';
 import { BaseStatsDto } from '../stats/base-stats.dto';
 import { RunZoneStatsDto } from './run-zone-stats.dto';
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, plainToInstance } from 'class-transformer';
 import {
   CreatedAtProperty,
   IdProperty,
@@ -99,7 +99,7 @@ export class RunDto implements Run {
   @NestedProperty(MapDto, { required: false })
   @Expose()
   get map(): MapDto {
-    return this.mmap;
+    return plainToInstance(MapDto, this.mmap);
   }
 
   @Exclude()


### PR DESCRIPTION
The MMap rename introduced a bug where MapDtos nested within other DTOs were no longer being transformed by class-transformer. This was due to the underlying `mmap` field no longer having the `NestedProperty` decorator, which applies the `@Type` decorator from class-transformer to transform the object to a class instance that class-transformer can handle and apply e.g. `@Transform`, `@Expose` decorators.

My solution is to explicitly apply the transformation in the MapDto getters. We could also using `@Type(() => MapDto)` on the `mmap` field, but that feels a bit too arcane for me, this makes it clearer what's going on.