### PR TITLE
refactor(shared): remove /api prefix on backend URLs

### DIFF
--- a/apps/backend-e2e/src/auth.e2e-spec.ts
+++ b/apps/backend-e2e/src/auth.e2e-spec.ts
@@ -107,6 +107,8 @@ describe('Auth', () => {
               return '1m';
             case 'jwt.refreshExpTime':
               return '5m';
+            case 'url.frontend':
+              return 'dashboard.momentum-mod.org';
           }
         });
       });
@@ -122,7 +124,7 @@ describe('Auth', () => {
 
         it('should succeed and redirect to dashboard', () => {
           expect(response.statusCode).toBe(302);
-          expect(response.headers.location).toBe('/');
+          expect(response.headers.location).toBe('dashboard.momentum-mod.org');
         });
 
         it('should create a new user', async () => {
@@ -177,7 +179,7 @@ describe('Auth', () => {
 
         it('should succeed and redirect to dashboard', () => {
           expect(response.statusCode).toBe(302);
-          expect(response.headers.location).toBe('/');
+          expect(response.headers.location).toBe('dashboard.momentum-mod.org');
         });
 
         it('should create a new user', async () => {

--- a/apps/backend-e2e/src/support/environment.ts
+++ b/apps/backend-e2e/src/support/environment.ts
@@ -55,7 +55,6 @@ export async function setupE2ETestEnvironment(
 
   app.useBodyParser('application/octet-stream', { bodyLimit: 1e8 });
 
-  app.setGlobalPrefix('api', { exclude: ['auth(.*)'] });
   app.enableVersioning({
     type: VersioningType.URI,
     defaultVersion: '1',

--- a/apps/backend-e2e/src/users.e2e-spec.ts
+++ b/apps/backend-e2e/src/users.e2e-spec.ts
@@ -237,7 +237,7 @@ describe('Users', () => {
     });
   });
 
-  describe('GET /api/users/{userID}/profile', () => {
+  describe('GET /users/{userID}/profile', () => {
     let user, token;
 
     beforeAll(
@@ -264,7 +264,7 @@ describe('Users', () => {
       req.get({ url: `users/${NULL_ID}/profile`, status: 404, token }));
   });
 
-  describe('GET /api/users/{userID}/activities', () => {
+  describe('GET /users/{userID}/activities', () => {
     let user, token;
 
     beforeAll(async () => {

--- a/apps/backend/src/app/filters/exception-handler.filter.ts
+++ b/apps/backend/src/app/filters/exception-handler.filter.ts
@@ -51,9 +51,8 @@ export class ExceptionHandlerFilter implements ExceptionFilter {
         };
       }
 
-      const isProd = env === Environment.PRODUCTION;
       const isActualError = !status || status >= 500;
-      if (isProd) {
+      if (env === Environment.PRODUCTION) {
         // Don't do anything for 4xxs in prod, they're not actual errors and
         // they'll get logged by pino-http like any other response.
         if (isActualError) {
@@ -80,11 +79,12 @@ export class ExceptionHandlerFilter implements ExceptionFilter {
           message: exception.message,
           stack: exception.stack // Stack is useful in dev, waste in prod, Sentry has all that.
         };
-        // We're in development, print actual errors (non-HttpException and 500s)
-        // as errors and the rest as debug
-        if (isActualError) {
+        if (env === Environment.DEVELOPMENT) {
+          // In development, print actual errors (non-HttpException and 500s)
+          // as errors and the rest as debug.
           this.logger.error(msg);
         } else {
+          // In E2E tests, print everything as debug.
           this.logger.debug(msg);
         }
       }

--- a/apps/backend/src/app/modules/auth/auth.controller.ts
+++ b/apps/backend/src/app/modules/auth/auth.controller.ts
@@ -76,7 +76,7 @@ export class AuthController {
   }
 
   @Get('/web/return')
-  @Redirect('/', HttpStatus.FOUND)
+  @Redirect('', HttpStatus.FOUND)
   @BypassJwtAuth()
   @UseGuards(SteamWebGuard)
   @ApiOperation({ summary: 'Assigns a JWT using OpenID data from Steam login' })
@@ -90,6 +90,8 @@ export class AuthController {
     res.setCookie('accessToken', jwt.accessToken, this.cookieOptions);
     res.setCookie('refreshToken', jwt.refreshToken, this.cookieOptions);
     res.setCookie('user', JSON.stringify(user), this.cookieOptions);
+
+    return { url: this.configService.getOrThrow('url.frontend') };
   }
 
   @Post('/game')

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -55,9 +55,6 @@ async function bootstrap() {
   app.useGlobalPipes(new ValidationPipe(VALIDATION_PIPE_CONFIG));
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
-  // Prefix everything but auth/health with /api
-  app.setGlobalPrefix('api', { exclude: ['auth(.*)', 'health(.*)'] });
-
   // All routes (besides auth, which uses VERSION_NEUTRAL) are version 1 by
   // default, versions can be incremented on a per-route basis upon future
   // versions
@@ -114,7 +111,7 @@ async function bootstrap() {
 
   // Swagger stuff
   SwaggerModule.setup(
-    'api-docs',
+    'docs',
     app,
     SwaggerModule.createDocument(
       app,

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -13,7 +13,6 @@ import {
 import cookie from '@fastify/cookie';
 import helmet from '@fastify/helmet';
 import cors from '@fastify/cors';
-import { FastifyReply } from 'fastify';
 import { Logger } from 'nestjs-pino';
 import { Environment } from './app/config';
 import { AppModule } from './app/app.module';
@@ -63,20 +62,6 @@ async function bootstrap() {
     defaultVersion: '1',
     prefix: 'v'
   });
-
-  // In dev, serve a script to the client to handle redirecting after auth.
-  // Usually we'd let Nest handle routing, but doing a separate controller file
-  // would be silly, especially since this is developer-only.
-  if (env !== Environment.PRODUCTION) {
-    // Since TS 5 / Nest 10 this `any` cast has been necessary. May be possible
-    // to remove once `@nestjs/platform-fastify` is on latest `fastify`.
-    const fastify = app.getHttpAdapter().getInstance() as any as FastifyAdapter;
-    fastify.get('/', (_, reply: FastifyReply) =>
-      reply
-        .type('text/html')
-        .send("<script>window.location.port = '4200';</script>")
-    );
-  }
 
   // Enable @fastify/helmet header protections
   await app.register(helmet, {

--- a/apps/frontend/src/app/env/environment.ts
+++ b/apps/frontend/src/app/env/environment.ts
@@ -2,6 +2,6 @@ import { Environment } from './environment.interface';
 
 export const env: Environment = {
   production: false,
-  api: 'http://localhost:3000/api',
+  api: 'http://localhost:3000',
   auth: 'http://localhost:3000/auth'
 };

--- a/libs/test-utils/src/utils/request.util.ts
+++ b/libs/test-utils/src/utils/request.util.ts
@@ -10,7 +10,7 @@ import { FILES_PATH } from '../files-path.const';
 import { isEmpty } from '@momentum/util-fn';
 import { MergeExclusive, Primitive } from 'type-fest';
 
-export const URL_PREFIX = '/api/v1/';
+export const URL_PREFIX = '/v1/';
 
 export class RequestUtil {
   constructor(private readonly app: NestFastifyApplication) {}


### PR DESCRIPTION
The new production deploy uses api.momentum-mod.org / staging-api.momentum-mod.org, so /api/ is redundant. In dev I don't think the prefix is particularly helpful either.

### Checks

- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have ran `nx run db:create-migration` and committed the migration if I've made DB schema changes
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
