### PR TITLE
ci(meta): ignore all angular-related packages in auto update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,8 @@ updates:
         dependency-type: "development"
     ignore:
       - dependency-name: "@nx*"
-      - dependency-name: "@angular*"
+      - dependency-name: "nx"
+      - dependency-name: "*angular*"
       - dependency-name: "typescript"
       - dependency-name: "*eslint*"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Was trying to bump @schematics/angular to 18.0.7 whilst other Angular stuff (which we do manually) is on 18.0.6.