### PR TITLE
refactor(front): remove /profile page, always use /profile/{userID}

### DIFF
--- a/apps/frontend/src/app/components/header/header.component.ts
+++ b/apps/frontend/src/app/components/header/header.component.ts
@@ -18,7 +18,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
   userMenu: NbMenuItem[] = [
     {
       title: 'Profile',
-      link: '/dashboard/profile'
+      // If `user` hasn't been fetched yet, just navigate to ProfileRedirect
+      // component, which will await the user result then redirect to relatived URL.
+      link: this.user?.id
+        ? `/dashboard/profile/${this.user.id}`
+        : '/dashboard/profile'
     },
     {
       title: 'Edit Profile',
@@ -29,7 +33,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     }
   ];
 
-  user: User;
+  user?: User;
   notifications: Notification[];
   numUnreadNotifs: number;
 

--- a/apps/frontend/src/app/pages/dashboard/profile/profile-edit/profile-edit.component.ts
+++ b/apps/frontend/src/app/pages/dashboard/profile/profile-edit/profile-edit.component.ts
@@ -231,9 +231,7 @@ export class ProfileEditComponent implements OnInit, OnDestroy {
   }
 
   returnToProfile() {
-    this.router.navigate([
-      `/dashboard/profile${this.isLocal ? '' : '/' + this.user.id}`
-    ]);
+    this.router.navigate([`/dashboard/profile/${this.user.id}`]);
   }
 
   deleteUser() {

--- a/apps/frontend/src/app/pages/dashboard/profile/profile-redirect.component.ts
+++ b/apps/frontend/src/app/pages/dashboard/profile/profile-redirect.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { LocalUserService } from '@momentum/frontend/data';
+import { firstValueFrom } from 'rxjs';
+
+/**
+ * Redirects `/profile` to `/profile/<logged-in-ID>` if has a logged in user,
+ * otherwise to home page.
+ */
+@Component({ selector: 'mom-profile-redirect-local', template: '' })
+export class ProfileRedirectComponent implements OnInit {
+  constructor(
+    private readonly router: Router,
+    private readonly localUserService: LocalUserService
+  ) {}
+
+  async ngOnInit(): Promise<void> {
+    const localUser = await firstValueFrom(this.localUserService.getLocal());
+
+    await this.router.navigate([
+      localUser?.id ? `/dashboard/profile/${localUser.id}` : '/dashboard'
+    ]);
+  }
+}

--- a/apps/frontend/src/app/pages/dashboard/profile/profile-routing.module.ts
+++ b/apps/frontend/src/app/pages/dashboard/profile/profile-routing.module.ts
@@ -5,6 +5,7 @@ import { NotFoundDashboardComponent } from '../../not-found/dashboard/not-found-
 import { NgModule } from '@angular/core';
 import { ProfileComponent } from './profile.component';
 import { Role } from '@momentum/constants';
+import { ProfileRedirectComponent } from './profile-redirect.component';
 
 @NgModule({
   imports: [
@@ -25,7 +26,7 @@ import { Role } from '@momentum/constants';
               }
             ]
           },
-          { path: '', component: UserProfileComponent },
+          { path: '', component: ProfileRedirectComponent },
           { path: '**', component: NotFoundDashboardComponent }
         ]
       }

--- a/apps/frontend/src/app/pages/dashboard/profile/profile.module.ts
+++ b/apps/frontend/src/app/pages/dashboard/profile/profile.module.ts
@@ -8,11 +8,13 @@ import { ProfileRoutingModule } from './profile-routing.module';
 import { ProfileComponent } from './profile.component';
 import { ProfileNotifyEditComponent } from './profile-follow/profile-notify-edit/profile-notify-edit.component';
 import { SharedModule } from '../../../shared.module';
+import { ProfileRedirectComponent } from './profile-redirect.component';
 
 @NgModule({
   imports: [SharedModule, ProfileRoutingModule],
   declarations: [
     ProfileComponent,
+    ProfileRedirectComponent,
     UserProfileComponent,
     ProfileEditComponent,
     ProfileFollowComponent,


### PR DESCRIPTION
Someone earlier asked how they can link find a URL to their profile, given that if they navigate to their profile page on the frontend, they just go to /dashboard/profile, and don't know their userID.

The simplest solution to me is to just always use the relativized URL containing the user's id. Incidentally this seems to be how most sites handle profile pages.