### PR TITLE
Update CI to use Node 20 based jobs

### DIFF
--- a/.github/workflows/backend_docker_image.yml
+++ b/.github/workflows/backend_docker_image.yml
@@ -22,19 +22,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: node_cache
         with:
           path: node_modules
           key: modules-${{ hashFiles('package-lock.json') }}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: 'npm'
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build
         run: npx nx run backend:build:production
-      
+
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@v5
         with:

--- a/.github/workflows/frontend_cf_pages.yml
+++ b/.github/workflows/frontend_cf_pages.yml
@@ -54,9 +54,8 @@ jobs:
         run: npx nx run frontend:build:${{ contains( inputs.project_name, 'staging' ) && 'staging' || 'production' }}
 
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: ${{ inputs.project_name }}
-          directory: dist/apps/frontend
+          command: pages deploy dist/apps/frontend --project-name=${{ inputs.project_name }} --commit-dirty=true

--- a/.github/workflows/frontend_cf_pages.yml
+++ b/.github/workflows/frontend_cf_pages.yml
@@ -26,21 +26,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: node_cache
         with:
           path: node_modules
           key: modules-${{ hashFiles('package-lock.json') }}
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 20
           cache: 'npm'
 
       - name: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,24 +8,24 @@ jobs:
     name: Install Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Original node_modules Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: original_cache
         with:
           path: node_modules
           key: modules-${{ hashFiles('package-lock.json') }}
 
       - name: node_modules Cache with Prisma Client
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: modules-${{ github.run_id }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 20
           cache: 'npm'
 
       - name: npm install
@@ -40,14 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: install-deps
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
           submodules: 'true'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: node_modules
           key: modules-${{ github.run_id }}
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: install-deps
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -82,7 +82,7 @@ jobs:
           submodules: 'true'
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: modules-${{ github.run_id }}
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: install-deps
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -107,7 +107,7 @@ jobs:
           submodules: 'true'
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: modules-${{ github.run_id }}
@@ -124,14 +124,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: install-deps
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: modules-${{ github.run_id }}
@@ -164,14 +164,14 @@ jobs:
 #    runs-on: ubuntu-latest
 #    needs: install-deps
 #    steps:
-#      - uses: actions/checkout@v3
+#      - uses: actions/checkout@v4
 #        with:
 #          ref: ${{ github.event.pull_request.head.ref }}
 #          repository: ${{ github.event.pull_request.head.repo.full_name }}
 #          fetch-depth: 0
 #          submodules: 'true'
 #      - name: Cache node_modules
-#        uses: actions/cache@v3
+#        uses: actions/cache@v4
 #        with:
 #          path: node_modules
 #          key: modules-${{ github.run_id }}


### PR DESCRIPTION
Bumps us to latest Node version, squashes warning in output.

Also moved us to wrangler directly to publish to cloudflare, seems like the pages action hasn't been updated in a while and will continue to give the Node 20 warning, whilst the wrangler action works fine and is kept up to date.