### PR TITLE
ci: separate staging.yml for frontend and backend

### DIFF
--- a/.github/workflows/staging_backend.yml
+++ b/.github/workflows/staging_backend.yml
@@ -1,0 +1,16 @@
+name: Publish Staging Backend
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "apps/frontend*/**"
+      - "scripts/**"
+
+jobs:
+  publish_backend:
+    permissions:
+      packages: write
+    uses: momentum-mod/website/.github/workflows/backend_docker_image.yml@main
+    secrets: inherit

--- a/.github/workflows/staging_frontend.yml
+++ b/.github/workflows/staging_frontend.yml
@@ -1,19 +1,15 @@
-name: Publish Staging
+name: Publish Staging Frontend
 
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "apps/backend*/**"
 
 jobs:
   publish_frontend:
     uses: momentum-mod/website/.github/workflows/frontend_cf_pages.yml@main
     with:
       project_name: 'frontend-staging'
-    secrets: inherit
-
-  publish_backend:
-    permissions:
-      packages: write
-    uses: momentum-mod/website/.github/workflows/backend_docker_image.yml@main
     secrets: inherit


### PR DESCRIPTION
Separate staging.yml to staging_frontend.yml and staging_backend.yml
This allows us to use the "paths" parameter, so that changes to the frontend only run the frontend action and changes to the backend only run the backend action instead of running both.

### Screenshots (if applicable)

<!-- Attach screenshots here, if your PR contains any visual changes, e.g. frontend work -->

### Checks

- [ ] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [ ] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
