### PR TITLE
Stop dependabot bumping Prettier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       - dependency-name: "*angular*"
       - dependency-name: "typescript"
       - dependency-name: "*eslint*"
+      - dependency-name: "*prettier*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -69,7 +69,7 @@ export const ConfigFactory = (): ConfigInterface => {
       maxCreditsExceptTesters: MAX_CREDITS_EXCEPT_TESTERS,
       preSignedUrlExpTime: PRE_SIGNED_URL_EXPIRE_TIME
     },
-    logLevel: (process.env['LOG_LEVEL'] ?? isTest
+    logLevel: ((process.env['LOG_LEVEL'] ?? isTest)
       ? 'warn'
       : 'info') as pino.LevelWithSilent
   };

--- a/libs/test-utils/src/utils/db.util.ts
+++ b/libs/test-utils/src/utils/db.util.ts
@@ -173,7 +173,7 @@ export class DbUtil {
             // Just creating the one leaderboard here, most maps will have more,
             // but isn't needed or worth the test perf hit
             leaderboards:
-              mmap?.leaderboards ?? noLeaderboards
+              (mmap?.leaderboards ?? noLeaderboards)
                 ? undefined
                 : {
                     create: {

--- a/libs/test-utils/src/utils/request.util.ts
+++ b/libs/test-utils/src/utils/request.util.ts
@@ -92,7 +92,7 @@ export class RequestUtil {
       accept: 'application/json'
     };
     injectOptions.url =
-      (options.skipApiPrefix ?? false ? '/' : URL_PREFIX) + options.url;
+      ((options.skipApiPrefix ?? false) ? '/' : URL_PREFIX) + options.url;
 
     if (options.query) {
       if (typeof options.query === 'string') {
@@ -146,7 +146,7 @@ export class RequestUtil {
         Object.assign(injectOptions.headers, form.getHeaders());
         injectOptions.payload = form;
       } else {
-        injectOptions.payload = 'body' in options ? options.body ?? {} : {};
+        injectOptions.payload = 'body' in options ? (options.body ?? {}) : {};
       }
     }
 


### PR DESCRIPTION
Dependabot recently upgraded Prettier, which makes our formatting checks in CI fail. We're not going to be in desperate need to upgrade Prettier, fine to do manually.