### PR TITLE
Use plain strings for map zones

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,7 +81,7 @@ module.exports = {
             selector: 'variable',
             types: ['boolean', 'string', 'number'],
             modifiers: ['exported'],
-            format: ['strictCamelCase', 'UPPER_CASE']
+            format: ['strictCamelCase', 'UPPER_CASE', 'PascalCase']
           },
           {
             selector: 'class',

--- a/apps/backend-e2e/src/admin.e2e-spec.ts
+++ b/apps/backend-e2e/src/admin.e2e-spec.ts
@@ -7,7 +7,6 @@ import {
   ReportDto,
   UserDto
 } from '../../backend/src/app/dto';
-
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import {
@@ -43,11 +42,10 @@ import {
 import { Prisma, PrismaClient } from '@prisma/client';
 import Zip from 'adm-zip';
 import {
-  BabyZonesStub,
-  ZonesStub,
-  ZonesStubLeaderboards
+  BabyZonesStubString,
+  ZonesStubLeaderboards,
+  ZonesStubString
 } from '@momentum/formats/zone';
-import { JsonValue } from 'type-fest';
 import {
   setupE2ETestEnvironment,
   teardownE2ETestEnvironment
@@ -962,13 +960,13 @@ describe('Admin', () => {
                   bspHash: createSha1Hash(
                     'apple banana cat dog elephant fox grape hat igloo joker'
                   ),
-                  zones: BabyZonesStub as unknown as JsonValue, // TODO: #855
+                  zones: BabyZonesStubString,
                   submitterID: u1.id
                 },
                 {
                   versionNum: 2,
                   bspHash,
-                  zones: BabyZonesStub as unknown as JsonValue, // TODO: #855
+                  zones: BabyZonesStubString,
                   submitterID: u1.id
                 }
               ]
@@ -1227,7 +1225,7 @@ describe('Admin', () => {
                 ...createMapData,
                 versions: {
                   create: {
-                    zones: BabyZonesStub as unknown as JsonValue, // TODO: #855
+                    zones: BabyZonesStubString,
                     versionNum: 1,
                     bspHash: createSha1Hash(bspBuffer),
                     submitterID: u1.id
@@ -1293,7 +1291,7 @@ describe('Admin', () => {
           ...createMapData,
           versions: {
             create: {
-              zones: BabyZonesStub as unknown as JsonValue, // TODO: #855
+              zones: BabyZonesStubString,
               versionNum: 1,
               bspHash: createSha1Hash(bspBuffer),
               submitterID: u1.id
@@ -1360,7 +1358,7 @@ describe('Admin', () => {
             create: {
               versionNum: 1,
               bspHash: createSha1Hash(bspBuffer),
-              zones: BabyZonesStub as unknown as JsonValue, // TODO: #855
+              zones: BabyZonesStubString,
               submitterID: u1.id
             }
           },
@@ -1455,14 +1453,14 @@ describe('Admin', () => {
                   {
                     versionNum: 1,
                     bspHash,
-                    zones: ZonesStub as any,
+                    zones: ZonesStubString,
                     hasVmf: true,
                     submitterID: u1.id
                   },
                   {
                     versionNum: 2,
                     bspHash,
-                    zones: ZonesStub as any,
+                    zones: ZonesStubString,
                     hasVmf: true,
                     submitterID: u1.id
                   }

--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -2,7 +2,6 @@
 
 import { Config } from '../../backend/src/app/config';
 import { MapDto } from '../../backend/src/app/dto';
-
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
@@ -38,14 +37,14 @@ import * as Enum from '@momentum/enum';
 import {
   generateRandomMapZones,
   ZonesStub,
-  ZonesStubLeaderboards
+  ZonesStubLeaderboards,
+  ZonesStubString
 } from '@momentum/formats/zone';
 import { arrayFrom } from '@momentum/util-fn';
 import {
   setupE2ETestEnvironment,
   teardownE2ETestEnvironment
 } from './support/environment';
-import { JsonValue } from 'type-fest';
 
 describe('Maps', () => {
   let app,
@@ -891,7 +890,9 @@ describe('Maps', () => {
           expect(
             Date.now() - new Date(createdMap.submission.dates[0].date).getTime()
           ).toBeLessThan(1000);
-          expect(createdMap.currentVersion.zones).toMatchObject(zones);
+          expect(JSON.parse(createdMap.currentVersion.zones)).toMatchObject(
+            zones
+          );
           expect(createdMap.currentVersion.submitterID).toBe(user.id);
           expect(createdMap.versions[0]).toMatchObject(
             createdMap.currentVersion
@@ -1795,7 +1796,7 @@ describe('Maps', () => {
             status: MapStatus.PRIVATE_TESTING,
             versions: {
               create: {
-                zones: ZonesStub as unknown as JsonValue, // TODO: #855
+                zones: ZonesStubString,
                 versionNum: 1,
                 bspHash: createSha1Hash(Buffer.from('hash browns')),
                 submitter: { connect: { id: u1.id } }
@@ -2507,7 +2508,7 @@ describe('Maps', () => {
           },
           versions: {
             create: {
-              zones: ZonesStub,
+              zones: ZonesStubString,
               versionNum: 1,
               bspHash: createSha1Hash(Buffer.from('shashashs')),
               submitter: { connect: { id: user.id } }
@@ -2675,7 +2676,7 @@ describe('Maps', () => {
               },
               versions: {
                 create: {
-                  zones: ZonesStub,
+                  zones: ZonesStubString,
                   versionNum: 1,
                   bspHash: createSha1Hash(Buffer.from('shashashs')),
                   submitter: { connect: { id: user.id } }
@@ -2733,7 +2734,7 @@ describe('Maps', () => {
           },
           versions: {
             create: {
-              zones: ZonesStub,
+              zones: ZonesStubString,
               versionNum: 1,
               bspHash: createSha1Hash(Buffer.from('shashashs')),
               submitter: { connect: { id: user.id } }
@@ -2787,7 +2788,7 @@ describe('Maps', () => {
           },
           versions: {
             create: {
-              zones: ZonesStub,
+              zones: ZonesStubString,
               versionNum: 1,
               bspHash: createSha1Hash(Buffer.from('shashashs')),
               submitter: { connect: { id: user.id } }
@@ -2837,7 +2838,7 @@ describe('Maps', () => {
           },
           versions: {
             create: {
-              zones: ZonesStub,
+              zones: ZonesStubString,
               versionNum: 1,
               bspHash: createSha1Hash(Buffer.from('shashashs')),
               submitter: { connect: { id: user.id } }
@@ -3095,7 +3096,7 @@ describe('Maps', () => {
           versions: {
             create: {
               // Has a bonus
-              zones: ZonesStub,
+              zones: ZonesStubString,
               versionNum: 1,
               bspHash: createSha1Hash(Buffer.from('shashashs')),
               submitter: { connect: { id: user.id } }

--- a/apps/backend-e2e/src/session.e2e-spec.ts
+++ b/apps/backend-e2e/src/session.e2e-spec.ts
@@ -22,8 +22,7 @@ import {
   TrackType
 } from '@momentum/constants';
 import { PrismaClient } from '@prisma/client';
-import { ZonesStub } from '@momentum/formats/zone';
-import { JsonValue } from 'type-fest';
+import { ZonesStubString } from '@momentum/formats/zone';
 import {
   setupE2ETestEnvironment,
   teardownE2ETestEnvironment
@@ -547,7 +546,7 @@ describe('Session', () => {
           where: { id: map.id },
           data: {
             currentVersion: {
-              update: { zones: ZonesStub as unknown as JsonValue }
+              update: { zones: ZonesStubString }
             }
           }
         });

--- a/apps/backend/src/app/app.module.ts
+++ b/apps/backend/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
-import { LoggerModule } from 'nestjs-pino';
+import { LoggerModule, Params as PinoParams } from 'nestjs-pino';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { FastifyMulterModule } from '@nest-lab/fastify-multer';
 import { ExceptionHandlerFilter } from './filters/exception-handler.filter';
@@ -35,7 +35,7 @@ import { setupNestInterceptor } from '../instrumentation';
     // all HTTP requests (so no need for a Nest interceptor).
     // In dev mode, outputs as more human-readable strings using `pino-pretty`.
     LoggerModule.forRootAsync({
-      useFactory: async (config: ConfigService) => ({
+      useFactory: async (config: ConfigService): Promise<PinoParams> => ({
         pinoHttp: {
           customProps: (_req, _res) => ({ context: 'HTTP' }),
           level: config.getOrThrow('logLevel'),

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -69,9 +69,8 @@ export const ConfigFactory = (): ConfigInterface => {
       maxCreditsExceptTesters: MAX_CREDITS_EXCEPT_TESTERS,
       preSignedUrlExpTime: PRE_SIGNED_URL_EXPIRE_TIME
     },
-    logLevel: ((process.env['LOG_LEVEL'] ?? isTest)
-      ? 'warn'
-      : 'info') as pino.LevelWithSilent
+    logLevel: (process.env['LOG_LEVEL'] ??
+      (isTest ? 'warn' : 'info')) as pino.LevelWithSilent
   };
 };
 

--- a/apps/backend/src/app/modules/map-review/map-review.service.ts
+++ b/apps/backend/src/app/modules/map-review/map-review.service.ts
@@ -13,7 +13,6 @@ import {
   mapReviewAssetPath,
   MapReviewEdit,
   MapReviewSuggestion,
-  MapZones,
   Role
 } from '@momentum/constants';
 import { MapReview, Prisma, User } from '@prisma/client';
@@ -179,7 +178,7 @@ export class MapReviewService {
       try {
         validateSuggestions(
           body.suggestions,
-          map.currentVersion.zones as unknown as MapZones, // TODO: #855
+          JSON.parse(map.currentVersion.zones),
           SuggestionType.REVIEW
         );
       } catch (error) {
@@ -296,7 +295,7 @@ export class MapReviewService {
       try {
         validateSuggestions(
           body.suggestions,
-          map.currentVersion.zones as unknown as MapZones, // TODO: #855
+          JSON.parse(map.currentVersion.zones),
           SuggestionType.REVIEW
         );
       } catch (error) {

--- a/apps/backend/src/app/modules/maps/maps.controller.ts
+++ b/apps/backend/src/app/modules/maps/maps.controller.ts
@@ -463,11 +463,10 @@ export class MapsController {
     description: "The map's zones"
   })
   @ApiNotFoundResponse({ description: 'Map not found' })
-  getZones(
-    @Param('mapID', ParseIntSafePipe) mapID: number
-  ): Promise<MapZonesDto> {
+  getZones(@Param('mapID', ParseIntSafePipe) mapID: number): Promise<string> {
     return this.mapsService.getZones(mapID);
   }
+
   //#endregion
 
   //#region Images

--- a/apps/backend/src/app/modules/session/run/run-processor.class.spec.ts
+++ b/apps/backend/src/app/modules/session/run/run-processor.class.spec.ts
@@ -40,7 +40,7 @@ describe('RunProcessor', () => {
         mmap: {
           id: 1,
           name: mapName,
-          currentVersion: { zones: mapZones as any, bspHash: mapHash }
+          currentVersion: { zones: JSON.stringify(mapZones), bspHash: mapHash }
         } as any,
         user: { id: 1, steamID: 1n } as any
       },

--- a/apps/backend/src/app/modules/session/run/run-processor.class.ts
+++ b/apps/backend/src/app/modules/session/run/run-processor.class.ts
@@ -36,7 +36,7 @@ export class RunProcessor {
     this.startTime = session.createdAt.getTime();
     this.timestamps = session.timestamps;
     this.map = session.mmap;
-    this.zones = session.mmap.currentVersion.zones as unknown as MapZones; // TODO: #855
+    this.zones = JSON.parse(session.mmap.currentVersion.zones);
     this.userID = user.id;
     this.steamID = user.steamID;
   }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -68,8 +68,8 @@ services:
       - "3000:3000"
     command: >
       sh -c "
-        npm install
-        npx nx run db:push &&
+        npm install &&
+        npx nx run db:deploy &&
         npx nx run backend-e2e:e2e
       "
   frontend-e2e:

--- a/libs/db/project.json
+++ b/libs/db/project.json
@@ -32,6 +32,13 @@
         "cwd": "libs/db/src"
       }
     },
+    "deploy": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "prisma migrate deploy",
+        "cwd": "libs/db/src"
+      }
+    },
     "create-migration": {
       "executor": "nx:run-commands",
       "options": {

--- a/libs/db/src/migrations/20240927170504_map_zone_strings/migration.sql
+++ b/libs/db/src/migrations/20240927170504_map_zone_strings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MapVersion" ALTER COLUMN "zones" SET DATA TYPE TEXT;

--- a/libs/db/src/schema.prisma
+++ b/libs/db/src/schema.prisma
@@ -214,7 +214,10 @@ model MapVersion {
   bspHash    String? @db.Char(40) // Nullable as we set to null if we delete files if map gets "deleted" (disabled)
   zoneHash   String? @db.Char(40) // Nullable as we set to null if we delete files if map gets "deleted" (disabled)
   hasVmf     Boolean @default(false)
-  zones      Json? /// map-zones.model.ts
+  // Stringified JSON of map-zones.model.ts.
+  // We don't gain anything from storing as jsonb, text is (presumably) faster
+  // and preserves whitespace so zoneHash is reliable.
+  zones      String? 
 
   submitterID Int?
   submitter   User? @relation(fields: [submitterID], references: [id])

--- a/libs/formats/zone/src/zones.stub.ts
+++ b/libs/formats/zone/src/zones.stub.ts
@@ -166,6 +166,8 @@ export const ZonesStub: MapZones = {
   }
 };
 
+export const ZonesStubString = JSON.stringify(ZonesStub);
+
 /**
  * Defining properties of all the leaderboards that *should* be generated from
  * ZonesStub, for a main track on RJ and bonus on CPM Defrag.
@@ -255,3 +257,5 @@ export const BabyZonesStub: MapZones = {
     bonuses: []
   }
 };
+
+export const BabyZonesStubString = JSON.stringify(BabyZonesStub);

--- a/libs/test-utils/src/utils/db.util.ts
+++ b/libs/test-utils/src/utils/db.util.ts
@@ -25,7 +25,7 @@ import {
   Style,
   TrackType
 } from '@momentum/constants';
-import { ZonesStub } from '@momentum/formats/zone';
+import { ZonesStub, ZonesStubString } from '@momentum/formats/zone';
 import { createSha1Hash } from './crypto.util';
 import { arrayFrom } from '@momentum/util-fn';
 
@@ -154,8 +154,8 @@ export class DbUtil {
               changelog: 'hello',
               submitter: this.getNewUserCreateData(),
               bspHash: createSha1Hash(Math.random().toString()),
-              zones: ZonesStub as unknown as JsonValue, // TODO: #855
-              zoneHash: createSha1Hash(JSON.stringify(ZonesStub))
+              zones: ZonesStubString,
+              zoneHash: createSha1Hash(ZonesStubString)
             }
           },
           submission: {
@@ -246,7 +246,7 @@ export class DbUtil {
           changelog: 'hello',
           submitter: this.getNewUserCreateData(),
           bspHash: createSha1Hash(Math.random().toString()),
-          zones: ZonesStub as unknown as JsonValue, // TODO: #855
+          zones: ZonesStubString,
           zoneHash: createSha1Hash(JSON.stringify(ZonesStub))
         }
       },

--- a/libs/test-utils/src/utils/db.util.ts
+++ b/libs/test-utils/src/utils/db.util.ts
@@ -13,7 +13,7 @@
 } from '@prisma/client';
 import { CamelCase, JsonValue, PartialDeep } from 'type-fest';
 import { v4 as uuid4 } from 'uuid';
-import { merge } from 'lodash'; // TODO: Replace with fastify deepmerge when everything is passing!
+import { deepmerge } from '@fastify/deepmerge';
 import { AuthUtil } from './auth.util';
 import { randomHash, randomSteamID } from './random.util';
 import {
@@ -81,10 +81,8 @@ export class DbUtil {
 
   createUser(args: CreateUserArgs = {}): Promise<User> {
     return this.prisma.user.create(
-      merge(
-        {
-          data: this.getNewUserCreateData().create
-        },
+      deepmerge()(
+        { data: this.getNewUserCreateData().create },
         args
       ) as Prisma.UserCreateArgs
     );

--- a/libs/test-utils/src/utils/request.util.ts
+++ b/libs/test-utils/src/utils/request.util.ts
@@ -1,4 +1,4 @@
-﻿import { get as getDeep, isObject } from 'lodash';
+﻿import { get as getDeep } from 'lodash';
 import { Type } from '@nestjs/common';
 import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import { InjectOptions, Response } from 'light-my-request';
@@ -7,7 +7,7 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import path from 'node:path';
 import { FILES_PATH } from '../files-path.const';
-import { isEmpty } from '@momentum/util-fn';
+import { isEmpty, isObject } from '@momentum/util-fn';
 import { MergeExclusive, Primitive } from 'type-fest';
 
 export const URL_PREFIX = '/v1/';

--- a/scripts/src/seed.script.ts
+++ b/scripts/src/seed.script.ts
@@ -5,7 +5,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import zlib from 'node:zlib';
@@ -156,7 +156,7 @@ prismaWrapper(async (prisma: PrismaClient) => {
 
   if (args.has('-h') || args.has('--help')) {
     console.log(
-      'usage: seed.js [-h] [--reset]\n\t' +
+      'usage: seed.js [-h] [--reset] [--dump-map-list]\n\t' +
         Object.keys(defaultVars)
           .map((v) => `--${v}=N (or N-M for min-max)`)
           .join('\n\t')
@@ -1073,12 +1073,9 @@ prismaWrapper(async (prisma: PrismaClient) => {
 
     const mapListJson = JSON.stringify(maps);
 
-    // Uncomment below line to write this out to disk if you want to debug output of this.
-    // eslint-disable-next-line unicorn/no-await-expression-member
-    (await import('node:fs')).writeFileSync(
-      `./map-list-${type}.json`,
-      mapListJson
-    );
+    if (args.has('--dump-map-list')) {
+      writeFileSync(`./map-list-${type}.json`, mapListJson);
+    }
 
     const compressed = await promisify(zlib.deflate)(mapListJson);
     await s3.send(

--- a/scripts/src/seed.script.ts
+++ b/scripts/src/seed.script.ts
@@ -35,7 +35,6 @@ import {
   imgLargePath,
   AdminActivityType,
   imgXlPath,
-  MapZones,
   GamemodeInfo,
   bspPath
 } from '@momentum/constants';
@@ -47,7 +46,6 @@ import { arrayFrom, parallel, promiseAllSync } from '@momentum/util-fn';
 import { COS_XP_PARAMS, XpSystems } from '@momentum/xp-systems';
 import axios from 'axios';
 import sharp from 'sharp';
-import { JsonValue } from 'type-fest';
 import { v4 as uuidv4 } from 'uuid';
 import { prismaWrapper } from './prisma-wrapper.util';
 
@@ -419,15 +417,13 @@ prismaWrapper(async (prisma: PrismaClient) => {
       };
 
       const versions = arrayFrom(randRange(vars.submissionVersions), (i) => {
-        const zones = randomZones();
+        const zones = JSON.stringify(randomZones());
         return {
           versionNum: i + 1,
           bspHash: mapHash,
           hasVmf: false, // Could add a VMF if we really want but leaving for now
-          zones: zones as unknown as JsonValue, // TODO: #855
-          zoneHash: createHash('sha1')
-            .update(JSON.stringify(zones))
-            .digest('hex'),
+          zones,
+          zoneHash: createHash('sha1').update(zones).digest('hex'),
           changelog: faker.lorem.paragraphs({ min: 1, max: 10 })
         };
       });
@@ -437,7 +433,7 @@ prismaWrapper(async (prisma: PrismaClient) => {
 
       //#region Leaderboards, suggestions, etc...
 
-      const zones = versions.at(-1).zones as unknown as MapZones; // TODO: #855
+      const zones = JSON.parse(versions.at(-1).zones);
       const numModes = randRange(vars.modesPerLeaderboard);
       const modesSet = new Set<Gamemode>();
       while (modesSet.size < numModes) {


### PR DESCRIPTION
Refactors backend/DB so that zones are stored as plain `text` rather than `jsonb`.
 
With incoming map cache changes, we perform a hash check on map load to check zone files match the hash on the `zoneHash` field of the `MapVersion` table. Currently, zones are stored in Postgres as `jsonb`, a Postgres-specific binary serialization of JSON. It doesn't store whitespace, so makes storing zone hashes unreliable - it's *probably* possible to get the hash check to be consistent but I was struggling to get it working and felt very messy.

The main purpose of `jsonb` is to allow queries over that JSON data, which for zones we never need to do - we're really just using using the field for storage. The only thing we gain from using `jsonb` is that Prisma queries automatically parse the JSON into JSOs for us; this change requires we stick some `JSON.parse`s in the backend code, but it's really not a big deal.

I haven't spent the time benching/profiling anything, but I suspect this method is quite a lot more performant overall, since the `maps/<mapID>/zones` GETs can just return raw strings, rather than having to serialize and deserialize each time, and that endpoint is called very frequently by the game.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
