### PR TITLE
Fix MinIO in CI

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -40,7 +40,8 @@ module.exports = {
         'formats',
         'discord',
         'twitch',
-        'prod'
+        'prod',
+        'ci'
       ]
     ],
     'subject-case': [

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,6 +13,7 @@ services:
       POSTGRES_PASSWORD: root
       POSTGRES_PORT: 5432
       DATABASE_URL: postgresql://root:root@postgres/momentum?schema=public
+      MINIO_SITE_REGION: us-west-1
       MINIO_SERVER_PORT: 9000
       MINIO_CONSOLE_PORT: 9001
       MINIO_ROOT_USER: minio
@@ -25,7 +26,6 @@ services:
       STEAM_WEB_API_KEY: thisisenoughtogenerateanopenidreferralforsomereason
       SESSION_SECRET: thisisashitsecretdontuseitinprod
       JWT_SECRET: thisisalsonotasecure
-      MINIO_SITE_REGION: ${STORAGE_REGION}
     ports:
       - "5432:5432"
   minio:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     image: postgres:15-alpine
     restart: unless-stopped
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2024-08-17T01-24-54Z
     container_name: minio
   createbuckets:
-    image: minio/mc
+    image: minio/mc:RELEASE.2024-08-17T11-33-50Z
     container_name: minio_create_buckets
     depends_on:
       - minio


### PR DESCRIPTION
Latest version of MinIO fails in test CI for some reason. Just pinning to a working version, we only use it for dev/test CI anyway.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
