### PR TITLE
Revert XP constant changes

### DIFF
--- a/apps/backend-e2e/src/prisma.e2e-spec.ts
+++ b/apps/backend-e2e/src/prisma.e2e-spec.ts
@@ -80,7 +80,7 @@ describe('Prisma Client Extensions', () => {
       expect(profile.userID).toBe(userID);
       expect(userStats).toMatchObject({
         userID: userID,
-        level: 0,
+        level: 1,
         cosXP: 0n,
         mapsCompleted: 0,
         runsSubmitted: 0,

--- a/libs/db/src/prisma/schema.prisma
+++ b/libs/db/src/prisma/schema.prisma
@@ -63,7 +63,7 @@ model UserAuth {
 model UserStats {
   totalJumps    BigInt @default(0) @db.BigInt
   totalStrafes  BigInt @default(0) @db.BigInt
-  level         Int    @default(0) @db.SmallInt
+  level         Int    @default(1) @db.SmallInt
   cosXP         BigInt @default(0) @db.BigInt
   mapsCompleted Int    @default(0)
   runsSubmitted Int    @default(0)

--- a/libs/xp-systems/src/constants.ts
+++ b/libs/xp-systems/src/constants.ts
@@ -21,7 +21,7 @@ export const RANK_XP_PARAMS: RankXpParams = {
 export const COS_XP_PARAMS: CosXpParams = {
   levels: {
     maxLevels: 500,
-    startingValue: 0,
+    startingValue: 20000,
     linearScaleBaseIncrease: 1000,
     linearScaleInterval: 10,
     linearScaleIntervalMultiplier: 1,

--- a/libs/xp-systems/src/xp-system.class.spec.ts
+++ b/libs/xp-systems/src/xp-system.class.spec.ts
@@ -7,27 +7,60 @@ describe('XpSystemsService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('getCosmeticXpInLevel', () => {
-    it('should handle 0', () => {
-      const xp = service.getCosmeticXpInLevel(0);
-      expect(xp).toEqual(0);
+  it('should calculate correct level assignments for original constants', () => {
+    // These constants may get changed in the future, we also care about the maths,
+    // so mock here and check values correspond to below sheet
+    // https://docs.google.com/spreadsheets/d/1JiHJYsxlGPXAZqCPh7-paJI6U_TH-Ro0H0OWDFCiA74
+
+    // Note, this is NOT quite what the linked spreadsheet produces.
+    // At level 101, the sheet expects xpInLevel from 101 to be
+    // 152000 - it must factor in `startingValue` for some reason.  In code,
+    // `startingValue` isn't used at all for levels greater than
+    // `staticScaleStart`. Not really an issue, but worth being aware of.
+    jest.replaceProperty(service, 'cosXpParams', {
+      levels: {
+        maxLevels: 500,
+        startingValue: 20000,
+        linearScaleBaseIncrease: 1000,
+        linearScaleInterval: 10,
+        linearScaleIntervalMultiplier: 1,
+        staticScaleStart: 101,
+        staticScaleBaseMultiplier: 1.5,
+        staticScaleInterval: 25,
+        staticScaleIntervalMultiplier: 0.5
+      },
+      completions: {
+        unique: { tierScale: { linear: 2500, staged: 2500 } },
+        repeat: {
+          tierScale: { linear: 20, staged: 40, stages: 5, bonus: 40 }
+        }
+      }
     });
 
-    it('should handle greater than 0', () => {
-      const xp = service.getCosmeticXpInLevel(1);
-      expect(xp).toBeGreaterThan(0);
-    });
-  });
-
-  describe('getCosmeticXpForLevel', () => {
-    it('should handle 0', () => {
-      const xp = service.getCosmeticXpForLevel(0);
-      expect(xp).toEqual(0);
-    });
-
-    it('should handle greater than 0', () => {
-      const xp = service.getCosmeticXpForLevel(1);
-      expect(xp).toBeGreaterThan(0);
-    });
+    // prettier-ignore
+    for (const { level, xpInLevel, total } of [
+      { level: 1, xpInLevel: 21000, total: 21000 },
+      { level: 2, xpInLevel: 22000, total: 43000 },
+      { level: 3, xpInLevel: 23000, total: 66000 },
+      { level: 4, xpInLevel: 24000, total: 90000 },
+      { level: 5, xpInLevel: 25000, total: 115000 },
+      { level: 6, xpInLevel: 26000, total: 141000 },
+      { level: 7, xpInLevel: 27000, total: 168000 },
+      { level: 8, xpInLevel: 28000, total: 196000 },
+      { level: 9, xpInLevel: 29000, total: 225000 },
+      { level: 10, xpInLevel: 30000, total: 255000 },
+      { level: 11, xpInLevel: 42000, total: 297000 },
+      { level: 97, xpInLevel: 990000, total: 34995000 },
+      { level: 98, xpInLevel: 1000000, total: 35995000 },
+      { level: 99, xpInLevel: 1010000, total: 37005000 },
+      { level: 100, xpInLevel: 1020000, total: 38025000 },
+      { level: 101, xpInLevel: 1500000, total: 39525000 },
+      { level: 102, xpInLevel: 1500000, total: 41025000 },
+      { level: 103, xpInLevel: 1500000, total: 42525000 },
+      { level: 104, xpInLevel: 1500000, total: 44025000 }
+    ]) {
+      expect(service.getCosmeticXpInLevel(level)).toBe(xpInLevel);
+      expect(service.getCosmeticXpForLevel(level)).toBe(total);
+    }
   });
 });

--- a/libs/xp-systems/src/xp-systems.class.ts
+++ b/libs/xp-systems/src/xp-systems.class.ts
@@ -27,7 +27,7 @@ export class XpSystems {
     this.xpInLevels = [0];
     this.xpForLevels = [0, 0];
 
-    for (let i = 0; i < this.cosXpParams.levels.maxLevels; i++) {
+    for (let i = 1; i < this.cosXpParams.levels.maxLevels; i++) {
       this.xpInLevels[i] = this.getCosmeticXpInLevel(i);
 
       if (i > 0)
@@ -38,7 +38,7 @@ export class XpSystems {
   getCosmeticXpInLevel(level: number): number {
     const levels = this.cosXpParams.levels;
 
-    if (!levels || level < 0 || level > levels.maxLevels) return -1;
+    if (!levels || level < 1 || level > levels.maxLevels) return -1;
 
     if (level < levels.staticScaleStart) {
       return (
@@ -70,7 +70,7 @@ export class XpSystems {
   getCosmeticXpForLevel(level: number): number {
     if (
       !this.cosXpParams ||
-      level < 0 ||
+      level < 1 ||
       level > this.cosXpParams.levels.maxLevels
     )
       return -1;


### PR DESCRIPTION
Split these changes out from https://github.com/momentum-mod/website/pull/876 so we can review separately. Sorry that it's still on top of all those commits, some file renaming/moving requires it, this branch is really just the last two commits!

So, I completely misunderstood how new user cosmetic XP/level assignment worked, getting the wrong impression that new users were supposed to start at 20,000 XP. This was completely my own fault, I ported some of the initial XP systems code from the old backend wrong, and assumed the weird behaviour was a result of the original design, not my own crappy porting. Apologies for that! This reverts to the original constants, and **starts new users with the correct starting values of level 1, 0 XP**. I don't test that directly, but hopefully @ianwillis98 or whoever ends up doing https://github.com/momentum-mod/website/issues/868 can do checks in there.

Also, having dug up the original spreadsheet to the cosmetic XP stuff, I wrote some unit tests for those values. Don't worry, the Google sheets URL in the comment is view-only.