### PR TITLE
Discord webhook notifications

### DIFF
--- a/apps/backend-e2e/src/users.e2e-spec.ts
+++ b/apps/backend-e2e/src/users.e2e-spec.ts
@@ -19,7 +19,8 @@ import {
   ActivityType,
   MapCreditType,
   MapStatus,
-  Role
+  Role,
+  steamAvatarUrl
 } from '@momentum/constants';
 import { PrismaClient } from '@prisma/client';
 import {
@@ -220,7 +221,7 @@ describe('Users', () => {
         });
 
         expect(res.body.avatarURL).toBe(
-          'https://avatars.cloudflare.steamstatic.com/ac7305567f93a4c9eec4d857df993191c61fb240_full.jpg'
+          steamAvatarUrl('ac7305567f93a4c9eec4d857df993191c61fb240')
         );
       });
 

--- a/apps/backend/src/app/config/config.interface.ts
+++ b/apps/backend/src/app/config/config.interface.ts
@@ -1,4 +1,5 @@
-﻿import * as pino from 'pino';
+﻿import { GamemodeCategory } from '@momentum/constants';
+import * as pino from 'pino';
 
 export enum Environment {
   DEVELOPMENT = 'dev',
@@ -48,5 +49,6 @@ export interface ConfigInterface {
     maxCreditsExceptTesters: number;
     preSignedUrlExpTime: number;
   };
+  discordWebhooks: Record<GamemodeCategory, string>;
   logLevel: pino.LevelWithSilent;
 }

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -12,8 +12,10 @@
   JWT_WEB_EXPIRY_TIME,
   JWT_REFRESH_EXPIRY_TIME,
   MAX_MAP_IMAGE_SIZE,
-  PRE_SIGNED_URL_EXPIRE_TIME
+  PRE_SIGNED_URL_EXPIRE_TIME,
+  GamemodeCategory
 } from '@momentum/constants';
+import * as Enum from '@momentum/enum';
 import { ConfigInterface, Environment } from './config.interface';
 import * as process from 'node:process';
 import * as pino from 'pino';
@@ -69,6 +71,14 @@ export const ConfigFactory = (): ConfigInterface => {
       maxCreditsExceptTesters: MAX_CREDITS_EXCEPT_TESTERS,
       preSignedUrlExpTime: PRE_SIGNED_URL_EXPIRE_TIME
     },
+    discordWebhooks: Object.fromEntries(
+      Enum.values(GamemodeCategory).map((cat) => [
+        cat,
+        isTest
+          ? ''
+          : (process.env[`DISCORD_WEBHOOK_${GamemodeCategory[cat]}_URL`] ?? '')
+      ])
+    ) as Record<GamemodeCategory, string>,
     logLevel: (process.env['LOG_LEVEL'] ??
       (isTest ? 'warn' : 'info')) as pino.LevelWithSilent
   };

