### PR TITLE
Map submission status visibility changes

### DIFF
--- a/apps/backend/src/app/dto/queries/map-queries.dto.ts
+++ b/apps/backend/src/app/dto/queries/map-queries.dto.ts
@@ -148,8 +148,10 @@ export class MapsGetAllSubmissionQueryDto
   readonly expand?: MapsGetAllSubmissionExpand;
 
   @EnumFilterQueryProperty([
+    MapStatus.PRIVATE_TESTING,
+    MapStatus.CONTENT_APPROVAL,
     MapStatus.PUBLIC_TESTING,
-    MapStatus.PRIVATE_TESTING
+    MapStatus.FINAL_APPROVAL
   ])
   readonly filter?: MapsGetAllSubmissionFilter;
 }

--- a/apps/backend/src/app/modules/maps/maps.service.spec.ts
+++ b/apps/backend/src/app/modules/maps/maps.service.spec.ts
@@ -80,7 +80,7 @@ describe('MapsService', () => {
        for (const status of Enum.values(MapStatus)) {
            db.mMap.findUnique.mockResolvedValueOnce({id: 1, status } as any);
 
-           if ([MapStatus.APPROVED, MapStatus.PUBLIC_TESTING].includes(status)) {
+           if ([MapStatus.APPROVED, MapStatus.PUBLIC_TESTING, MapStatus.FINAL_APPROVAL].includes(status)) {
              expect(await service.getMapAndCheckReadAccess({ mapID: 1, })).toBeTruthy();
            } else {
              await expect(service.getMapAndCheckReadAccess({ mapID: 1 })).rejects.toThrow(ForbiddenException);
@@ -94,8 +94,8 @@ describe('MapsService', () => {
       [MapStatus.APPROVED]: 'any',
       [MapStatus.PUBLIC_TESTING]: 'any',
       [MapStatus.PRIVATE_TESTING]: ['admin', 'moderator', 'submitter', 'acceptedRequest', 'inCredits'],
-      [MapStatus.CONTENT_APPROVAL]: ['admin', 'moderator', 'submitter' ,'reviewer'],
-      [MapStatus.FINAL_APPROVAL]: ['admin', 'moderator', 'submitter', 'reviewer'],
+      [MapStatus.CONTENT_APPROVAL]: ['admin', 'moderator', 'submitter' ,'reviewer',  'acceptedRequest', 'inCredits'],
+      [MapStatus.FINAL_APPROVAL]: 'any',
       [MapStatus.DISABLED]: ['admin', 'moderator']
     };
 

--- a/libs/constants/src/types/queries/map-queries.model.ts
+++ b/libs/constants/src/types/queries/map-queries.model.ts
@@ -58,7 +58,10 @@ export type MapsGetAllAdminQuery = MapsGetAllBaseQuery & {
 };
 
 export type MapsGetAllSubmissionFilter = Array<
-  MapStatus.PUBLIC_TESTING | MapStatus.PRIVATE_TESTING
+  | MapStatus.PUBLIC_TESTING
+  | MapStatus.PRIVATE_TESTING
+  | MapStatus.CONTENT_APPROVAL
+  | MapStatus.FINAL_APPROVAL
 >;
 
 export type MapsGetAllSubmissionQuery = MapsGetAllBaseQuery & {
@@ -69,13 +72,6 @@ export type MapsGetAllSubmissionQuery = MapsGetAllBaseQuery & {
 export type MapsGetAllUserSubmissionQuery = Omit<
   MapsGetAllSubmissionQuery,
   'submitterID'
->;
-
-export type MapsGetAllSubmissionAdminFilter = Array<
-  | MapStatus.PUBLIC_TESTING
-  | MapStatus.PRIVATE_TESTING
-  | MapStatus.CONTENT_APPROVAL
-  | MapStatus.FINAL_APPROVAL
 >;
 
 //#endregion

--- a/libs/db/src/scripts/seed.ts
+++ b/libs/db/src/scripts/seed.ts
@@ -1084,12 +1084,15 @@ prismaWrapper(async (prisma: PrismaClient) => {
         )}`;
       }
 
-      for (const image of map.images as any[]) {
-        image.small = s3Url(imgSmallPath(image));
-        image.medium = s3Url(imgMediumPath(image));
-        image.large = s3Url(imgLargePath(image));
-        image.xl = s3Url(imgXlPath(image));
-      }
+      map.images = map.images.map((image) => ({
+        id: image,
+        small: s3Url(imgSmallPath(image)),
+        medium: s3Url(imgMediumPath(image)),
+        large: s3Url(imgLargePath(image)),
+        xl: s3Url(imgXlPath(image))
+      }));
+
+      map.thumbnail = map.images[0];
 
       for (const credit of map.credits as any[]) {
         credit.user.steamID = credit.user.steamID?.toString();


### PR DESCRIPTION
Small PR for once! 
- All users can now see maps that are in `FINAL_APPROVAL`
- Creditors and testers can still see maps in `CONTENT_APPROVAL`
- /maps/submission  to request maps with specific filters

We'll be using this in game code to request in `PRIVATE_TESTING` and `CONTENT_APPROVAL`, since `PUBLIC_TESTING` and `FINAL_APPROVAL` are stored in the static map cache.