### PR TITLE
fix(back): Mark allow bhop regions as optional

### DIFF
--- a/apps/backend/src/app/dto/map/map-zones.dto.ts
+++ b/apps/backend/src/app/dto/map/map-zones.dto.ts
@@ -183,7 +183,8 @@ export class MainTrackDto /* extends JsonifiableDto */ implements MainTrack {
       "Overrides the game mode's settings to allow bhopping on this track"
   })
   @IsBoolean()
-  readonly bhopEnabled: boolean;
+  @IsOptional()
+  readonly bhopEnabled?: boolean;
 }
 
 export class BonusTrackDto /* extends JsonifiableDto */ implements BonusTrack {
@@ -201,7 +202,8 @@ export class BonusTrackDto /* extends JsonifiableDto */ implements BonusTrack {
       "Overrides the game mode's settings to allow bhopping on this track"
   })
   @IsBoolean()
-  readonly bhopEnabled: boolean;
+  @IsOptional()
+  readonly bhopEnabled?: boolean;
 }
 
 export class MapTracksDto /* extends JsonifiableDto */ implements MapTracks {
@@ -257,5 +259,6 @@ export class MapZonesDto /* extends JsonifiableDto */ implements MapZones {
   readonly tracks: MapTracksDto;
 
   @NestedProperty(GlobalRegionsDto, { required: false })
+  @IsOptional()
   readonly globalRegions?: GlobalRegionsDto;
 }


### PR DESCRIPTION
Fixes e2e backend tests after model changes for map zones

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
