### PR TITLE
fix(meta): Run backend Dockerfile under non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN npm --omit=dev -f install
 RUN node_modules/.bin/prisma generate --schema schema.prisma
 RUN rm schema.prisma
 
+EXPOSE 3000
+USER backend
 CMD [ "node", "main.js" ]


### PR DESCRIPTION
We also expose the port desired in the PORT env var via EXPOSE, so that our system running the backend can still talk to it

Closes #940