### PR TITLE
Fix cosmetic xp calculations

### DIFF
--- a/apps/frontend/src/app/components/level-indicator/level-indicator.component.html
+++ b/apps/frontend/src/app/components/level-indicator/level-indicator.component.html
@@ -1,11 +1,12 @@
 <div
   [ngStyle]="{ 'background-color': levelColor }"
-  [ngClass]="[prestige ? 'pl-1 pr-3' : 'px-2', textColor]"
-  class="flex items-center gap-1 rounded py-0 font-display text-xl shadow"
+  [ngClass]="[textColor, prestige ? 'pl-1' : 'pl-2']"
+  class="flex items-center gap-1 rounded pr-2 font-display shadow"
+  [mTooltip]="'Prestige ' + prestige + ' - Level ' + level"
 >
   <!-- Display prestige icon if available -->
-  <img *ngIf="prestige" [ngClass]="imageClass" [src]="prestigeIcon" alt="Prestige Icon" />
+  <img *ngIf="prestige" [ngClass]="imageClass" class="h-5 w-5 drop-shadow-sm" [src]="prestigeIcon" alt="Prestige Icon" />
 
   <!-- Display the level -->
-  <b>{{ level }}</b>
+  <b class="pointer-events-none text-xl drop-shadow-sm">{{ level }}</b>
 </div>

--- a/apps/frontend/src/app/components/level-indicator/level-indicator.component.ts
+++ b/apps/frontend/src/app/components/level-indicator/level-indicator.component.ts
@@ -1,11 +1,12 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { XpSystemsService } from '../../services/xp-systems.service';
+import { TooltipDirective } from '../../directives/tooltip.directive';
 
 @Component({
   selector: 'm-level-indicator',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, TooltipDirective],
   templateUrl: './level-indicator.component.html'
 })
 export class LevelIndicatorComponent implements OnChanges {

--- a/apps/frontend/src/app/components/player-card/player-card.component.ts
+++ b/apps/frontend/src/app/components/player-card/player-card.component.ts
@@ -36,7 +36,7 @@ export class PlayerCardComponent implements OnInit {
         if (!user) return;
         this.user = user;
         this.level = user.userStats.level;
-        this.xp = user.userStats.cosXP as number;
+        this.xp = user.userStats.cosXP;
         this.currLevelXp = this.xpService.getCosmeticXpForLevel(this.level);
         this.nextLevelXp = this.xpService.getCosmeticXpForLevel(this.level + 1);
       });

--- a/apps/frontend/src/app/pages/profile/profile.component.html
+++ b/apps/frontend/src/app/pages/profile/profile.component.html
@@ -77,7 +77,7 @@
                 <p class="pb-1 leading-none">{{ currXp }} / {{ nextXp }} xp</p>
                 <p-progressBar class="h-2 w-full" [showValue]="false" [value]="(100 * currXp) / nextXp" />
               </div>
-              <p class="mt-auto rounded bg-gray-500 px-2 shadow">{{ user.userStats.level }}</p>
+              <m-level-indicator class="mt-auto" [totalLevel]="user.userStats.level" />
             </div>
           }
         </div>

