### PR TITLE
Pre-signed urls for map submission

### DIFF
--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -972,25 +972,15 @@ describe('Maps', () => {
 
           await req.postAttach({
             url: 'maps',
+            status: 503,
             data: createMapObject,
             files: [
-              { file: bspBuffer, field: 'bsp', fileName: 'surf_map.bsp' },
               { file: vmfBuffer, field: 'vmfs', fileName: 'surf_map.vmf' }
             ],
             token: adminToken
           });
 
-          await req.patch({
-            url: 'admin/killswitch',
-            status: 204,
-            body: {
-              NEW_SIGNUPS: false,
-              RUN_SUBMISSION: false,
-              MAP_SUBMISSION: false,
-              MAP_REVIEWS: false
-            },
-            token: adminToken
-          });
+          await resetKillswitches(req, adminToken);
         });
       });
 

--- a/apps/backend-e2e/src/multi-stage.e2e-spec.ts
+++ b/apps/backend-e2e/src/multi-stage.e2e-spec.ts
@@ -64,6 +64,17 @@ describe('Multi-stage E2E tests', () => {
     const vmfBuffer = readFileSync(path.join(FILES_PATH, 'map.vmf'));
     const vmfHash = createSha1Hash(vmfBuffer);
 
+    const preSignedUrlRes = await req.get({
+      url: 'maps/getMapUploadUrl',
+      query: {
+        fileSize: bspBuffer.length
+      },
+      status: 200,
+      token
+    });
+
+    await fileStore.putToPreSignedUrl(preSignedUrlRes.body.url, bspBuffer);
+
     const {
       body: { id: mapID }
     } = await req.postAttach({
@@ -93,7 +104,6 @@ describe('Multi-stage E2E tests', () => {
         zones: BabyZonesStub
       },
       files: [
-        { file: bspBuffer, field: 'bsp', fileName: 'surf_todd_howard.bsp' },
         {
           file: vmfBuffer,
           field: 'vmfs',
@@ -144,12 +154,22 @@ describe('Multi-stage E2E tests', () => {
     );
     const vmf2Hash = createSha1Hash(vmf2Buffer);
 
+    const preSignedUrl2Res = await req.get({
+      url: 'maps/getMapUploadUrl',
+      query: {
+        fileSize: bsp2Buffer.length
+      },
+      status: 200,
+      token
+    });
+
+    await fileStore.putToPreSignedUrl(preSignedUrl2Res.body.url, bsp2Buffer);
+
     await req.postAttach({
       url: `maps/${mapID}`,
       status: 201,
       data: { changelog: 'it just works' },
       files: [
-        { file: bsp2Buffer, field: 'bsp', fileName: 'surf_todd_howard.bsp' },
         {
           file: vmf2Buffer,
           field: 'vmfs',

--- a/apps/backend/src/app/config/config.interface.ts
+++ b/apps/backend/src/app/config/config.interface.ts
@@ -51,6 +51,7 @@ export interface ConfigInterface {
     testInvites: number;
     minPublicTestingDuration: number;
     maxCreditsExceptTesters: number;
+    preSignedUrlExpTime: number;
   };
   logLevel: pino.LevelWithSilent;
 }

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -11,7 +11,8 @@
   JWT_GAME_EXPIRY_TIME,
   JWT_WEB_EXPIRY_TIME,
   JWT_REFRESH_EXPIRY_TIME,
-  MAX_MAP_IMAGE_SIZE
+  MAX_MAP_IMAGE_SIZE,
+  PRE_SIGNED_URL_EXPIRE_TIME
 } from '@momentum/constants';
 import { ConfigInterface, Environment } from './config.interface';
 import * as process from 'node:process';
@@ -71,7 +72,8 @@ export const ConfigFactory = (): ConfigInterface => {
       reviewLength: MAX_REVIEW_LENGTH,
       testInvites: MAX_TEST_INVITES,
       minPublicTestingDuration: MIN_PUBLIC_TESTING_DURATION,
-      maxCreditsExceptTesters: MAX_CREDITS_EXCEPT_TESTERS
+      maxCreditsExceptTesters: MAX_CREDITS_EXCEPT_TESTERS,
+      preSignedUrlExpTime: PRE_SIGNED_URL_EXPIRE_TIME
     },
     logLevel: (process.env['LOG_LEVEL'] ?? isTest
       ? 'warn'

--- a/apps/backend/src/app/dto/index.ts
+++ b/apps/backend/src/app/dto/index.ts
@@ -25,6 +25,7 @@ export * from './map/map-review-comment.dto';
 export * from './map/map-review-suggestions.dto';
 export * from './map/map-review-edit.dto';
 export * from './map/map-test-invite.dto';
+export * from './map/map-pre-signed-url.dto';
 export * from './report/report.dto';
 export * from './run/leaderboard-run.dto';
 export * from './run/past-run.dto';

--- a/apps/backend/src/app/dto/map/map-pre-signed-url.dto.ts
+++ b/apps/backend/src/app/dto/map/map-pre-signed-url.dto.ts
@@ -1,0 +1,9 @@
+import { MapPreSignedUrl } from '@momentum/constants';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUrl } from 'class-validator';
+
+export class MapPreSignedUrlDto implements MapPreSignedUrl {
+  @ApiProperty()
+  @IsUrl()
+  readonly url: string;
+}

--- a/apps/backend/src/app/dto/map/map.dto.ts
+++ b/apps/backend/src/app/dto/map/map.dto.ts
@@ -16,7 +16,6 @@ import {
   ArrayMinSize,
   IsArray,
   IsBoolean,
-  IsDefined,
   IsHash,
   IsInt,
   IsOptional,
@@ -237,14 +236,6 @@ export class CreateMapDto
 }
 
 export class CreateMapWithFilesDto implements CreateMapWithFiles {
-  @ApiProperty({
-    type: 'file',
-    format: 'binary',
-    description: 'BSP for the map. MUST be run through bspzip!'
-  })
-  @IsDefined()
-  readonly bsp: any;
-
   @ApiProperty({
     type: 'file array',
     format: 'binary',

--- a/apps/backend/src/app/modules/filestore/file-store-s3.service.ts
+++ b/apps/backend/src/app/modules/filestore/file-store-s3.service.ts
@@ -8,6 +8,7 @@ import {
   DeleteObjectsCommand,
   ListObjectsV2Command
 } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { ConfigService } from '@nestjs/config';
 import { FileStoreFile } from './file-store.interface';
 import { FileStoreService } from './file-store.service';
@@ -125,6 +126,22 @@ export class FileStoreS3Service extends FileStoreService {
 
     if (response.KeyCount === 0 || !response.Contents) return [];
     return response.Contents.map(({ Key }) => Key);
+  }
+
+  async getPreSignedUrl(
+    fileKey: string,
+    fileSize: number,
+    urlExpires: number
+  ): Promise<string> {
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: fileKey,
+      ContentLength: fileSize
+    });
+
+    return await getSignedUrl(this.s3Client, command, {
+      expiresIn: urlExpires
+    });
   }
 
   private async isMissingHandler(

--- a/apps/backend/src/app/modules/filestore/file-store.service.ts
+++ b/apps/backend/src/app/modules/filestore/file-store.service.ts
@@ -52,6 +52,15 @@ export abstract class FileStoreService {
   abstract listFileKeys(prefix: string): Promise<string[]>;
 
   /**
+   * Get pre-signed url for an object with set key and size
+   */
+  abstract getPreSignedUrl(
+    fileKey: string,
+    fileSize: number,
+    urlExpires: number
+  ): Promise<string>;
+
+  /**
    * Get a SHA1 hash for a buffer.
    */
   static getHashForBuffer(buffer: Buffer): string {

--- a/apps/frontend/src/app/services/data/maps.service.ts
+++ b/apps/frontend/src/app/services/data/maps.service.ts
@@ -22,7 +22,8 @@ import {
   UpdateMap,
   UpdateMapImagesWithFiles,
   CreateMapSubmissionVersionWithFiles,
-  CreateMapTestInvite
+  CreateMapTestInvite,
+  MapPreSignedUrl
 } from '@momentum/constants';
 import { HttpService } from './http.service';
 
@@ -69,15 +70,16 @@ export class MapsService {
     return this.http.put<MapCredit[]>(`maps/${mapID}/credits`, { body });
   }
 
-  submitMap({
-    bsp,
-    data,
-    vmfs
-  }: CreateMapWithFiles): Observable<HttpEvent<string>> {
+  getPreSignedUrl(fileSize: number): Observable<MapPreSignedUrl> {
+    return this.http.get<MapPreSignedUrl>('maps/getMapUploadUrl', {
+      query: { fileSize }
+    });
+  }
+
+  submitMap({ data, vmfs }: CreateMapWithFiles): Observable<HttpEvent<string>> {
     const formData = new FormData();
 
     formData.append('data', JSON.stringify(data));
-    formData.append('bsp', bsp, bsp.name);
     for (const vmf of vmfs ?? []) formData.append('vmfs', vmf, vmf.name);
 
     return this.http.post('maps', {
@@ -90,12 +92,11 @@ export class MapsService {
 
   submitMapVersion(
     mapID: number,
-    { bsp, data, vmfs }: CreateMapSubmissionVersionWithFiles
+    { data, vmfs }: CreateMapSubmissionVersionWithFiles
   ): Observable<HttpEvent<string>> {
     const formData = new FormData();
 
     formData.append('data', JSON.stringify(data));
-    formData.append('bsp', bsp, bsp.name);
     for (const vmf of vmfs ?? []) formData.append('vmfs', vmf, vmf.name);
 
     return this.http.post(`maps/${mapID}`, {

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -46,7 +46,8 @@ services:
      bash -c "
        mc alias set momentum_minio http://minio:${MINIO_SERVER_PORT} ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD} &&
        mc mb momentum_minio/${STORAGE_BUCKET_NAME} --ignore-existing &&
-       mc anonymous set public momentum_minio/${STORAGE_BUCKET_NAME}
+       mc anonymous set public momentum_minio/${STORAGE_BUCKET_NAME} &&
+       mc ilm rule add --prefix "upload_tmp/" --expire-days 1 momentum_minio/${STORAGE_BUCKET_NAME}
      "
   pgadmin:
     container_name: pgadmin

--- a/libs/constants/src/consts/limits.const.ts
+++ b/libs/constants/src/consts/limits.const.ts
@@ -19,3 +19,4 @@ export const MAX_MAP_DESCRIPTION_LENGTH = 1500;
 export const MIN_MAP_NAME_LENGTH = 3;
 export const MAX_MAP_NAME_LENGTH = 32; // Seems high but this is actually a constant in engine.
 export const MAX_MAP_SUGGESTION_COMMENT_LENGTH = 500;
+export const PRE_SIGNED_URL_EXPIRE_TIME = 5 * 60;

--- a/libs/constants/src/types/models/index.ts
+++ b/libs/constants/src/types/models/index.ts
@@ -20,6 +20,7 @@ export * from './map/map-tags.model';
 export * from './map/map-test-invite.model';
 export * from './map/map-zones.model';
 export * from './map/map-list-version.model';
+export * from './map/map-pre-signed-url.model';
 export * from './run/leaderboard.model';
 export * from './run/leaderboard-run.model';
 export * from './run/past-run.model';

--- a/libs/constants/src/types/models/map/map-pre-signed-url.model.ts
+++ b/libs/constants/src/types/models/map/map-pre-signed-url.model.ts
@@ -1,0 +1,3 @@
+export interface MapPreSignedUrl {
+  url: string;
+}

--- a/libs/constants/src/types/models/map/map-submission-version.model.ts
+++ b/libs/constants/src/types/models/map/map-submission-version.model.ts
@@ -14,7 +14,6 @@ export interface CreateMapSubmissionVersion
 }
 
 export interface CreateMapSubmissionVersionWithFiles {
-  bsp: File;
   vmfs: File[];
   data: CreateMapSubmissionVersion;
 }

--- a/libs/constants/src/types/models/map/map.model.ts
+++ b/libs/constants/src/types/models/map/map.model.ts
@@ -44,7 +44,6 @@ export interface MMap extends Omit<PrismaMMap, 'zones' | 'images'> {
 }
 
 export interface CreateMapWithFiles {
-  bsp: File;
   vmfs: File[];
   data: CreateMap;
 }

--- a/libs/test-utils/src/utils/s3.util.ts
+++ b/libs/test-utils/src/utils/s3.util.ts
@@ -96,6 +96,23 @@ export class FileStoreUtil {
     }
   }
 
+  async list(prefix: string): Promise<string[]> {
+    try {
+      const response = await this.s3.send(
+        new ListObjectsV2Command({
+          Bucket: process.env['STORAGE_BUCKET_NAME'] ?? '',
+          Delimiter: '/',
+          Prefix: prefix
+        })
+      );
+
+      if (response.KeyCount === 0 || !response.Contents) return [];
+      return response.Contents.map(({ Key }) => Key);
+    } catch {
+      return null;
+    }
+  }
+
   async exists(key: string): Promise<boolean> {
     try {
       return !!(await this.get(key));
@@ -127,6 +144,10 @@ export class FileStoreUtil {
     return axios
       .get(url, { responseType: 'arraybuffer' })
       .then((res) => Buffer.from(res.data, 'binary'));
+  }
+
+  async putToPreSignedUrl(url: string, data: Buffer) {
+    return await axios.put(url, data);
   }
 
   async getMapListVersion(type: FlatMapList, version: number) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/platform-browser-dynamic": "17.3.2",
         "@angular/router": "17.3.2",
         "@aws-sdk/client-s3": "3.540.0",
+        "@aws-sdk/s3-request-presigner": "^3.600.0",
         "@fastify/cookie": "9.3.1",
         "@fastify/cors": "9.0.1",
         "@fastify/deepmerge": "1.3.0",
@@ -2220,6 +2221,402 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.600.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.600.0.tgz",
+      "integrity": "sha512-MYRwgti1DDc9/Q9AzvTQy0Ih0j4vLe0zYLV3qtSI0H8G02yRqTzet2s/76pUNOYJK9ASSgcxQ9yeV9EGKBwndQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-format-url": "3.598.0",
+        "@smithy/middleware-endpoint": "^3.0.2",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.598.0.tgz",
+      "integrity": "sha512-5AGtLAh9wyK6ANPYfaKTqJY1IFJyePIxsEbxa7zS6REheAqyVmgJFaGu3oQ5XlxfGr5Uq59tFTRkyx26G1HkHA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@aws-sdk/util-arn-parser": "3.568.0",
+        "@smithy/node-config-provider": "^3.1.1",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.2",
+        "@smithy/types": "^3.1.0",
+        "@smithy/util-config-provider": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.598.0.tgz",
+      "integrity": "sha512-1r/EyTrO1gSa1FirnR8V7mabr7gk+l+HkyTI0fcTSr8ucB7gmYyW6WjkY8JCz13VYHFK62usCEDS7yoJoJOzTA==",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.598.0",
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/protocol-http": "^4.0.1",
+        "@smithy/signature-v4": "^3.1.0",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+      "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
+      "dependencies": {
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.568.0.tgz",
+      "integrity": "sha512-XUKJWWo+KOB7fbnPP0+g/o5Ulku/X53t7i/h+sPHr5xxYTJJ9CYnbToo95mzxe7xWvkLrsNtJ8L+MnNn9INs2w==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/abort-controller": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.0.tgz",
+      "integrity": "sha512-XOm4LkuC0PsK1sf2bBJLIlskn5ghmVxiEBVlo/jg0R8hxASBKYYgOoJEhKWgOr4vWGkN+5rC+oyBAqHYtxjnwQ==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/fetch-http-handler": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.1.0.tgz",
+      "integrity": "sha512-s7oQjEOUH9TYjctpITtWF4qxOdg7pBrP9eigEQ8SBsxF3dRFV0S28pGMllC83DUr7ECmErhO/BUwnULfoNhKgQ==",
+      "dependencies": {
+        "@smithy/protocol-http": "^4.0.2",
+        "@smithy/querystring-builder": "^3.0.2",
+        "@smithy/types": "^3.2.0",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.3.tgz",
+      "integrity": "sha512-ARAXHodhj4tttKa9y75zvENdSoHq6VGsSi7XS3+yLutrnxttJs6N10UMInCC1yi3/bopT8xug3iOP/y9R6sKJQ==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.2",
+        "@smithy/node-config-provider": "^3.1.2",
+        "@smithy/shared-ini-file-loader": "^3.1.2",
+        "@smithy/types": "^3.2.0",
+        "@smithy/url-parser": "^3.0.2",
+        "@smithy/util-middleware": "^3.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.2.tgz",
+      "integrity": "sha512-oT2abV5zLhBucJe1LIIFEcRgIBDbZpziuMPswTMbBQNcaEUycLFvX63zsFmqfwG+/ZQKsNx+BSE8W51CMuK7Yw==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.2.tgz",
+      "integrity": "sha512-6fRcxomlNKBPIy/YjcnC7YHpMAjRvGUYlYVJAfELqZjkW0vQegNcImjY7T1HgYA6u3pAcCxKVBLYnkTw8z/l0A==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.2.tgz",
+      "integrity": "sha512-388fEAa7+6ORj/BDC70peg3fyFBTTXJyXfXJ0Bwd6FYsRltePr2oGzIcm5AuC1WUSLtZ/dF+hYOnfTMs04rLvA==",
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.2",
+        "@smithy/shared-ini-file-loader": "^3.1.2",
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/node-http-handler": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.0.tgz",
+      "integrity": "sha512-pOpgB6B+VLXLwAyyvRz+ZAVXABlbAsJ2xvn3WZvrppAPImxwQOPFbeSUzWYMhpC8Tr7yQ3R8fG990QDhskkf1Q==",
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.0",
+        "@smithy/protocol-http": "^4.0.2",
+        "@smithy/querystring-builder": "^3.0.2",
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/property-provider": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.2.tgz",
+      "integrity": "sha512-Hzp32BpeFFexBpO1z+ts8okbq/VLzJBadxanJAo/Wf2CmvXMBp6Q/TLWr7Js6IbMEcr0pDZ02V3u1XZkuQUJaA==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/protocol-http": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.2.tgz",
+      "integrity": "sha512-X/90xNWIOqSR2tLUyWxVIBdatpm35DrL44rI/xoeBWUuanE0iyCXJpTcnqlOpnEzgcu0xCKE06+g70TTu2j7RQ==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.2.tgz",
+      "integrity": "sha512-xhv1+HacDYsOLdNt7zW+8Fe779KYAzmWvzs9bC5NlKM8QGYCwwuFwDBynhlU4D5twgi2pZ14Lm4h6RiAazCtmA==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.2.tgz",
+      "integrity": "sha512-C5hyRKgrZGPNh5QqIWzXnW+LXVrPmVQO0iJKjHeb5v3C61ZkP9QhrKmbfchcTyg/VnaE0tMNf/nmLpQlWuiqpg==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.2.tgz",
+      "integrity": "sha512-tgnXrXbLMO8vo6VeuqabMw/eTzQHlLmZx0TC0TjtjJghnD0Xl4pEnJtBjTJr6XF5fHMNrt5BcczDXHJT9yNQnA==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/signature-v4": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.1.tgz",
+      "integrity": "sha512-2/vlG86Sr489XX8TA/F+VDA+P04ESef04pSz0wRtlQBExcSPjqO08rvrkcas2zLnJ51i+7ukOURCkgqixBYjSQ==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/types": "^3.2.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/smithy-client": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.4.tgz",
+      "integrity": "sha512-y6xJROGrIoitjpwXLY7P9luDHvuT9jWpAluliuSFdBymFxcl6iyQjo9U/JhYfRHFNTruqsvKOrOESVuPGEcRmQ==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^3.0.3",
+        "@smithy/middleware-stack": "^3.0.2",
+        "@smithy/protocol-http": "^4.0.2",
+        "@smithy/types": "^3.2.0",
+        "@smithy/util-stream": "^3.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/types": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.2.0.tgz",
+      "integrity": "sha512-cKyeKAPazZRVqm7QPvcPD2jEIt2wqDPAL1KJKb0f/5I7uhollvsWZuZKLclmyP6a+Jwmr3OV3t+X0pZUUHS9BA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/url-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.2.tgz",
+      "integrity": "sha512-pRiPHrgibeAr4avtXDoBHmTLtthwA4l8jKYRfZjNgp+bBPyxDMPRg2TMJaYxqbKemvrOkHu9MIBTv2RkdNfD6w==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.2",
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/util-middleware": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.2.tgz",
+      "integrity": "sha512-7WW5SD0XVrpfqljBYzS5rLR+EiDzl7wCVJZ9Lo6ChNFV4VYDk37Z1QI5w/LnYtU/QKnSawYoHRd7VjSyC8QRQQ==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/util-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.4.tgz",
+      "integrity": "sha512-CcMioiaOOsEVdb09pS7ux1ij7QcQ2jE/cE1+iin1DXMeRgAEQN/47m7Xztu7KFQuQsj0A5YwB2UN45q97CqKCg==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^3.1.0",
+        "@smithy/node-http-handler": "^3.1.0",
+        "@smithy/types": "^3.2.0",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.535.0.tgz",
@@ -2287,6 +2684,67 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.598.0.tgz",
+      "integrity": "sha512-1X0PlREk5K6tQg8rFZOjoKVtDyI1WgbKJNCymHhMye6STryY6fhuuayKstiDThkqDYxqahjUJz/Tl2p5W3rbcw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.598.0",
+        "@smithy/querystring-builder": "^3.0.1",
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.598.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.598.0.tgz",
+      "integrity": "sha512-742uRl6z7u0LFmZwDrFP6r1wlZcgVPw+/TilluDJmCAR8BgRw3IR+743kUXKBGd8QZDRW2n6v/PYsi/AWCDDMQ==",
+      "dependencies": {
+        "@smithy/types": "^3.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.2.tgz",
+      "integrity": "sha512-xhv1+HacDYsOLdNt7zW+8Fe779KYAzmWvzs9bC5NlKM8QGYCwwuFwDBynhlU4D5twgi2pZ14Lm4h6RiAazCtmA==",
+      "dependencies": {
+        "@smithy/types": "^3.2.0",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/types": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.2.0.tgz",
+      "integrity": "sha512-cKyeKAPazZRVqm7QPvcPD2jEIt2wqDPAL1KJKb0f/5I7uhollvsWZuZKLclmyP6a+Jwmr3OV3t+X0pZUUHS9BA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@angular/platform-browser-dynamic": "17.3.2",
     "@angular/router": "17.3.2",
     "@aws-sdk/client-s3": "3.540.0",
+    "@aws-sdk/s3-request-presigner": "^3.600.0",
     "@fastify/cookie": "9.3.1",
     "@fastify/cors": "9.0.1",
     "@fastify/deepmerge": "1.3.0",


### PR DESCRIPTION
Closes #705
Closes #318 

When uploading BSP for map submission s3 pre-signed urls will be used now.

### Checks

- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have ran `nx run db:create-migration` and committed the migration if I've made DB schema changes
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
