### PR TITLE
Disallow self follow

### DIFF
--- a/apps/backend-e2e/src/user.e2e-spec.ts
+++ b/apps/backend-e2e/src/user.e2e-spec.ts
@@ -717,6 +717,14 @@ describe('User', () => {
         });
       });
 
+      it('should 400 if the authenticated user is the target user', async () => {
+        await req.post({
+          url: `user/follow/${u1.id}`,
+          status: 400,
+          token: u1Token
+        });
+      });
+
       it('should 401 when no access token is provided', () =>
         req.unauthorizedTest('user/follow/1', 'post'));
     });

--- a/apps/backend/src/app/modules/users/users.service.ts
+++ b/apps/backend/src/app/modules/users/users.service.ts
@@ -450,6 +450,9 @@ export class UsersService {
     if (!(await this.db.user.exists({ where: { id: targetUserID } })))
       throw new NotFoundException('Target user not found');
 
+    if (localUserID === targetUserID)
+      throw new BadRequestException('Target user cannot be logged in user');
+
     const isFollowing = await this.getFollower(localUserID, targetUserID);
     if (isFollowing)
       throw new BadRequestException(

--- a/apps/frontend/src/app/pages/profile/profile.component.ts
+++ b/apps/frontend/src/app/pages/profile/profile.component.ts
@@ -96,7 +96,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
               });
             }
           }
-          this.isLocal = false;
+          this.isLocal = true;
           this.localUserService.refreshLocalUser();
           return this.localUserService.localUserSubject;
         }),


### PR DESCRIPTION
This change prevents a user from following themself by both removing the "Follow" button from the profile view for the logged in user and by checking that target and logged in user are not the same in the follow API.

Closes #892

I simply removed the follow button component when viewing the logged in user's profile as this is not a bug in production so there should not be a risk of real users having following themself. If desired I can rework this to remove only the "Follow" button leave the "Unfollow" button.