### PR TITLE
fix(build): Make backend user in docker own node_modules

### DIFF
--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -10,11 +10,11 @@ COPY ../libs/db/src/prisma/ ./prisma/
 
 RUN chown -R backend:backend .
 
+USER backend
 RUN npm --omit=dev --ignore-scripts install
 RUN node_modules/.bin/prisma generate --schema ./prisma/schema.prisma
 
 RUN rm package.json package-lock.json
-COPY ./prod/package.json .
+COPY --chown=backend ./prod/package.json .
 
-USER backend
 CMD [ "npm", "run", "start" ]


### PR DESCRIPTION
Makes all files in /app folder of docker container be owned by backend user.
Should help with migration errors

### Checks

- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have ran `nx run db:create-migration` and committed the migration if I've made DB schema changes
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