--- a/apps/backend/src/app/dto/user/user.dto.ts
+++ b/apps/backend/src/app/dto/user/user.dto.ts
@@ -6,7 +6,8 @@ import {
   STEAM_MISSING_AVATAR,
   User,
   NON_WHITESPACE_REGEXP,
-  DateString
+  DateString,
+  steamAvatarUrl
 } from '@momentum/constants';
 import { ApiProperty, ApiPropertyOptional, PickType } from '@nestjs/swagger';
 import {
@@ -66,11 +67,11 @@ export class UserDto implements User {
   @Expose()
   @IsString()
   get avatarURL(): string {
-    return `https://avatars.cloudflare.steamstatic.com/${
+    return steamAvatarUrl(
       Bitflags.has(this.bans, Ban.AVATAR) || !this.avatar
         ? STEAM_MISSING_AVATAR
         : this.avatar
-    }_full.jpg`;
+    );
   }
 
   @NestedProperty(ProfileDto, {

--- a/apps/backend/src/app/modules/maps/map-webhooks.service.ts
+++ b/apps/backend/src/app/modules/maps/map-webhooks.service.ts
@@ -1,0 +1,168 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  Leaderboard,
+  MapCredit,
+  MapInfo,
+  MapSubmission,
+  MMap,
+  User
+} from '@prisma/client';
+import { HttpService } from '@nestjs/axios';
+import {
+  MapSubmissionSuggestion,
+  GamemodeCategories,
+  GamemodeInfo,
+  TrackType,
+  imgLargePath,
+  MapCreditType,
+  MapSubmissionPlaceholder,
+  LeaderboardType,
+  Gamemode,
+  steamAvatarUrl
+} from '@momentum/constants';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class MapWebhooksService {
+  constructor(
+    private config: ConfigService,
+    private http: HttpService
+  ) {}
+
+  private readonly logger = new Logger('Discord Webhooks');
+
+  async sendPublicTestingDiscordEmbed(
+    extendedMap: MMap & {
+      info: MapInfo;
+      submission: MapSubmission;
+      submitter: User;
+      credits: Array<MapCredit & { user: User }>;
+    }
+  ) {
+    const suggestions =
+      (extendedMap.submission
+        .suggestions as unknown as MapSubmissionSuggestion[]) ?? []; // TODO: #855
+
+    const placeholders =
+      (extendedMap.submission
+        .placeholders as unknown as MapSubmissionPlaceholder[]) ?? []; // TODO: #855
+
+    const mainTrackSuggestions = suggestions.filter(
+      ({ trackType }) => trackType === TrackType.MAIN
+    );
+
+    const mainTrackGamemodes = new Set(
+      mainTrackSuggestions.map(({ gamemode }) => gamemode)
+    );
+
+    const mapAuthors = [
+      ...placeholders
+        .filter(({ type }) => type === MapCreditType.AUTHOR)
+        .map(({ alias }) => alias),
+      ...extendedMap.credits
+        .filter(({ type }) => type === MapCreditType.AUTHOR)
+        .map(({ user }) => user.alias)
+    ].sort();
+
+    const webhookBody = this.createMapUpdateWebhookBody(
+      'A new map is open for public testing!',
+      extendedMap,
+      mapAuthors,
+      mainTrackSuggestions
+    );
+
+    await this.broadcastWebhookToCategories(mainTrackGamemodes, webhookBody);
+  }
+
+  async sendApprovedDiscordEmbed(
+    extendedMap: MMap & {
+      info: MapInfo;
+      leaderboards: Array<Leaderboard>;
+      submitter: User;
+      credits: Array<MapCredit & { user: User }>;
+    }
+  ) {
+    const mainTrackLeaderboards = extendedMap.leaderboards.filter(
+      ({ trackType, type }) =>
+        trackType === TrackType.MAIN && type !== LeaderboardType.HIDDEN
+    );
+
+    const mainTrackGamemodes = new Set(
+      mainTrackLeaderboards.map(({ gamemode }) => gamemode)
+    );
+
+    const mapAuthors = extendedMap.credits
+      .filter(({ type }) => type === MapCreditType.AUTHOR)
+      .map(({ user }) => user.alias)
+      .sort();
+
+    const webhookBody = this.createMapUpdateWebhookBody(
+      'A new map has been added!',
+      extendedMap,
+      mapAuthors,
+      mainTrackLeaderboards
+    );
+
+    await this.broadcastWebhookToCategories(mainTrackGamemodes, webhookBody);
+  }
+
+  createMapUpdateWebhookBody(
+    text: string,
+    extendedMap: MMap & { info: MapInfo; submitter: User },
+    authors: Array<string>,
+    gamemodes: MapSubmissionSuggestion[] | Leaderboard[]
+  ) {
+    const frontendUrl = this.config.getOrThrow('url.frontend');
+    const cdnUrl = this.config.getOrThrow('url.cdn');
+
+    return {
+      content: text,
+      embeds: [
+        {
+          title: extendedMap.name,
+          description: 'By ' + authors.map((a) => `**${a}**`).join(', '),
+          url: `${frontendUrl}/maps/${extendedMap.id}`,
+          timestamp: extendedMap.info.creationDate.toISOString(),
+          color: 1611475,
+          image: {
+            url: `${cdnUrl}/${imgLargePath(extendedMap.images[0])}`
+          },
+          fields: gamemodes.map(
+            (gm: MapSubmissionSuggestion | Leaderboard) => ({
+              name: GamemodeInfo.get(gm.gamemode).name,
+              value: `Tier ${gm.tier}${gm.type === LeaderboardType.UNRANKED ? ' (Unranked)' : ''}`,
+              inline: true
+            })
+          ),
+          footer: {
+            icon_url: steamAvatarUrl(extendedMap.submitter.avatar),
+            text: extendedMap.submitter.alias
+          }
+        }
+      ]
+    };
+  }
+
+  async broadcastWebhookToCategories(
+    gamemodes: Set<Gamemode>,
+    webhookBody: object
+  ): Promise<void> {
+    await Promise.all(
+      [...GamemodeCategories.entries()]
+        .filter(([, modes]) => modes.some((gm) => gamemodes.has(gm)))
+        .map(([category]) => {
+          const webhookUrl = this.config.getOrThrow(
+            `discordWebhooks.${category}`
+          );
+          if (webhookUrl === '') return;
+
+          return firstValueFrom(
+            this.http.post(webhookUrl, webhookBody, {
+              headers: { 'Content-Type': 'application/json' }
+            })
+          );
+        })
+    ).catch((error) => this.logger.error('Failed to post to webhook', error));
+  }
+}

--- a/apps/backend/src/app/modules/maps/maps.module.ts
+++ b/apps/backend/src/app/modules/maps/maps.module.ts
@@ -13,6 +13,8 @@ import { MapTestInviteService } from './map-test-invite.service';
 import { MapListService } from './map-list.service';
 import { MapReviewModule } from '../map-review/map-review.module';
 import { KillswitchModule } from '../killswitch/killswitch.module';
+import { MapWebhooksService } from './map-webhooks.service';
+import { HttpModule } from '@nestjs/axios';
 
 @Module({
   imports: [
@@ -23,7 +25,8 @@ import { KillswitchModule } from '../killswitch/killswitch.module';
     forwardRef(() => RunsModule),
     forwardRef(() => AdminModule),
     forwardRef(() => MapReviewModule),
-    KillswitchModule
+    KillswitchModule,
+    HttpModule
   ],
   controllers: [MapsController],
   providers: [
@@ -31,7 +34,8 @@ import { KillswitchModule } from '../killswitch/killswitch.module';
     MapCreditsService,
     MapImageService,
     MapTestInviteService,
-    MapListService
+    MapListService,
+    MapWebhooksService
   ],
   exports: [MapsService]
 })

--- a/libs/constants/src/consts/steam-avatar.const.ts
+++ b/libs/constants/src/consts/steam-avatar.const.ts
@@ -1,0 +1,8 @@
+export function steamAvatarUrl(id: string): string {
+  return `https://avatars.cloudflare.steamstatic.com/${id}_full.jpg`;
+}
+
+// This is the specific key Steam uses for all missing avatars.
+// They even kept it when migrating to Cloudflare!
+export const STEAM_MISSING_AVATAR = 'fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb';
+export const STEAM_MISSING_AVATAR_URL = steamAvatarUrl(STEAM_MISSING_AVATAR);

--- a/libs/constants/src/consts/steam-default-avatar.const.ts
+++ b/libs/constants/src/consts/steam-default-avatar.const.ts
@@ -1,4 +1,0 @@
-// This is the specific key Steam uses for all missing avatars.
-// They even kept it when migrating to Cloudflare!
-export const STEAM_MISSING_AVATAR = 'fef49e7fa7e1997310d705b2a6158ff8dc1cdfeb';
-export const STEAM_MISSING_AVATAR_URL = `https://avatars.cloudflare.steamstatic.com/${STEAM_MISSING_AVATAR}_full.jpg`;

--- a/libs/constants/src/index.ts
+++ b/libs/constants/src/index.ts
@@ -3,7 +3,7 @@ export * from './consts/appids.const';
 export * from './consts/file-store-paths.const';
 export * from './consts/limits.const';
 export * from './consts/socials.const';
-export * from './consts/steam-default-avatar.const';
+export * from './consts/steam-avatar.const';
 export * from './enums/gamemode.enum';
 export * from './enums/run.enum';
 export * from './enums/role.enum';

--- a/scripts/src/seed.script.ts
+++ b/scripts/src/seed.script.ts
@@ -36,7 +36,8 @@ import {
   AdminActivityType,
   imgXlPath,
   GamemodeInfo,
-  bspPath
+  bspPath,
+  steamAvatarUrl
 } from '@momentum/constants';
 import * as Bitflags from '@momentum/bitflags';
 import { nuke } from '@momentum/db';
@@ -1071,7 +1072,7 @@ prismaWrapper(async (prisma: PrismaClient) => {
 
       for (const credit of map.credits as any[]) {
         credit.user.steamID = credit.user.steamID?.toString();
-        credit.user.avatarURL = `https://avatars.cloudflare.steamstatic.com/${credit.user.avatar}_full.jpg`;
+        credit.user.avatarURL = steamAvatarUrl(credit.user.avatar);
         delete credit.user.avatar;
         delete credit.mapID;
       }


### PR DESCRIPTION
Closes #607

Adds triggering discord webhooks for when map goes to public testing or was approved.

Tom, if you want me to move webhook service to separate module please comment here, I'm just not that sure about it.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
