### PR TITLE
Add optional pgadmin container to dev docker compose config

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -47,3 +47,14 @@ services:
       - ${POSTGRES_PORT}:${POSTGRES_PORT}
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
+  pgadmin:
+    container_name: pgadmin
+    image: dpage/pgadmin4
+    restart: always
+    profiles:
+      - pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: root@root.com
+      PGADMIN_DEFAULT_PASSWORD: root
+    ports:
+      - "5050:80"


### PR DESCRIPTION
Usually Prisma Studio is fine for checking DB contents, but I've been finding [pgadmin](https://www.pgadmin.org/) useful for benchmarking and messing with raw queries. This lets you include it in the typical Docker dev setup with `docker compose --profile pgadmin up`