### PR TITLE
Generalized Map Versioning

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,8 @@ Closes #<!--(issue number here)-->
 
 ### Checks
 
+- [ ] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
 - [ ] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
-- [ ] I have ran `nx run db:create-migration` and committed the migration if I've made DB schema changes
 - [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
 - [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
 - [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review

--- a/apps/backend-e2e/src/admin.e2e-spec.ts
+++ b/apps/backend-e2e/src/admin.e2e-spec.ts
@@ -1189,6 +1189,8 @@ describe('Admin', () => {
         `${MapStatus.CONTENT_APPROVAL},${MapStatus.FINAL_APPROVAL  },${Role.ADMIN}`,
         `${MapStatus.CONTENT_APPROVAL},${MapStatus.DISABLED        },${Role.MODERATOR}`,
         `${MapStatus.CONTENT_APPROVAL},${MapStatus.DISABLED        },${Role.ADMIN}`,
+        `${MapStatus.PUBLIC_TESTING  },${MapStatus.FINAL_APPROVAL  },${Role.MODERATOR}`,
+        `${MapStatus.PUBLIC_TESTING  },${MapStatus.FINAL_APPROVAL  },${Role.ADMIN}`,
         `${MapStatus.PUBLIC_TESTING  },${MapStatus.CONTENT_APPROVAL},${Role.MODERATOR}`,
         `${MapStatus.PUBLIC_TESTING  },${MapStatus.CONTENT_APPROVAL},${Role.ADMIN}`,
         `${MapStatus.PUBLIC_TESTING  },${MapStatus.DISABLED        },${Role.MODERATOR}`,

--- a/apps/backend-e2e/src/maps-2.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps-2.e2e-spec.ts
@@ -49,6 +49,7 @@ import {
 import { MapListVersionDto } from '../../backend/src/app/dto/map/map-list-version.dto';
 import path from 'node:path';
 import { LeaderboardStatsDto } from '../../backend/src/app/dto/run/leaderboard-stats.dto';
+import { JsonValue } from 'type-fest';
 
 describe('Maps Part 2', () => {
   let app,
@@ -759,7 +760,15 @@ describe('Maps Part 2', () => {
         async () =>
           ([token, map] = await Promise.all([
             db.loginNewUser(),
-            db.createMap({ zones: ZonesStub })
+            db.createMap({
+              versions: {
+                create: {
+                  zones: ZonesStub as unknown as JsonValue, // TODO: #855
+                  versionNum: 1,
+                  submitter: db.getNewUserCreateData()
+                }
+              }
+            })
           ]))
       );
 

--- a/apps/backend-e2e/src/multi-stage.e2e-spec.ts
+++ b/apps/backend-e2e/src/multi-stage.e2e-spec.ts
@@ -231,7 +231,7 @@ describe('Multi-stage E2E tests', () => {
 
     const { body: mapRes } = await req.get({
       url: `maps/${mapID}`,
-      query: { expand: 'credits,info,leaderboards' },
+      query: { expand: 'credits,info,leaderboards,currentVersion' },
       status: 200,
       token
     });
@@ -268,12 +268,18 @@ describe('Multi-stage E2E tests', () => {
     expect(bsp2Hash).not.toBe(bspHash);
     expect(vmf2Hash).not.toBe(vmfHash);
     expect(
-      (mapRes.downloadURL as string).endsWith('surf_todd_howard.bsp')
+      (mapRes.currentVersion.downloadURL as string).endsWith(
+        `${mapRes.currentVersion.id}.bsp`
+      )
     ).toBeTruthy();
-    const bspDownloadBuffer = await fileStore.downloadHttp(mapRes.downloadURL);
+    const bspDownloadBuffer = await fileStore.downloadHttp(
+      mapRes.currentVersion.downloadURL
+    );
     expect(createSha1Hash(bspDownloadBuffer)).toBe(bsp2Hash);
 
-    const vmfZip = new Zip(await fileStore.downloadHttp(mapRes.vmfDownloadURL));
+    const vmfZip = new Zip(
+      await fileStore.downloadHttp(mapRes.currentVersion.vmfDownloadURL)
+    );
     expect(
       createSha1Hash(vmfZip.getEntry('surf_todd_howard_main.vmf').getData())
     ).toBe(vmf2Hash);

--- a/apps/backend-e2e/src/session.e2e-spec.ts
+++ b/apps/backend-e2e/src/session.e2e-spec.ts
@@ -482,7 +482,7 @@ describe('Session', () => {
           runFlags: 0,
           mapID: map.id,
           mapName: map.name,
-          mapHash: map.hash,
+          mapHash: map.currentVersion.bspHash,
           steamID: user.steamID,
           tickRate: Tickrates.get(map.type),
           startTick: 0,
@@ -545,7 +545,11 @@ describe('Session', () => {
         // So we can screw around with zones in specific tests
         await prisma.mMap.update({
           where: { id: map.id },
-          data: { zones: ZonesStub as unknown as JsonValue }
+          data: {
+            currentVersion: {
+              update: { zones: ZonesStub as unknown as JsonValue }
+            }
+          }
         });
 
         await prisma.mapStats.update({

--- a/apps/backend/src/app/dto/index.ts
+++ b/apps/backend/src/app/dto/index.ts
@@ -18,7 +18,7 @@ export * from './map/map-submission.dto';
 export * from './map/map-submission-approval.dto';
 export * from './map/map-submission-placeholder.dto';
 export * from './map/map-submission-suggestion.dto';
-export * from './map/map-submission-version.dto';
+export * from './map/map-version.dto';
 export * from './map/map-review.dto';
 export * from './map/map-review-comment.dto';
 export * from './map/map-review-suggestions.dto';

--- a/apps/backend/src/app/dto/map/map-submission.dto.ts
+++ b/apps/backend/src/app/dto/map/map-submission.dto.ts
@@ -1,10 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { MapSubmission, MapSubmissionType } from '@momentum/constants';
-import { IsArray, IsOptional, IsUUID } from 'class-validator';
+import { IsArray, IsOptional } from 'class-validator';
 import { Exclude } from 'class-transformer';
 import { NestedProperty } from '../decorators';
 import { MapSubmissionSuggestionDto } from './map-submission-suggestion.dto';
-import { MapSubmissionVersionDto } from './map-submission-version.dto';
 import { MapSubmissionDateDto } from './map-submission-dates.dto';
 import { MapSubmissionPlaceholderDto } from './map-submission-placeholder.dto';
 
@@ -30,14 +29,4 @@ export class MapSubmissionDto implements MapSubmission {
 
   @Exclude()
   readonly mapID: number;
-
-  @NestedProperty(MapSubmissionVersionDto, { required: false })
-  readonly currentVersion: MapSubmissionVersionDto;
-
-  @ApiProperty()
-  @IsUUID()
-  readonly currentVersionID: string;
-
-  @NestedProperty(MapSubmissionVersionDto, { required: false, isArray: true })
-  readonly versions: MapSubmissionVersionDto[];
 }

--- a/apps/backend/src/app/dto/queries/map-queries.dto.ts
+++ b/apps/backend/src/app/dto/queries/map-queries.dto.ts
@@ -73,9 +73,12 @@ export class MapsGetAllQueryDto
   implements MapsGetAllQuery
 {
   @ExpandQueryProperty([
-    'zones',
     'leaderboards',
     'info',
+    'currentVersion',
+    'currentVersionWithZones',
+    'versions',
+    'versionsWithZones',
     'stats',
     'submitter',
     'credits',
@@ -130,17 +133,18 @@ export class MapsGetAllSubmissionQueryDto
   implements MapsGetAllSubmissionQuery
 {
   @ExpandQueryProperty([
-    'zones',
     'leaderboards',
     'info',
+    'currentVersion',
+    'currentVersionWithZones',
+    'versions',
+    'versionsWithZones',
     'stats',
     'submitter',
     'credits',
     'inFavorites',
     'personalBest',
     'worldRecord',
-    'currentVersion',
-    'versions',
     'reviews'
   ])
   readonly expand?: MapsGetAllSubmissionExpand;
@@ -163,9 +167,12 @@ export class MapsGetAllUserSubmissionQueryDto
 
 export class MapsGetQueryDto extends QueryDto implements MapsGetQuery {
   @ExpandQueryProperty([
-    'zones',
     'leaderboards',
     'info',
+    'currentVersion',
+    'currentVersionWithZones',
+    'versions',
+    'versionsWithZones',
     'credits',
     'submitter',
     'stats',
@@ -174,8 +181,6 @@ export class MapsGetQueryDto extends QueryDto implements MapsGetQuery {
     'personalBest',
     'worldRecord',
     'submission',
-    'currentVersion',
-    'versions',
     'reviews',
     'testInvites'
   ])

--- a/apps/backend/src/app/modules/map-review/map-review.service.ts
+++ b/apps/backend/src/app/modules/map-review/map-review.service.ts
@@ -16,13 +16,7 @@ import {
   MapZones,
   Role
 } from '@momentum/constants';
-import {
-  MapReview,
-  MapSubmission,
-  MapSubmissionVersion,
-  Prisma,
-  User
-} from '@prisma/client';
+import { MapReview, Prisma, User } from '@prisma/client';
 import { File } from '@nest-lab/fastify-multer';
 import {
   expandToIncludes,
@@ -172,7 +166,7 @@ export class MapReviewService {
       userID,
       select: {
         status: true,
-        submission: { select: { currentVersion: { select: { zones: true } } } }
+        currentVersion: { select: { zones: true } }
       },
       submissionOnly: true
     });
@@ -185,11 +179,7 @@ export class MapReviewService {
       try {
         validateSuggestions(
           body.suggestions,
-          (
-            map.submission as MapSubmission & {
-              currentVersion: MapSubmissionVersion;
-            }
-          ).currentVersion.zones as unknown as MapZones, // TODO: #855
+          map.currentVersion.zones as unknown as MapZones, // TODO: #855
           SuggestionType.REVIEW
         );
       } catch (error) {
@@ -299,20 +289,14 @@ export class MapReviewService {
       mapID: review.mapID,
       userID,
       submissionOnly: true,
-      include: {
-        submission: { select: { currentVersion: { select: { zones: true } } } }
-      }
+      include: { currentVersion: { select: { zones: true } } }
     });
 
     if (body.suggestions) {
       try {
         validateSuggestions(
           body.suggestions,
-          (
-            map.submission as MapSubmission & {
-              currentVersion: MapSubmissionVersion;
-            }
-          ).currentVersion.zones as unknown as MapZones, // TODO: #855
+          map.currentVersion.zones as unknown as MapZones, // TODO: #855
           SuggestionType.REVIEW
         );
       } catch (error) {

--- a/apps/backend/src/app/modules/maps/map-list.service.ts
+++ b/apps/backend/src/app/modules/maps/map-list.service.ts
@@ -69,7 +69,6 @@ export class MapListService implements OnModuleInit {
       select: {
         id: true,
         name: true,
-        hash: true,
         status: true,
         images: true,
         info: true,
@@ -83,28 +82,11 @@ export class MapListService implements OnModuleInit {
             }
           }
         },
-        submission:
-          type === FlatMapList.SUBMISSION
-            ? {
-                select: {
-                  currentVersion: {
-                    select: {
-                      id: true,
-                      versionNum: true,
-                      hash: true,
-                      changelog: true,
-                      zones: true,
-                      createdAt: true
-                    }
-                  },
-                  type: true,
-                  placeholders: true,
-                  suggestions: true,
-                  dates: true
-                }
-              }
-            : undefined,
-        createdAt: true
+        createdAt: true,
+        currentVersion: { omit: { zones: true, changelog: true } },
+        ...(type === FlatMapList.SUBMISSION
+          ? { submission: true, versions: { omit: { zones: true } } }
+          : {})
       }
     });
 

--- a/apps/backend/src/app/modules/maps/maps.controller.ts
+++ b/apps/backend/src/app/modules/maps/maps.controller.ts
@@ -53,7 +53,6 @@ import {
   CreateMapDto,
   CreateMapReviewDto,
   CreateMapReviewWithFilesDto,
-  CreateMapSubmissionVersionDto,
   CreateMapTestInviteDto,
   CreateMapWithFilesDto,
   LeaderboardRunDto,
@@ -77,7 +76,8 @@ import {
   UpdateMapImagesDto,
   UpdateMapTestInviteDto,
   MapPreSignedUrlDto,
-  VALIDATION_PIPE_CONFIG
+  VALIDATION_PIPE_CONFIG,
+  CreateMapVersionDto
 } from '../../dto';
 import { BypassJwtAuth, LoggedInUser, Roles } from '../../decorators';
 import { ParseIntSafePipe } from '../../pipes';
@@ -241,7 +241,7 @@ export class MapsController {
       'if those are being changed by the user, be sure to send the /:id PATCH first!'
   })
   @ApiBody({
-    type: CreateMapSubmissionVersionDto,
+    type: CreateMapVersionDto,
     required: true
   })
   @ApiOkResponse({ type: MapDto, description: 'Map with new version attached' })
@@ -251,18 +251,13 @@ export class MapsController {
   )
   submitMapVersion(
     @Param('mapID', ParseIntSafePipe) mapID: number,
-    @Body('data') data: CreateMapSubmissionVersionDto,
+    @Body('data') data: CreateMapVersionDto,
     @UploadedFiles() files: { vmfs: File[] },
     @LoggedInUser('id') userID: number
   ): Promise<MapDto> {
     this.mapSubmissionFileValidation(files.vmfs);
 
-    return this.mapsService.submitMapSubmissionVersion(
-      mapID,
-      data,
-      userID,
-      files.vmfs
-    );
+    return this.mapsService.submitMapVersion(mapID, data, userID, files.vmfs);
   }
 
   private mapSubmissionFileValidation(vmfFiles: File[]) {

--- a/apps/backend/src/app/modules/session/run/run-processor.class.spec.ts
+++ b/apps/backend/src/app/modules/session/run/run-processor.class.spec.ts
@@ -40,8 +40,7 @@ describe('RunProcessor', () => {
         mmap: {
           id: 1,
           name: mapName,
-          hash: mapHash,
-          zones: mapZones as any
+          currentVersion: { zones: mapZones as any, bspHash: mapHash }
         } as any,
         user: { id: 1, steamID: 1n } as any
       },

--- a/apps/backend/src/app/modules/session/run/run-session.interface.ts
+++ b/apps/backend/src/app/modules/session/run/run-session.interface.ts
@@ -4,7 +4,7 @@ import { RunStats, Style } from '@momentum/constants';
 export const RUN_SESSION_COMPLETED_INCLUDE = {
   timestamps: true,
   user: true,
-  mmap: true
+  mmap: { include: { currentVersion: true } }
 };
 
 const runSessionCompletedIncludeValidator =

--- a/apps/backend/src/app/modules/session/run/run-session.service.ts
+++ b/apps/backend/src/app/modules/session/run/run-session.service.ts
@@ -167,7 +167,7 @@ export class RunSessionService {
       include: {
         timestamps: { orderBy: { createdAt: 'asc' } },
         user: true,
-        mmap: true
+        mmap: { include: { currentVersion: true } }
       }
     });
 

--- a/apps/frontend/src/app/components/map-list/map-list-item.component.html
+++ b/apps/frontend/src/app/components/map-list/map-list-item.component.html
@@ -106,7 +106,7 @@
             } @else {
               <span class="text-gray-300">Current Status: </span>
               <span class="font-medium text-red-200">{{ MapStatusName.get(map.status) }}</span>
-              @if (!map.hash && !map.submission?.currentVersion?.hash) {
+              @if (!map.currentVersion?.bspHash) {
                 <span class="ml-2 font-bold text-red-500">Files deleted!</span>
               }
             }

--- a/apps/frontend/src/app/components/map-review/map-review-form.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review-form.component.ts
@@ -59,7 +59,7 @@ export class MapReviewFormComponent {
         // validator that fetches the current map zones on the class whenever
         // validator is run.
         suggestionsValidator(
-          () => this.map?.zones ?? this.map?.submission?.currentVersion?.zones,
+          () => this.map?.currentVersion?.zones,
           SuggestionType.REVIEW
         )
       ]

--- a/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.ts
@@ -59,9 +59,7 @@ export class MapReviewSuggestionsFormComponent implements ControlValueAccessor {
         label: GamemodeInfo.get(gamemode).name
       }));
     this.availableBonusTracks =
-      (
-        map?.zones ?? map?.submission?.currentVersion?.zones
-      )?.tracks?.bonuses?.map((_, i) => ({
+      map?.currentVersion?.zones?.tracks?.bonuses?.map((_, i) => ({
         trackNum: i + 1,
         label: i + 1
       })) ?? [];

--- a/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.ts
@@ -92,7 +92,6 @@ export class MapReviewSuggestionsFormComponent implements ControlValueAccessor {
           .map(({ trackNum }) => trackNum)
       );
 
-      trackNum = 1;
       while (bonusNums.has(trackNum)) trackNum++;
     }
 

--- a/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.ts
+++ b/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.ts
@@ -172,7 +172,7 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
     suggestions: new FormControl<MapSubmissionSuggestion[]>([], {
       validators: [
         suggestionsValidator(
-          () => this.map?.zones ?? this.map?.submission?.currentVersion?.zones,
+          () => this.map?.currentVersion.zones,
           SuggestionType.SUBMISSION
         )
       ]
@@ -242,10 +242,9 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
             expand: [
               'submission',
               'versions',
-              'currentVersion',
+              'currentVersionWithZones',
               'info',
               'credits',
-              'zones',
               'leaderboards',
               'reviews',
               'testInvites'
@@ -311,13 +310,12 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
       )
     );
 
-    this.lbSelection.zones =
-      this.map?.zones ?? this.map.submission?.currentVersion?.zones;
+    this.lbSelection.zones = this.map?.currentVersion?.zones;
     this.suggestions.setValue(this.map.submission.suggestions);
 
     if (this.map.status === MapStatus.FINAL_APPROVAL) {
       const validatorFn = suggestionsValidator(
-        () => this.map?.zones ?? this.map.submission?.currentVersion?.zones,
+        () => this.map?.currentVersion?.zones,
         SuggestionType.APPROVAL
       );
       this.status.valueChanges
@@ -550,7 +548,7 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
     } catch (error) {
       this.messageService.add({
         severity: 'error',
-        summary: 'Failed to post submission version!',
+        summary: 'Failed to post version!',
         detail: JSON.stringify(error.error.message)
       });
       this.isUploading = false;

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -34,7 +34,7 @@
           <m-icon class="mr-2 pb-0.5" icon="play-circle" />
           Play
         </button>
-        @if (map.downloadURL ?? map.submission?.currentVersion?.downloadURL; as bsp) {
+        @if (map.currentVersion.downloadURL; as bsp) {
           <a (click)="downloadOverlay.show($event)" class="btn btn-purple" mTooltip="Download map file">
             <m-icon class="pb-0.5" icon="download" />
             <p-overlayPanel #downloadOverlay appendTo="body">
@@ -48,7 +48,7 @@
                 <p>
                   <a class="link cursor-pointer" (click)="downloadZoneFile(map)">Download Zones</a>
                 </p>
-                @if (map.vmfDownloadURL ?? map.submission?.currentVersion?.vmfDownloadURL; as vmf) {
+                @if (map.currentVersion?.vmfDownloadURL; as vmf) {
                   <p><a class="link" [href]="vmf">Download VMF</a></p>
                 }
               </div>
@@ -168,7 +168,7 @@
         } @else if (map.status === MapStatus.DISABLED) {
           <div class="flex flex-col items-center gap-2 border border-red-500 bg-red-500 bg-opacity-50 p-3 text-center">
             <b>Map Disabled</b>
-            @if (map.hash || map.submission?.currentVersion?.hash) {
+            @if (map.currentVersion?.bspHash) {
               <i>This map is currently disabled. It's only visible to moderators and admins, and can only be re-enabled by admins.</i>
             } @else {
               <i>

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.ts
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.ts
@@ -123,7 +123,6 @@ export class MapInfoComponent implements OnInit {
           this.mapService.getMap(params.get('name'), {
             expand: [
               'info',
-              'zones',
               'leaderboards',
               'credits',
               'submitter',
@@ -131,7 +130,12 @@ export class MapInfoComponent implements OnInit {
               'inFavorites',
               'submission',
               'versions',
-              'currentVersion'
+              // Map review system needs zones to work, so we have to fetch
+              // zones. This is very annoying; we'd really rather avoid
+              // having to fetch so much data. However, we don't know whether
+              // we map review stuff prior to response to this query since we
+              // don't know the status. Maybe worth rethinking in future.
+              'currentVersionWithZones'
             ]
           })
         ),

--- a/apps/frontend/src/app/pages/maps/map-info/map-submission/map-submission.component.ts
+++ b/apps/frontend/src/app/pages/maps/map-info/map-submission/map-submission.component.ts
@@ -4,9 +4,9 @@ import {
   MapSubmissionType,
   MapStatusName,
   TrackType,
-  MapSubmissionVersion,
   LeaderboardType,
-  GamemodeInfo
+  GamemodeInfo,
+  MapVersion
 } from '@momentum/constants';
 import { SharedModule } from '../../../../shared.module';
 import {
@@ -32,7 +32,7 @@ export class MapSubmissionComponent {
   protected readonly downloadZoneFile = downloadZoneFile;
 
   protected suggestions: GroupedMapSubmissionSuggestions;
-  protected versions: MapSubmissionVersion[];
+  protected versions: MapVersion[];
   protected visibleVersions: number;
 
   private _map: MMap;
@@ -42,7 +42,7 @@ export class MapSubmissionComponent {
   @Input({ required: true }) set map(map: MMap) {
     this._map = map;
     this.suggestions = groupMapSuggestions(map.submission.suggestions);
-    this.versions = map?.submission?.versions.toReversed();
+    this.versions = map?.versions.toReversed();
     this.visibleVersions = 2;
   }
 }

--- a/apps/frontend/src/app/services/data/maps.service.ts
+++ b/apps/frontend/src/app/services/data/maps.service.ts
@@ -21,7 +21,7 @@ import {
   UpdateMapReview,
   UpdateMap,
   UpdateMapImagesWithFiles,
-  CreateMapSubmissionVersionWithFiles,
+  CreateMapVersionWithFiles,
   CreateMapTestInvite,
   MapPreSignedUrl
 } from '@momentum/constants';
@@ -92,7 +92,7 @@ export class MapsService {
 
   submitMapVersion(
     mapID: number,
-    { data, vmfs }: CreateMapSubmissionVersionWithFiles
+    { data, vmfs }: CreateMapVersionWithFiles
   ): Observable<HttpEvent<string>> {
     const formData = new FormData();
 

--- a/apps/frontend/src/app/util/download-zone-file.util.ts
+++ b/apps/frontend/src/app/util/download-zone-file.util.ts
@@ -1,4 +1,4 @@
-import { CombinedMapStatuses, MMap } from '@momentum/constants';
+import { MMap } from '@momentum/constants';
 
 /**
  * Creates a blob of prettified map zones and downloads it using silly browser
@@ -6,9 +6,7 @@ import { CombinedMapStatuses, MMap } from '@momentum/constants';
  * https://stackoverflow.com/a/52183135
  */
 export function downloadZoneFile(map: MMap) {
-  const zones = CombinedMapStatuses.IN_SUBMISSION.includes(map.status)
-    ? map.submission?.currentVersion?.zones
-    : map.zones;
+  const zones = map?.currentVersion?.zones;
   if (!zones?.formatVersion || !map.name) {
     console.error('Bad map data, could not create zones file!');
     return;

--- a/libs/constants/src/consts/file-store-paths.const.ts
+++ b/libs/constants/src/consts/file-store-paths.const.ts
@@ -1,19 +1,11 @@
 import { FlatMapList } from '../enums/flat-map-list.enum';
 
-export function approvedBspPath(key: string | number): string {
+export function bspPath(key: string | number): string {
   return `maps/${key}.bsp`;
 }
 
-export function approvedVmfsPath(key: string | number): string {
+export function vmfsPath(key: string | number): string {
   return `maps/${key}_VMFs.zip`;
-}
-
-export function submissionBspPath(key: string | number): string {
-  return `submissions/${key}.bsp`;
-}
-
-export function submissionVmfsPath(key: string | number): string {
-  return `submissions/${key}_VMFs.zip`;
 }
 
 export function imgSmallPath(key: string): string {

--- a/libs/constants/src/maps/map-status-change-rules.map.ts
+++ b/libs/constants/src/maps/map-status-change-rules.map.ts
@@ -43,7 +43,7 @@ export const MapStatusChangeRules: ReadonlyArray<{from: MapStatus; to: MapStatus
   { from: MapStatus.PUBLIC_TESTING,   to: MapStatus.PRIVATE_TESTING,  roles: []},
   { from: MapStatus.PUBLIC_TESTING,   to: MapStatus.CONTENT_APPROVAL, roles: [Role.ADMIN, Role.MODERATOR]},
   { from: MapStatus.PUBLIC_TESTING,   to: MapStatus.PUBLIC_TESTING,   roles: []},
-  { from: MapStatus.PUBLIC_TESTING,   to: MapStatus.FINAL_APPROVAL,   roles: ['submitter']},
+  { from: MapStatus.PUBLIC_TESTING,   to: MapStatus.FINAL_APPROVAL,   roles: ['submitter', Role.ADMIN, Role.MODERATOR]},
   { from: MapStatus.PUBLIC_TESTING,   to: MapStatus.DISABLED,         roles: [Role.ADMIN, Role.MODERATOR]},
 
   { from: MapStatus.FINAL_APPROVAL,   to: MapStatus.APPROVED,         roles: [Role.ADMIN, Role.MODERATOR]},

--- a/libs/constants/src/types/models/models.ts
+++ b/libs/constants/src/types/models/models.ts
@@ -174,13 +174,12 @@ export interface MMap {
   id: number;
   name: string;
   status: MapStatus;
-  downloadURL: string;
-  hash: string;
-  vmfDownloadURL: string;
   submitterID: number;
   createdAt: DateString;
   updatedAt: DateString;
-  zones: MapZones;
+  currentVersion: MapVersion;
+  currentVersionID: string;
+  versions: MapVersion[];
   info: MapInfo;
   submission: MapSubmission;
   submitter: User;
@@ -193,6 +192,19 @@ export interface MMap {
   worldRecords: LeaderboardRun[];
   personalBests: LeaderboardRun[];
   testInvites?: MapTestInvite[];
+}
+
+export interface MapVersion {
+  id: string;
+  versionNum: number;
+  submitterID: number | null;
+  changelog: string;
+  zones: MapZones;
+  bspHash: string;
+  zoneHash: string;
+  downloadURL: string;
+  vmfDownloadURL?: string;
+  createdAt: DateString;
 }
 
 export interface MapInfo {
@@ -309,8 +321,6 @@ export interface MapSubmission {
   suggestions: MapSubmissionSuggestion[];
   placeholders: MapSubmissionPlaceholder[];
   dates: MapSubmissionDate[];
-  currentVersion: MapSubmissionVersion;
-  versions: MapSubmissionVersion[];
 }
 
 export interface MapSubmissionApproval {
@@ -340,17 +350,6 @@ export interface MapSubmissionSuggestion {
   type: LeaderboardType.RANKED | LeaderboardType.UNRANKED;
   comment?: string;
   //  TODO: Tags!
-}
-
-export interface MapSubmissionVersion {
-  id: string;
-  versionNum: number;
-  changelog: string;
-  zones: MapZones;
-  hash: string;
-  downloadURL: string;
-  vmfDownloadURL?: string;
-  createdAt: DateString;
 }
 
 export type MapTags = string[];

--- a/libs/constants/src/types/models/prisma-correspondence.ts
+++ b/libs/constants/src/types/models/prisma-correspondence.ts
@@ -127,12 +127,12 @@ assertTypeCorrespondence<
   { mapID: OmitMe; currentVersionID: OmitMe }
 >();
 
-import { MapSubmissionVersion } from './models';
-import { MapSubmissionVersion as PMapSubmissionVersion } from '@prisma/client';
+import { MapVersion } from './models';
+import { MapVersion as PMapVersion } from '@prisma/client';
 assertTypeCorrespondence<
-  MapSubmissionVersion,
-  PMapSubmissionVersion,
-  { hasVmf: OmitMe; submissionID: OmitMe }
+  MapVersion,
+  PMapVersion,
+  { hasVmf: OmitMe; mapID: OmitMe }
 >();
 
 //#endregion

--- a/libs/constants/src/types/queries/map-queries.model.ts
+++ b/libs/constants/src/types/queries/map-queries.model.ts
@@ -13,7 +13,7 @@ import {
   MapSubmissionApproval,
   MapSubmissionPlaceholder,
   MapSubmissionSuggestion,
-  MapSubmissionVersion,
+  MapVersion,
   MapZones,
   MMap
 } from '../../';
@@ -21,11 +21,14 @@ import {
 //#region Map
 
 type BaseMapsGetAllExpand =
-  | 'zones'
   | 'leaderboards'
   | 'info'
   | 'stats'
   | 'submitter'
+  | 'currentVersionWithZones'
+  | 'currentVersion'
+  | 'versions'
+  | 'versionsWithZones'
   | 'credits';
 
 export type MapsGetAllExpand = Array<
@@ -37,8 +40,6 @@ export type MapsGetAllSubmissionExpand = Array<
   | 'inFavorites'
   | 'personalBest'
   | 'worldRecord'
-  | 'currentVersion'
-  | 'versions'
   | 'reviews'
 >;
 
@@ -199,14 +200,14 @@ export type MapLeaderboardGetRunQuery = PagedQuery & {
 //#endregion
 //#region Submissions
 
-export interface CreateMapSubmissionVersion
-  extends Pick<MapSubmissionVersion, 'changelog' | 'zones'> {
+export interface CreateMapVersion
+  extends Pick<MapVersion, 'changelog' | 'zones'> {
   resetLeaderboards?: boolean;
 }
 
-export interface CreateMapSubmissionVersionWithFiles {
+export interface CreateMapVersionWithFiles {
   vmfs: File[];
-  data: CreateMapSubmissionVersion;
+  data: CreateMapVersion;
 }
 
 //#endregion

--- a/libs/db/project.json
+++ b/libs/db/project.json
@@ -36,7 +36,8 @@
       "executor": "nx:run-commands",
       "options": {
         "command": "prisma migrate dev --skip-seed --name",
-        "cwd": "libs/db/src"
+        "cwd": "libs/db/src",
+        "parallel": false
       }
     },
     "seed": {

--- a/libs/db/src/migrations/20240903162533_map_versions/migration.sql
+++ b/libs/db/src/migrations/20240903162533_map_versions/migration.sql
@@ -1,0 +1,66 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `updatedAt` on the `Follow` table. All the data in the column will be lost.
+  - You are about to drop the column `hasVmf` on the `MMap` table. All the data in the column will be lost.
+  - You are about to drop the column `hash` on the `MMap` table. All the data in the column will be lost.
+  - You are about to drop the column `zones` on the `MMap` table. All the data in the column will be lost.
+  - You are about to drop the column `currentVersionID` on the `MapSubmission` table. All the data in the column will be lost.
+  - You are about to drop the `MapSubmissionVersion` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[currentVersionID]` on the table `MMap` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "MapSubmission" DROP CONSTRAINT "MapSubmission_currentVersionID_fkey";
+
+-- DropForeignKey
+ALTER TABLE "MapSubmissionVersion" DROP CONSTRAINT "MapSubmissionVersion_submissionID_fkey";
+
+-- DropIndex
+DROP INDEX "MapSubmission_currentVersionID_key";
+
+-- AlterTable
+ALTER TABLE "Follow" DROP COLUMN "updatedAt";
+
+-- AlterTable
+ALTER TABLE "MMap" DROP COLUMN "hasVmf",
+DROP COLUMN "hash",
+DROP COLUMN "zones",
+ADD COLUMN     "currentVersionID" UUID;
+
+-- AlterTable
+ALTER TABLE "MapSubmission" DROP COLUMN "currentVersionID";
+
+-- DropTable
+DROP TABLE "MapSubmissionVersion";
+
+-- CreateTable
+CREATE TABLE "MapVersion" (
+    "id" UUID NOT NULL,
+    "versionNum" SMALLINT NOT NULL,
+    "changelog" TEXT,
+    "bspHash" CHAR(40),
+    "zoneHash" CHAR(40),
+    "hasVmf" BOOLEAN NOT NULL DEFAULT false,
+    "zones" JSONB,
+    "submitterID" INTEGER,
+    "mapID" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MapVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MapVersion_mapID_idx" ON "MapVersion"("mapID");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MMap_currentVersionID_key" ON "MMap"("currentVersionID");
+
+-- AddForeignKey
+ALTER TABLE "MMap" ADD CONSTRAINT "MMap_currentVersionID_fkey" FOREIGN KEY ("currentVersionID") REFERENCES "MapVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MapVersion" ADD CONSTRAINT "MapVersion_submitterID_fkey" FOREIGN KEY ("submitterID") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MapVersion" ADD CONSTRAINT "MapVersion_mapID_fkey" FOREIGN KEY ("mapID") REFERENCES "MMap"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/db/src/schema.prisma
+++ b/libs/db/src/schema.prisma
@@ -1,5 +1,5 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
   previewFeatures = ["tracing"]
 }
 
@@ -20,27 +20,27 @@ model User {
   avatar  String?
   country String? @db.Char(2)
 
-  userAuth          UserAuth?
-  profile           Profile?
-  userStats         UserStats?
-  submittedMaps     MMap[]
-  mapCredits        MapCredit[]
-  mapFavorites      MapFavorite[]
-  activities        Activity[]
-  follows           Follow[]           @relation("follow_follow")
-  followers         Follow[]           @relation("follow_follower")
-  mapNotifies       MapNotify[]
-  notifications     Notification[]
-  runSessions       RunSession[]
-  leaderboardRuns   LeaderboardRun[]
-  pastRuns          PastRun[]
-  reportSubmitted   Report[]           @relation("report_submitter")
-  reportResolved    Report[]           @relation("report_resolver")
-  testInvites       MapTestInvite[]
-  reviewsSubmitted  MapReview[]        @relation("mapreview_reviewer")
-  reviewsResolved   MapReview[]        @relation("mapreview_resolver")
-  reviewComments    MapReviewComment[]
-  adminActivities   AdminActivity[]
+  userAuth         UserAuth?
+  profile          Profile?
+  userStats        UserStats?
+  submittedMaps    MMap[]
+  mapCredits       MapCredit[]
+  mapFavorites     MapFavorite[]
+  activities       Activity[]
+  follows          Follow[]           @relation("follow_follow")
+  followers        Follow[]           @relation("follow_follower")
+  mapNotifies      MapNotify[]
+  notifications    Notification[]
+  runSessions      RunSession[]
+  leaderboardRuns  LeaderboardRun[]
+  pastRuns         PastRun[]
+  reportSubmitted  Report[]           @relation("report_submitter")
+  reportResolved   Report[]           @relation("report_resolver")
+  testInvites      MapTestInvite[]
+  reviewsSubmitted MapReview[]        @relation("mapreview_reviewer")
+  reviewsResolved  MapReview[]        @relation("mapreview_resolver")
+  reviewComments   MapReviewComment[]
+  adminActivities  AdminActivity[]
 
   createdAt DateTime @default(now())
 }

--- a/libs/db/src/schema.prisma
+++ b/libs/db/src/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["tracing"]
+  previewFeatures = ["tracing", "omitApi"]
 }
 
 datasource db {

--- a/libs/db/src/schema.prisma
+++ b/libs/db/src/schema.prisma
@@ -20,27 +20,28 @@ model User {
   avatar  String?
   country String? @db.Char(2)
 
-  userAuth         UserAuth?
-  profile          Profile?
-  userStats        UserStats?
-  submittedMaps    MMap[]
-  mapCredits       MapCredit[]
-  mapFavorites     MapFavorite[]
-  activities       Activity[]
-  follows          Follow[]           @relation("follow_follow")
-  followers        Follow[]           @relation("follow_follower")
-  mapNotifies      MapNotify[]
-  notifications    Notification[]
-  runSessions      RunSession[]
-  leaderboardRuns  LeaderboardRun[]
-  pastRuns         PastRun[]
-  reportSubmitted  Report[]           @relation("report_submitter")
-  reportResolved   Report[]           @relation("report_resolver")
-  testInvites      MapTestInvite[]
-  reviewsSubmitted MapReview[]        @relation("mapreview_reviewer")
-  reviewsResolved  MapReview[]        @relation("mapreview_resolver")
-  reviewComments   MapReviewComment[]
-  adminActivities  AdminActivity[]
+  userAuth             UserAuth?
+  profile              Profile?
+  userStats            UserStats?
+  submittedMaps        MMap[]
+  submittedMapVersions MapVersion[]
+  mapCredits           MapCredit[]
+  mapFavorites         MapFavorite[]
+  activities           Activity[]
+  follows              Follow[]           @relation("follow_follow")
+  followers            Follow[]           @relation("follow_follower")
+  mapNotifies          MapNotify[]
+  notifications        Notification[]
+  runSessions          RunSession[]
+  leaderboardRuns      LeaderboardRun[]
+  pastRuns             PastRun[]
+  reportSubmitted      Report[]           @relation("report_submitter")
+  reportResolved       Report[]           @relation("report_resolver")
+  testInvites          MapTestInvite[]
+  reviewsSubmitted     MapReview[]        @relation("mapreview_reviewer")
+  reviewsResolved      MapReview[]        @relation("mapreview_resolver")
+  reviewComments       MapReviewComment[]
+  adminActivities      AdminActivity[]
 
   createdAt DateTime @default(now())
 }
@@ -173,9 +174,6 @@ model MMap {
 
   name   String   @unique
   status Int      @db.SmallInt /// map-status.enum.ts
-  hash   String?  @db.Char(40)
-  hasVmf Boolean  @default(false)
-  zones  Json? /// map-zones.model.ts
   images String[]
 
   submitter   User? @relation(fields: [submitterID], references: [id], onDelete: SetNull)
@@ -184,6 +182,10 @@ model MMap {
   stats MapStats?
   info  MapInfo?
 
+  currentVersion   MapVersion? @relation(name: "current_version", fields: [currentVersionID], references: [id])
+  currentVersionID String?     @unique @db.Uuid
+
+  versions        MapVersion[]
   leaderboards    Leaderboard[]
   leaderboardRuns LeaderboardRun[]
   pastRuns        PastRun[]
@@ -202,6 +204,29 @@ model MMap {
   // @unique on name provides an index.
   @@index([submitterID])
   @@index([status, createdAt(sort: Desc)])
+}
+
+model MapVersion {
+  id String @id @default(uuid()) @db.Uuid // BSP file stored relative to this
+
+  versionNum Int     @db.SmallInt
+  changelog  String?
+  bspHash    String? @db.Char(40) // Nullable as we set to null if we delete files if map gets "deleted" (disabled)
+  zoneHash   String? @db.Char(40) // Nullable as we set to null if we delete files if map gets "deleted" (disabled)
+  hasVmf     Boolean @default(false)
+  zones      Json? /// map-zones.model.ts
+
+  submitterID Int?
+  submitter   User? @relation(fields: [submitterID], references: [id])
+
+  currentVersion MMap? @relation(name: "current_version")
+
+  mmap  MMap @relation(fields: [mapID], references: [id], onDelete: Cascade)
+  mapID Int
+
+  createdAt DateTime @default(now())
+
+  @@index([mapID])
 }
 
 model MapCredit {
@@ -281,30 +306,6 @@ model MapSubmission {
   suggestions  Json  @default("[]") /// Array of map-submission-suggestions.model.ts
   placeholders Json? /// Array of map-submission-placeholder.model.ts
   dates        Json  @default("[]") /// Array of map-submission-dates.model.ts
-
-  versions MapSubmissionVersion[]
-
-  currentVersion   MapSubmissionVersion? @relation(name: "current_version", fields: [currentVersionID], references: [id])
-  currentVersionID String?               @unique @db.Uuid
-}
-
-model MapSubmissionVersion {
-  id String @id @default(uuid()) @db.Uuid // BSP file stored relative to this
-
-  currentVersion MapSubmission? @relation(name: "current_version")
-
-  versionNum Int     @db.SmallInt
-  changelog  String?
-  hash       String? @db.Char(40) // Nullable as we set to null if we delete files if map gets "deleted" (disabled)
-  hasVmf     Boolean @default(false)
-  zones      Json? /// map-zones.model.ts
-
-  submission   MapSubmission @relation(fields: [submissionID], references: [mapID], onDelete: Cascade)
-  submissionID Int
-
-  createdAt DateTime @default(now())
-
-  @@index([submissionID])
 }
 
 // This model will be greatly expanded in the future to include screenshots,


### PR DESCRIPTION
Closes #1006
Closes #857

Replaces the `MapSubmissionVersion` table with `MapVersion`. Map storage is now always using the zone system, even for approved maps. Previously, prior to approval maps, would be stored at `submissions/<MapSubmissionVersion UUID ID>.bsp`, then upon approval moved to `maps/<map name>.bsp`. Now, all maps are just stored at `maps/<MapVersion UUID ID>.bsp`. This makes frontend and game code quite a lot simpler.

Whilst I haven't done admin map updating quite yet (https://github.com/momentum-mod/website/issues/916), this change is essential to that system.

Also, since zones are now always stored on MapVersion, so always requires a join table to fetch, it's a lot easier to avoid fetching the zones JSON unnecessarily, plus I added Prisma's preview "omit" API which simplifies code even more. So https://github.com/momentum-mod/website/issues/857 can be closed in the process. 

### Checks

- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have ran `nx run db:create-migration` and committed the migration if I've made DB schema changes
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
