### PR TITLE
Add LOG_LEVEL env var

### DIFF
--- a/apps/backend-e2e/src/support/environment.ts
+++ b/apps/backend-e2e/src/support/environment.ts
@@ -2,8 +2,6 @@ import { Server } from 'node:http';
 import { Test, TestingModuleBuilder } from '@nestjs/testing';
 import {
   ClassSerializerInterceptor,
-  Logger,
-  LogLevel,
   ValidationPipe,
   VersioningType
 } from '@nestjs/common';
@@ -44,25 +42,17 @@ export async function setupE2ETestEnvironment(
     return this.toString();
   };
 
-  const logger = new Logger().localInstance;
-  const logLevel: LogLevel[] = ['error'];
-  // Env var for heavier debugging. In WebStorm it's useful to have this in the
-  // env var settings for your default configuration but *not* your main test
-  // configuration so it doesn't spam when running everything, but is enabled
-  // for when you run specific tests.
-  if (process.env.TEST_LOG_DEBUG === 'true') logLevel.push('debug', 'warn');
-  logger.setLogLevels(logLevel);
-
   let moduleBuilder = Test.createTestingModule({
     imports: [AppModule]
-  }).setLogger(logger);
+  });
   if (moduleOverrides) moduleBuilder = moduleOverrides(moduleBuilder);
   const moduleRef = await moduleBuilder.compile();
 
   const app = moduleRef.createNestApplication<NestFastifyApplication>(
     new FastifyAdapter(),
-    { rawBody: true }
+    { bufferLogs: true, rawBody: true }
   );
+
   app.useBodyParser('application/octet-stream', { bodyLimit: 1e8 });
 
   app.setGlobalPrefix('api', { exclude: ['auth(.*)'] });

--- a/apps/backend/src/app/app.module.ts
+++ b/apps/backend/src/app/app.module.ts
@@ -65,6 +65,7 @@ import { DbModule } from './modules/database/db.module';
       useFactory: async (config: ConfigService) => ({
         pinoHttp: {
           customProps: (_req, _res) => ({ context: 'HTTP' }),
+          level: config.getOrThrow('logLevel'),
           transport:
             config.getOrThrow('env') !== Environment.PRODUCTION
               ? {

--- a/apps/backend/src/app/config/config.interface.ts
+++ b/apps/backend/src/app/config/config.interface.ts
@@ -1,4 +1,6 @@
-﻿export enum Environment {
+﻿import * as pino from 'pino';
+
+export enum Environment {
   DEVELOPMENT = 'dev',
   PRODUCTION = 'prod',
   TEST = 'test'
@@ -50,4 +52,5 @@ export interface ConfigInterface {
     minPublicTestingDuration: number;
     maxCreditsExceptTesters: number;
   };
+  logLevel: pino.LevelWithSilent;
 }

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -15,6 +15,7 @@
 } from '@momentum/constants';
 import { ConfigInterface, Environment } from './config.interface';
 import * as process from 'node:process';
+import * as pino from 'pino';
 
 export const ConfigFactory = (): ConfigInterface => {
   const env: Environment = process.env['NODE_ENV'] as Environment;
@@ -71,7 +72,10 @@ export const ConfigFactory = (): ConfigInterface => {
       testInvites: MAX_TEST_INVITES,
       minPublicTestingDuration: MIN_PUBLIC_TESTING_DURATION,
       maxCreditsExceptTesters: MAX_CREDITS_EXCEPT_TESTERS
-    }
+    },
+    logLevel: (process.env['LOG_LEVEL'] ?? isTest
+      ? 'warn'
+      : 'info') as pino.LevelWithSilent
   };
 };
 

--- a/apps/backend/src/app/config/config.validation.ts
+++ b/apps/backend/src/app/config/config.validation.ts
@@ -1,6 +1,7 @@
 import {
   IsBoolean,
   IsEnum,
+  IsIn,
   IsInt,
   IsNumber,
   IsOptional,
@@ -13,6 +14,7 @@ import {
 import { plainToInstance } from 'class-transformer';
 import { IsOptionalWithEmptyString } from '../validators';
 import { Environment } from './config.interface';
+import * as pino from 'pino';
 
 export function validate(config: Record<string, unknown>) {
   const validatedConfig = plainToInstance(ConfigValidation, config, {
@@ -102,4 +104,9 @@ export class ConfigValidation {
   @IsString()
   @Length(32, 32)
   readonly SESSION_SECRET?: string;
+
+  @IsString()
+  @IsIn(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
+  @IsOptional()
+  readonly LOG_LEVEL?: pino.LevelWithSilent;
 }


### PR DESCRIPTION
This is very helpful in tests, replacing the old "TEST_LOG_DEBUG" var. By default, E2E tests don't spew INFO logs anymore.