### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/backend-container/devcontainer.json
+++ b/.devcontainer/backend-container/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "Momentum Mod API",
+  "dockerComposeFile": [
+    "../../docker-compose.yml",
+    "../../docker-compose.override.yml",
+    "../docker-compose.devcontainer.yml"
+  ],
+  "service": "api",
+  "shutdownAction": "none",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/nx-npm:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "nrwl.angular-console",
+        "esbenp.prettier-vscode",
+        "firsttris.vscode-jest-runner",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  },
+  "forwardPorts": [3000],
+  "initializeCommand": [".devcontainer/init"],
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git config --global --add safe.directory ${containerWorkspaceFolder}/apps/frontend/src/app/theme/shared_styling && git submodule update --init",
+  "postStartCommand": "npm install && nx run db:push && nx run db:seed && npm run serve:backend"
+}

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/typescript-node
+    volumes:
+      - ../:/workspaces:cached
+    command: sleep infinity
+    env_file:
+      - .env
+    depends_on:
+      - minio
+      - db
+      - createbuckets
+      - api
+  api:
+    image: mcr.microsoft.com/devcontainers/typescript-node
+    volumes:
+      - ../:/workspaces:cached
+    command: sleep infinity
+    environment:
+      IS_DOCKERIZED_API: 'true'
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}?schema=public
+    depends_on:
+      - minio
+      - db
+      - createbuckets

--- a/.devcontainer/frontend-container/devcontainer.json
+++ b/.devcontainer/frontend-container/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "Momentum Mod Website",
+  "dockerComposeFile": [
+    "../../docker-compose.yml",
+    "../../docker-compose.override.yml",
+    "../docker-compose.devcontainer.yml"
+  ],
+  "service": "app",
+  "shutdownAction": "none",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/nx-npm:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "nrwl.angular-console",
+        "esbenp.prettier-vscode",
+        "firsttris.vscode-jest-runner",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  },
+  "forwardPorts": [4200],
+  "initializeCommand": [".devcontainer/init"],
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git config --global --add safe.directory ${containerWorkspaceFolder}/apps/frontend/src/app/theme/shared_styling && git submodule update --init",
+  "postStartCommand": "npm install && npm run serve:frontend"
+}

--- a/.devcontainer/init
+++ b/.devcontainer/init
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp -n -p env.TEMPLATE .env

--- a/.devcontainer/init.cmd
+++ b/.devcontainer/init.cmd
@@ -1,0 +1,1 @@
+IF NOT EXIST .env COPY /-y env.TEMPLATE .env

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+*Dockerfile*
+*docker-compose*
+node_modules
+data
+dist
+.nx

--- a/libs/db/src/scripts/seed.ts
+++ b/libs/db/src/scripts/seed.ts
@@ -161,7 +161,9 @@ prismaWrapper(async (prisma: PrismaClient) => {
   const s3 = doFileUploads
     ? new S3Client({
         region: process.env['STORAGE_REGION'],
-        endpoint: process.env['STORAGE_ENDPOINT_URL'],
+        endpoint: process.env['IS_DOCKERIZED_API']
+          ? process.env['STORAGE_ENDPOINT_URL_DOCKERIZED']
+          : process.env['STORAGE_ENDPOINT_URL'],
         credentials: {
           accessKeyId: process.env['STORAGE_ACCESS_KEY_ID'],
           secretAccessKey: process.env['STORAGE_SECRET_ACCESS_KEY']

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "scripts": {
     "postinstall": "nx run db:generate",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "serve:backend": "nx serve backend",
+    "serve:frontend": "nx serve frontend"
   },
   "dependencies": {
     "@angular/animations": "17.0.4",


### PR DESCRIPTION
We already encourage users to use docker to spin up containers for minio and postgres so I figured it could be useful to extend these configs such that devs are able to spin up the entire development environment in docker. This is completely optional, but hopefully this can help newer devs onboard more quickly and avoid comparability issues (for example incorrect node versions).

This config can also be utilized as a basis for running the project in places like CodeSandbox and GitHub Codespaces, which can sometimes be useful for sharing local builds, quickly spinning up branches and PRs in an env for testing, or developing on hardware like tablets where you might only have access to a browser. Since we utilize multiple containers, some extra steps [found here](https://github.com/codespaces-contrib/codespaces-multi-dev-container) are needed.

Setup steps for the repo when running in a devcontainer on your local machine:
1. Ensure docker, git, and VS Code are installed
2. Install the VS Code Dev Containers extension
3. Clone the project
4. Open the project root directory in VS Code
5. Run **Dev Containers: Reopen in Container** from the Command Palette (`F1`) and select `Momentum Mod API`
6. VS Code with then spin up the containers, reload the window, and connect to the container running the backend.
7. Once you see the files appear in the file explorer, open `.env` and add your `STEAM_WEB_API_KEY` as described [here](https://github.com/momentum-mod/website/wiki/Setup#environment-variables)
8. Use the Command Palette (`F1`) and run **Rebuild Container**
9. Once you see the `Nest application successfully started` log in the output, open a new VS Code window using **File > New Window** and open the project root in that new window
10. Run **Dev Containers: Reopen in Container** from the Command Palette (`F1`) and select `Momentum Mod Website`
11. Wait until you see the log `Local:   http://localhost:4200/` and open that address in your browser and you should see the Momentum Mod website. You should now have everything you need to contribute!

Once this is merged into main, we can use the following link instead of steps 2-5: 
[https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/momentum-mod/website](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/momentum-mod/website) This automatically installs the Dev Containers extension, clones the repo, and opens the project in the container.

Other editors with Dev Container support can be used instead of VS Code can be used although I haven't tested these. See the list of supported editors [here](https://containers.dev/supporting#editors)

Troubleshooting:
- If for any reason you hit an error and the container exits, you can use the Command Palette (`F1`) and run **Rebuild Container** 
- If you see spinners on the website and Unauthorized errors in the API output, try hard refreshing the web page
- To stop the containers you can open the project root in a terminal on your host machine and run `docker compose down`