### PR TITLE
Add logic to prevent changing user alias on logout/login

### DIFF
--- a/apps/backend-e2e/src/auth.e2e-spec.ts
+++ b/apps/backend-e2e/src/auth.e2e-spec.ts
@@ -171,7 +171,13 @@ describe('Auth', () => {
         let user;
 
         beforeAll(async () => {
-          user = await db.createUser({ data: { steamID: steamID } });
+          user = await db.createUser({
+            data: {
+              steamID: steamID,
+              alias: steamData.personaname,
+              avatar: steamData.avatarhash
+            }
+          });
 
           response = await request();
         });
@@ -392,7 +398,7 @@ describe('Auth', () => {
         const updatedUserDB = await prisma.user.findFirst();
         expect(updatedUserDB).toMatchObject({
           steamID: userDB.steamID,
-          alias: userSteamSummary.personaname,
+          alias: userDB.alias,
           country: userSteamSummary.loccountrycode,
           avatar: 'bbbbb5567f93a4c9eec4d857df993191c61fb240'
         });
@@ -599,8 +605,8 @@ describe('Auth', () => {
         const updatedUserDB = await prisma.user.findFirst();
         expect(updatedUserDB).toMatchObject({
           steamID: userDB.steamID,
-          alias: userSteamSummary.personaname,
-          country: userSteamSummary.loccountrycode,
+          alias: userDB.alias, // Alias should not change after logging in if Alias is defined.
+          country: userDB.country, // Country should not change after logging in if Country is defined.
           avatar: 'bbbbb5567f93a4c9eec4d857df993191c61fb240'
         });
       });

--- a/apps/backend-e2e/src/user.e2e-spec.ts
+++ b/apps/backend-e2e/src/user.e2e-spec.ts
@@ -118,6 +118,25 @@ describe('User', () => {
         expect(updatedUser.alias).toBe(newAlias);
       });
 
+      it("should fail to update the authenticated user's alias", async () => {
+        const [user, token] = await db.createAndLoginUser();
+        const newAlias = '    ';
+
+        await req.patch({
+          url: 'user',
+          status: 400,
+          body: { alias: newAlias },
+          token
+        });
+
+        const updatedUser = await prisma.user.findFirst({
+          where: { id: user.id },
+          include: { profile: true }
+        });
+
+        expect(updatedUser.alias).not.toBe(newAlias);
+      });
+
       it("should update the authenticated user's bio", async () => {
         const [user, token] = await db.createAndLoginUser();
         const newBio = 'I Love Donkey Kong';
@@ -1468,7 +1487,7 @@ describe('User', () => {
           data: { userID: user.id, mapID: map.id }
         });
 
-        const res = await req.get({
+        await req.get({
           url: `user/maps/favorites/${map.id}`,
           token,
           status: 204

--- a/apps/backend/src/app/dto/user/user.dto.ts
+++ b/apps/backend/src/app/dto/user/user.dto.ts
@@ -4,7 +4,8 @@ import {
   MergeUser,
   Role,
   STEAM_MISSING_AVATAR,
-  User
+  User,
+  NON_WHITESPACE_REGEXP
 } from '@momentum/constants';
 import { ApiProperty, ApiPropertyOptional, PickType } from '@nestjs/swagger';
 import {
@@ -12,6 +13,7 @@ import {
   IsISO31661Alpha2,
   IsOptional,
   IsString,
+  Matches,
   MaxLength
 } from 'class-validator';
 import { Exclude, Expose } from 'class-transformer';
@@ -45,6 +47,7 @@ export class UserDto implements User {
   })
   @IsString()
   @MaxLength(32)
+  @Matches(NON_WHITESPACE_REGEXP)
   readonly alias: string;
 
   @ApiPropertyOptional({

--- a/apps/backend/src/app/modules/users/users.service.spec.ts
+++ b/apps/backend/src/app/modules/users/users.service.spec.ts
@@ -223,9 +223,9 @@ describe('UserService', () => {
         roles: 0,
         bans: 0,
         steamID: BigInt(123456789),
-        alias: '',
+        alias: 'old alias',
         avatar: '',
-        country: '',
+        country: 'QA',
         createdAt: undefined
       };
       db.user.findUnique.mockResolvedValueOnce(existingUser as any);
@@ -246,9 +246,9 @@ describe('UserService', () => {
       expect(spy).toHaveBeenCalledWith({
         where: { id: existingUser.id },
         data: {
-          alias: userData.alias,
+          alias: existingUser.alias,
           avatar: userData.avatar.replace('_full.jpg', ''),
-          country: userData.country
+          country: existingUser.country
         },
         select: { id: true, steamID: true }
       });

--- a/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.html
+++ b/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.html
@@ -19,6 +19,9 @@
           @if (alias.hasError('maxlength')) {
             <p class="bg-dark-800 mb-0 mt-2 border border-red-600 px-3 py-2 text-red-600">Username cannot exceed 32 characters.</p>
           }
+          @if (alias.hasError('pattern')) {
+            <p class="bg-dark-800 mb-0 mt-2 border border-red-600 px-3 py-2 text-red-600">Invalid alias.</p>
+          }
           @if (alias.hasError('required') && alias.dirty) {
             <p class="bg-dark-800 mb-0 mt-2 border border-red-600 px-3 py-2 text-red-600">Username is required.</p>
           }

--- a/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.ts
+++ b/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.ts
@@ -11,7 +11,8 @@ import {
   ISOCountryCode,
   Role,
   Socials,
-  SocialsData
+  SocialsData,
+  NON_WHITESPACE_REGEXP
 } from '@momentum/constants';
 import { Bitflags } from '@momentum/bitflags';
 import { omit } from '@momentum/util-fn';
@@ -96,7 +97,12 @@ export class ProfileEditComponent implements OnInit {
     this.form = this.fb.group({
       alias: [
         '',
-        [Validators.required, Validators.minLength(3), Validators.maxLength(32)]
+        [
+          Validators.required,
+          Validators.minLength(3),
+          Validators.maxLength(32),
+          Validators.pattern(NON_WHITESPACE_REGEXP)
+        ]
       ],
       bio: ['', [Validators.maxLength(MAX_BIO_LENGTH)]],
       country: [''],

--- a/libs/constants/src/index.ts
+++ b/libs/constants/src/index.ts
@@ -41,3 +41,4 @@ export * from './types/utils/';
 export * from './regexp/youtube-id.regexp';
 export * from './regexp/map-name.regexp';
 export * from './regexp/iso-8601.regexp';
+export * from './regexp/non-whitespace.regexp';

--- a/libs/constants/src/regexp/non-whitespace.regexp.ts
+++ b/libs/constants/src/regexp/non-whitespace.regexp.ts
@@ -1,0 +1,3 @@
+// Checks user alias for whitespace including braille whitespace which
+// javascript's regex engine doesn't include in \s.
+export const NON_WHITESPACE_REGEXP = /^(?![\s028u{}]*$).+/;


### PR DESCRIPTION
Date:      Fri May 31 10:58:39 2024 -0500

Implements fix for bug #921

Implements fix for bug #921 which resets the users alias on logou and back in. This fix
    - Implements a new regex to disallow purely whitespace based aliases
    - E2e testing on the new aliases
    - Logic to test if the user name is valid, or is the default value

Closes #921