--- a/apps/frontend/src/app/pages/profile/profile.component.html
+++ b/apps/frontend/src/app/pages/profile/profile.component.html
@@ -74,8 +74,8 @@
           @if (!hasRole(Role.DELETED)) {
             <div class="flex w-full gap-2 font-display text-2xl">
               <div class="flex-grow">
-                <p class="pb-1 leading-none">{{ currXp }} / {{ nextXp }} xp</p>
-                <p-progressBar class="h-2 w-full" [showValue]="false" [value]="(100 * currXp) / nextXp" />
+                <p class="pb-1 leading-none">{{ xp - currLevelXp }} / {{ nextLevelXp - currLevelXp }} xp</p>
+                <p-progressBar class="h-2 w-full" [showValue]="false" [value]="(100 * (xp - currLevelXp)) / (nextLevelXp - currLevelXp)" />
               </div>
               <m-level-indicator class="mt-auto" [totalLevel]="user.userStats.level" />
             </div>

--- a/apps/frontend/src/app/pages/profile/profile.component.ts
+++ b/apps/frontend/src/app/pages/profile/profile.component.ts
@@ -34,6 +34,7 @@ import { FontSizeLerpDirective } from '../../directives/font-size-lerp.directive
 import { DialogService } from 'primeng/dynamicdialog';
 import { ProfileNotifyEditComponent } from './profile-notify-edit/profile-notify-edit.component';
 import { HttpErrorResponse } from '@angular/common/http';
+import { LevelIndicatorComponent } from '../../components/level-indicator/level-indicator.component';
 
 @Component({
   selector: 'm-user-profile',
@@ -48,7 +49,8 @@ import { HttpErrorResponse } from '@angular/common/http';
     TabsComponent,
     TabComponent,
     ProgressBarModule,
-    FontSizeLerpDirective
+    FontSizeLerpDirective,
+    LevelIndicatorComponent
   ]
 })
 export class ProfileComponent implements OnInit {

--- a/apps/frontend/src/app/pages/profile/profile.component.ts
+++ b/apps/frontend/src/app/pages/profile/profile.component.ts
@@ -81,8 +81,10 @@ export class ProfileComponent implements OnInit {
   followingUsers: Follow[] = [];
   followedByUsers: Follow[] = [];
   localFollowStatus = new BehaviorSubject<Follow>(null);
-  currXp: number;
-  nextXp: number;
+  level: number;
+  xp: number;
+  currLevelXp: number;
+  nextLevelXp: number;
   protected credits: MapCredit[];
   protected creditMap: Partial<Record<MapCreditType, MapCredit[]>>;
 
@@ -132,12 +134,13 @@ export class ProfileComponent implements OnInit {
 
           this.avatarLoaded = true;
           this.countryDisplayName = ISOCountryCode[this.user.country];
-          this.currXp =
-            (user.userStats.cosXP as number) -
-            this.xpService.getCosmeticXpForLevel(user.userStats.level);
-          this.nextXp =
-            this.xpService.getCosmeticXpForLevel(user.userStats.level + 1) -
-            this.xpService.getCosmeticXpForLevel(user.userStats.level);
+
+          this.level = user.userStats.level;
+          this.xp = user.userStats.cosXP;
+          this.currLevelXp = this.xpService.getCosmeticXpForLevel(this.level);
+          this.nextLevelXp = this.xpService.getCosmeticXpForLevel(
+            this.level + 1
+          );
 
           this.usersService.getUserFollows(this.user).subscribe({
             next: (response) => (this.followingUsers = response.data),

--- a/libs/random/src/index.ts
+++ b/libs/random/src/index.ts
@@ -4,7 +4,13 @@ export function chance(probabilityOfTrue = 0.5): boolean {
   return Math.random() < probabilityOfTrue;
 }
 
+export function int(max: number): number;
+export function int(min: number, max: number): number;
 export function int(max: number, min = 0): number {
+  if (min > max) {
+    [max, min] = [min, max];
+  }
+
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 

--- a/libs/util-fn/src/array-from.ts
+++ b/libs/util-fn/src/array-from.ts
@@ -1,6 +1,7 @@
 /**
  * Create an array of a given length, and map each element using a given
- * function. If a mapFn isn't provided, maps it to
+ * function. If a mapFn isn't provided, the array will be filled with
+ * `undefined` (same as `Array.from({ length: n })`).
  *
  * Very similar to `Array.from({ length }).map((_, i) => ...))` but shorter,
  * doesn't require ignoring the first mapFn argument, and faster (see from.benchmark.ts).

--- a/libs/xp-systems/src/constants.ts
+++ b/libs/xp-systems/src/constants.ts
@@ -20,7 +20,7 @@ export const RANK_XP_PARAMS: RankXpParams = {
 
 export const COS_XP_PARAMS: CosXpParams = {
   levels: {
-    maxLevels: 500,
+    maxLevels: 3000,
     startingValue: 20000,
     linearScaleBaseIncrease: 1000,
     linearScaleInterval: 10,

--- a/libs/xp-systems/src/xp-system.class.spec.ts
+++ b/libs/xp-systems/src/xp-system.class.spec.ts
@@ -8,13 +8,13 @@ describe('XpSystemsService', () => {
   });
 
   it('should calculate correct level assignments for original constants', () => {
-    // These constants may get changed in the future, we also care about the maths,
-    // so mock here and check values correspond to below sheet
+    // These constants may get changed in the future, we only care about the
+    // maths, so mock here and check values correspond to below sheet
     // https://docs.google.com/spreadsheets/d/1JiHJYsxlGPXAZqCPh7-paJI6U_TH-Ro0H0OWDFCiA74
 
     // Note, this is NOT quite what the linked spreadsheet produces.
     // At level 101, the sheet expects xpInLevel from 101 to be
-    // 152000 - it must factor in `startingValue` for some reason.  In code,
+    // 152000 - it must factor in `startingValue` for some reason. In code,
     // `startingValue` isn't used at all for levels greater than
     // `staticScaleStart`. Not really an issue, but worth being aware of.
     jest.replaceProperty(service, 'cosXpParams', {
@@ -38,29 +38,31 @@ describe('XpSystemsService', () => {
     });
 
     // prettier-ignore
-    for (const { level, xpInLevel, total } of [
-      { level: 1, xpInLevel: 21000, total: 21000 },
-      { level: 2, xpInLevel: 22000, total: 43000 },
-      { level: 3, xpInLevel: 23000, total: 66000 },
-      { level: 4, xpInLevel: 24000, total: 90000 },
-      { level: 5, xpInLevel: 25000, total: 115000 },
-      { level: 6, xpInLevel: 26000, total: 141000 },
-      { level: 7, xpInLevel: 27000, total: 168000 },
-      { level: 8, xpInLevel: 28000, total: 196000 },
-      { level: 9, xpInLevel: 29000, total: 225000 },
-      { level: 10, xpInLevel: 30000, total: 255000 },
-      { level: 11, xpInLevel: 42000, total: 297000 },
-      { level: 97, xpInLevel: 990000, total: 34995000 },
-      { level: 98, xpInLevel: 1000000, total: 35995000 },
-      { level: 99, xpInLevel: 1010000, total: 37005000 },
-      { level: 100, xpInLevel: 1020000, total: 38025000 },
-      { level: 101, xpInLevel: 1500000, total: 39525000 },
-      { level: 102, xpInLevel: 1500000, total: 41025000 },
-      { level: 103, xpInLevel: 1500000, total: 42525000 },
-      { level: 104, xpInLevel: 1500000, total: 44025000 }
+    for (const [ level, xpInLevel, xpForLevel ] of [
+      // Level | XP in level | XP for level
+      [  0,      0,            0         ],
+      [  1,      21000,        0         ],
+      [  2,      22000,        21000     ],
+      [  3,      23000,        43000     ],
+      [  4,      24000,        66000     ],
+      [  5,      25000,        90000     ],
+      [  6,      26000,        115000    ],
+      [  7,      27000,        141000    ],
+      [  8,      28000,        168000    ],
+      [  9,      29000,        196000    ],
+      [  10,     30000,        225000    ],
+      [  11,     42000,        255000    ],
+      [  97,     990000,       34005000  ],
+      [  98,     1000000,      34995000  ],
+      [  99,     1010000,      35995000  ],
+      [  100,    1020000,      37005000  ],
+      [  101,    1500000,      38025000  ],
+      [  102,    1500000,      39525000  ],
+      [  103,    1500000,      41025000  ],
+      [  104,    1500000,      42525000  ],
     ]) {
       expect(service.getCosmeticXpInLevel(level)).toBe(xpInLevel);
-      expect(service.getCosmeticXpForLevel(level)).toBe(total);
+      expect(service.getCosmeticXpForLevel(level)).toBe(xpForLevel);
     }
   });
 });

--- a/libs/xp-systems/src/xp-systems.class.ts
+++ b/libs/xp-systems/src/xp-systems.class.ts
@@ -30,8 +30,8 @@ export class XpSystems {
     for (let i = 1; i < this.cosXpParams.levels.maxLevels; i++) {
       this.xpInLevels[i] = this.getCosmeticXpInLevel(i);
 
-      if (i > 0)
-        this.xpForLevels[i] = this.xpForLevels[i - 1] + this.xpInLevels[i];
+      if (i > 1)
+        this.xpForLevels[i] = this.xpForLevels[i - 1] + this.xpInLevels[i - 1];
     }
   }
 


### PR DESCRIPTION
Closes #1045

Changes the code precalculating XP values in xp-systems to match [C++](https://github.com/momentum-mod/game/blob/develop/mp/src/game/shared/momentum/util/mom_system_xp.cpp). We don't unit test the C++ code, but I've manually checked all the expected values in our unit tests with the C++ version using a debugger.

After this change, the frontend components have the correct values (0 / 21000 XP for new user at level 1).

I also improved the docs for these functions (which were partially the cause of the confusion here) and cleaned up the xp-systems class a bit.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
