### PR TITLE
Enable filter bar for country selector in profile edit

### DIFF
--- a/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.html
+++ b/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.html
@@ -35,6 +35,7 @@
             optionValue="code"
             optionLabel="label"
             appendTo="body"
+            [filter]="true"
           />
         </div>
 


### PR DESCRIPTION
As suggested by BJack0 on discord, enables search bar for country selector on profile edit page

![image](https://github.com/momentum-mod/website/assets/44753329/81a8f7c0-cb98-45ea-a31e-922ba5607084)

### Checks

- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have ran `nx run db:create-migration` and committed the migration if I've made DB schema changes
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
