### PR TITLE
Static map list headers

### DIFF
--- a/apps/backend-e2e/src/admin.e2e-spec.ts
+++ b/apps/backend-e2e/src/admin.e2e-spec.ts
@@ -1769,23 +1769,27 @@ describe('Admin', () => {
             oldVersion.body.submissions + 1
           );
 
-          const approvedMapList = await fileStore.getMapListVersion(
+          const approved = await fileStore.getMapListVersion(
             FlatMapList.APPROVED,
             newVersion.body.approved
           );
-          expect(approvedMapList).toHaveLength(1);
-          expect(approvedMapList[0]).toMatchObject({
+          expect(approved.ident).toBe('MSML');
+          expect(approved.numMaps).toBe(1);
+          expect(approved.data).toHaveLength(1);
+          expect(approved.data[0]).toMatchObject({
             id: map.id,
             leaderboards: expect.anything(),
             info: expect.anything()
           });
-          expect(approvedMapList[0]).not.toHaveProperty('zones');
+          expect(approved.data[0]).not.toHaveProperty('zones');
 
-          const submissionMapList = await fileStore.getMapListVersion(
+          const submission = await fileStore.getMapListVersion(
             FlatMapList.SUBMISSION,
             newVersion.body.submissions
           );
-          expect(submissionMapList).toHaveLength(0);
+          expect(submission.ident).toBe('MSML');
+          expect(submission.numMaps).toBe(0);
+          expect(submission.data).toHaveLength(0);
         });
 
         it('should 400 when moving from FA to approved if leaderboards are not provided', async () => {
@@ -1832,12 +1836,14 @@ describe('Admin', () => {
         expect(newVersion.body.submissions).toBe(oldVersion.body.submissions);
         expect(newVersion.body.approved).toBe(oldVersion.body.approved + 1);
 
-        const approvedMapList = await fileStore.getMapListVersion(
+        const { ident, numMaps, data } = await fileStore.getMapListVersion(
           FlatMapList.APPROVED,
           newVersion.body.approved
         );
-        expect(approvedMapList).toHaveLength(1);
-        expect(approvedMapList[0]).toMatchObject({ id: map2.id });
+        expect(ident).toBe('MSML');
+        expect(numMaps).toBe(1);
+        expect(data).toHaveLength(1);
+        expect(data[0].id).toBe(map2.id);
       });
 
       it('should return 404 if map not found', () =>
@@ -1973,11 +1979,13 @@ describe('Admin', () => {
         expect(newVersion.body.submissions).toBe(oldVersion.body.submissions);
         expect(newVersion.body.approved).toBe(oldVersion.body.approved + 1);
 
-        const approvedMapList = await fileStore.getMapListVersion(
+        const { ident, numMaps, data } = await fileStore.getMapListVersion(
           FlatMapList.APPROVED,
           newVersion.body.approved
         );
-        expect(approvedMapList).toHaveLength(0);
+        expect(ident).toBe('MSML');
+        expect(numMaps).toBe(0);
+        expect(data).toHaveLength(0);
       });
 
       it('should return 404 if map not found', () =>

--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -2120,13 +2120,15 @@ describe('Maps', () => {
           oldListVersion.body.submissions + 1
         );
 
-        const submissionMapList = await fileStore.getMapListVersion(
+        const { ident, numMaps, data } = await fileStore.getMapListVersion(
           FlatMapList.SUBMISSION,
           newListVersion.body.submissions
         );
-        expect(submissionMapList).toHaveLength(1);
-        expect(submissionMapList[0].id).toBe(map.id);
-        expect(submissionMapList[0]).not.toHaveProperty('zones');
+        expect(ident).toBe('MSML');
+        expect(numMaps).toBe(1);
+        expect(data).toHaveLength(1);
+        expect(data[0].id).toBe(map.id);
+        expect(data[0]).not.toHaveProperty('zones');
       });
 
       it('should 400 for bad zones', async () => {
@@ -3016,7 +3018,6 @@ describe('Maps', () => {
         const newListVersion = await req.get({
           url: 'maps/maplistversion',
           status: 200,
-
           token
         });
 

--- a/apps/backend/src/app/dto/map/map-version.dto.ts
+++ b/apps/backend/src/app/dto/map/map-version.dto.ts
@@ -30,6 +30,9 @@ export class MapVersionDto implements MapVersion {
   @IsUUID()
   readonly id: string;
 
+  @Exclude()
+  readonly mapID: number;
+
   @ApiProperty()
   @IsInt()
   readonly versionNum: number;

--- a/apps/backend/src/app/modules/maps/leaderboard-handler.util.spec.ts
+++ b/apps/backend/src/app/modules/maps/leaderboard-handler.util.spec.ts
@@ -4,7 +4,7 @@ import {
   TrackType
 } from '@momentum/constants';
 import { ZonesStub } from '@momentum/formats/zone';
-import { LeaderboardHandler } from './leaderboard-handler.util';
+import * as LeaderboardHandler from './leaderboard-handler.util';
 
 describe('LeaderboardHandler', () => {
   describe('getCompatibleSuggestions', () => {

--- a/apps/backend/src/app/modules/maps/leaderboard-handler.util.ts
+++ b/apps/backend/src/app/modules/maps/leaderboard-handler.util.ts
@@ -15,28 +15,29 @@ export interface LeaderboardProps
   linear?: boolean;
 }
 
-export const LeaderboardHandler = {
-  /**
-   * Expand an array of map suggestions to data we can create all the
-   * leaderboards we want from, including stages and all compatible gamemodes
-   */
-  getMaximalLeaderboards: <T extends LeaderboardProps>(
-    leaderboards: T[],
-    zones: MapZones
-  ): LeaderboardProps[] =>
-    LeaderboardHandler.getCompatibleLeaderboards([
-      ...LeaderboardHandler.setLeaderboardLinearity(leaderboards, zones),
-      ...LeaderboardHandler.getStageLeaderboards(leaderboards, zones)
-    ]),
+/**
+ * Expand an array of map suggestions to data we can create all the
+ * leaderboards we want from, including stages and all compatible gamemodes
+ */
+export function getMaximalLeaderboards<T extends LeaderboardProps>(
+  leaderboards: T[],
+  zones: MapZones
+): LeaderboardProps[] {
+  return getCompatibleLeaderboards([
+    ...setLeaderboardLinearity(leaderboards, zones),
+    ...getStageLeaderboards(leaderboards, zones)
+  ]);
+}
 
-  /**
-   * Expand an array of MapSubmissionSuggestions in one containing equiv.
-   * entries for gamemodes that's "incompatible" with the suggestion's gamemode.
-   * E.g. a rocket jump track also gets a sticky jump entry, but not surf.
-   */
-  getCompatibleLeaderboards: <T extends LeaderboardProps>(
-    leaderboards: T[]
-  ): LeaderboardProps[] =>
+/**
+ * Expand an array of MapSubmissionSuggestions in one containing equiv.
+ * entries for gamemodes that's "incompatible" with the suggestion's gamemode.
+ * E.g. a rocket jump track also gets a sticky jump entry, but not surf.
+ */
+export function getCompatibleLeaderboards<T extends LeaderboardProps>(
+  leaderboards: T[]
+): LeaderboardProps[] {
+  return (
     leaderboards
       .flatMap(({ trackType, trackNum, linear, gamemode }) =>
         Enum.values(Gamemode) // Note: this will include `suggestion`
@@ -51,65 +52,62 @@ export const LeaderboardHandler = {
             gamemode: newGamemode
           }))
       )
-      .filter(
-        // Filter out any duplicates
-        (x, i, array) =>
-          !array.some(
-            (y, j) =>
-              x.trackType === y.trackType &&
-              x.trackNum === y.trackNum &&
-              x.gamemode === y.gamemode &&
-              i < j
+      // Filter out any duplicates
+      .filter((x, i, array) => !array.some((y, j) => isEqual(x, y) && i < j))
+  );
+}
+
+/**
+ * Returns leaderboard create inputs for all the stages on all gamemodes of
+ * a staged main track
+ *
+ * Stages have no important user-submitted data and tedious for them to
+ * create in frontend, so we may as well automatically generate them
+ */
+export function getStageLeaderboards<T extends LeaderboardProps>(
+  leaderboards: T[],
+  zones: MapZones
+): T[] {
+  return zones.tracks.main.zones.segments.length === 1
+    ? []
+    : leaderboards
+        .filter(({ trackType }) => trackType === TrackType.MAIN)
+        .flatMap((lb: T) =>
+          arrayFrom(
+            zones.tracks.main.zones.segments.length,
+            (i) =>
+              ({
+                gamemode: lb.gamemode,
+                // Whether is ranked depends on main Track, doesn't have a tier.
+                type: (lb as T & { type?: LeaderboardType }).type,
+                trackType: TrackType.STAGE,
+                trackNum: i + 1
+              }) as unknown as T
           )
-      ),
+        );
+}
 
-  /**
-   * Returns leaderboard create inputs for all the stages on all gamemodes of
-   * a staged main track
-   *
-   * Stages have no important user-submitted data and tedious for them to
-   * create in frontend, so we may as well automatically generate them
-   */
-  getStageLeaderboards: <T extends LeaderboardProps>(
-    leaderboards: T[],
-    zones: MapZones
-  ): T[] =>
-    zones.tracks.main.zones.segments.length === 1
-      ? []
-      : leaderboards
-          .filter(({ trackType }) => trackType === TrackType.MAIN)
-          .flatMap((lb: T) =>
-            arrayFrom(
-              zones.tracks.main.zones.segments.length,
-              (i) =>
-                ({
-                  gamemode: lb.gamemode,
-                  // Whether is ranked depends on main Track, doesn't have a tier.
-                  type: (lb as T & { type?: LeaderboardType }).type,
-                  trackType: TrackType.STAGE,
-                  trackNum: i + 1
-                }) as unknown as T
-            )
-          ),
-
-  isEqual: <T extends LeaderboardProps, U extends LeaderboardProps>(
-    x: T,
-    y: U
-  ) =>
+export function isEqual<T extends LeaderboardProps, U extends LeaderboardProps>(
+  x: T,
+  y: U
+) {
+  return (
     x.gamemode === y.gamemode &&
     x.trackType === y.trackType &&
-    x.trackNum === y.trackNum,
+    x.trackNum === y.trackNum
+  );
+}
 
-  /**
-   * Set linear (true/false/undef) for each suggestion based on zones
-   */
-  setLeaderboardLinearity: <T extends LeaderboardProps>(
-    leaderboards: T[],
-    zones: MapZones
-  ): T[] =>
-    leaderboards.map((lb) => ({
-      ...lb,
-      linear:
-        lb.trackType === TrackType.MAIN ? isLinearMainTrack(zones) : undefined
-    }))
-};
+/**
+ * Set linear (true/false/undef) for each suggestion based on zones
+ */
+export function setLeaderboardLinearity<T extends LeaderboardProps>(
+  leaderboards: T[],
+  zones: MapZones
+): T[] {
+  return leaderboards.map((lb) => ({
+    ...lb,
+    linear:
+      lb.trackType === TrackType.MAIN ? isLinearMainTrack(zones) : undefined
+  }));
+}

--- a/apps/backend/src/app/modules/maps/map-list.service.spec.ts
+++ b/apps/backend/src/app/modules/maps/map-list.service.spec.ts
@@ -1,16 +1,24 @@
 import { FlatMapList } from '@momentum/constants';
 import { MapListService } from './map-list.service';
 import { Test, TestingModule } from '@nestjs/testing';
-import { PRISMA_MOCK_PROVIDER } from '../../../../test/prisma-mock.const';
+import {
+  PRISMA_MOCK_PROVIDER,
+  PrismaMock
+} from '../../../../test/prisma-mock.const';
 import { mockDeep } from 'jest-mock-extended';
 import { FileStoreService } from '../filestore/file-store.service';
+import { EXTENDED_PRISMA_SERVICE } from '../database/db.constants';
+import { promisify } from 'node:util';
+import * as zlib from 'node:zlib';
 
 describe('MapListService', () => {
   describe('onModuleInit', () => {
-    let service: MapListService;
+    let service: MapListService, db: PrismaMock;
     const fileStoreMock = {
       listFileKeys: jest.fn(() => Promise.resolve([])),
-      deleteFiles: jest.fn()
+      storeFile: jest.fn(),
+      deleteFiles: jest.fn(),
+      deleteFile: jest.fn()
     };
 
     beforeEach(async () => {
@@ -25,6 +33,7 @@ describe('MapListService', () => {
         .compile();
 
       service = module.get(MapListService);
+      db = module.get(EXTENDED_PRISMA_SERVICE);
     });
 
     it('should set version values based on files in storage', async () => {
@@ -76,6 +85,42 @@ describe('MapListService', () => {
         'maplist/approved/3.dat',
         'maplist/approved/1.dat'
       ]);
+    describe('updateMapList', () => {
+      // prettier-ignore
+      const storedMap = {
+        id: 1,
+        name: 'The Map',
+        status: 0,
+        images: [ 'f2fecc26-34a0-448b-a3c7-007f43b9ec7e', 'a797e52e-3efc-4174-9f66-36e2c57ff55c', 'dee8bbd5-cec2-4341-9ddf-bdadd8337cdd' ],
+        info: { description: 'A map that makes me think I am becoming a better person', youtubeID: null, creationDate: '2024-09-27T10:18:42.318Z', mapID: 1 },
+        leaderboards: [ { mapID: 12345, gamemode: 8, trackType: 0, trackNum: 1, style: 0, tier: 3, linear: false, type: 1, tags: [] } ],
+        credits: [ { type: 1, description: 'who am i', user: { id: 674, alias: 'John God', avatar: '0227a240393e6d62f539ee7b306dd048b0830eeb', steamID: '43576820710' } } ],
+        createdAt: '2024-09-27T22:31:12.846Z',
+        currentVersion: { id: 'fc89afc9-7ad2-4590-853c-a9ff4f41ddd5', versionNum: 3, bspHash: 'ddd39cbfc070e98e1e68131bab0f40df1d06645f', zoneHash: '608437d3bb461dd6e4abfff881f6b16827629d0b', hasVmf: false, submitterID: null, createdAt: '2024-09-27T18:12:52.465Z' }
+      };
+
+      it('should generate a Momentum Static Map List file and send to filestore', async () => {
+        db.mMap.findMany.mockResolvedValueOnce([storedMap as any]);
+
+        await service.updateMapList(FlatMapList.APPROVED);
+
+        const buffer: Buffer = fileStoreMock.storeFile.mock.calls[0][0];
+        expect(buffer.subarray(0, 4)).toMatchObject(
+          Buffer.from('MSML', 'utf8')
+        );
+        expect(buffer.readUInt32LE(8)).toBe(1);
+
+        const decompressed = await promisify(zlib.inflate)(buffer.subarray(12));
+        expect(buffer.readUInt32LE(4)).toBe(decompressed.length);
+
+        const parsed = JSON.parse(decompressed.toString('utf8'));
+
+        // Can't do full toMatchObject, we've run through class-transformer.
+        expect(parsed[0]).toMatchObject({
+          id: storedMap.id,
+          name: storedMap.name
+        });
+      });
     });
   });
 });

--- a/apps/backend/src/app/modules/maps/maps.service.ts
+++ b/apps/backend/src/app/modules/maps/maps.service.ts
@@ -84,10 +84,7 @@ import {
 import { FileStoreService } from '../filestore/file-store.service';
 import { MapTestInviteService } from './map-test-invite.service';
 import { MapImageService } from './map-image.service';
-import {
-  LeaderboardHandler,
-  LeaderboardProps
-} from './leaderboard-handler.util';
+import * as LeaderboardHandler from './leaderboard-handler.util';
 import { MapListService } from './map-list.service';
 import { MapReviewService } from '../map-review/map-review.service';
 import { createHash } from 'node:crypto';
@@ -878,14 +875,14 @@ export class MapsService {
     suggestions: MapSubmissionSuggestion[],
     zones: MapZones
   ): Promise<void> {
-    const existingLeaderboards: LeaderboardProps[] =
+    const existingLeaderboards: LeaderboardHandler.LeaderboardProps[] =
       await this.db.leaderboard.findMany({
         where: { mapID },
         select: { gamemode: true, trackNum: true, trackType: true }
       });
 
     const desiredLeaderboards = LeaderboardHandler.getMaximalLeaderboards(
-      suggestions as unknown as LeaderboardProps[], // TODO: #855
+      suggestions as unknown as LeaderboardHandler.LeaderboardProps[], // TODO: #855
       zones
     );
 

--- a/apps/frontend/src/app/components/map-forms/map-status-form/map-status-form.component.ts
+++ b/apps/frontend/src/app/components/map-forms/map-status-form/map-status-form.component.ts
@@ -156,6 +156,7 @@ export class MapStatusFormComponent implements OnChanges {
       )?.date
     ).getTime();
     this.isBlockedForSubmissionTimeGate =
+      !(this.mod || this.adm) &&
       Date.now() - this.firstEnteredPublicTesting < MIN_PUBLIC_TESTING_DURATION;
 
     this.isBlockedForUnresolvedReviews = reviews.data.some(

--- a/libs/random/src/index.ts
+++ b/libs/random/src/index.ts
@@ -23,6 +23,13 @@ export function float(max: number, min = 0, decimalPlaces?: number): number {
       );
 }
 
+export function char(
+  min = 'a'.codePointAt(0)!,
+  max = 'z'.codePointAt(0)!
+): string {
+  return String.fromCodePoint(int(max, min));
+}
+
 export function element<T>(array: readonly T[]): T {
   return array[Math.floor(Math.random() * array.length)];
 }

--- a/libs/test-utils/src/utils/s3.util.ts
+++ b/libs/test-utils/src/utils/s3.util.ts
@@ -156,6 +156,11 @@ export class FileStoreUtil {
         type === FlatMapList.APPROVED ? 'approved' : 'submissions'
       }/${version}.dat`
     );
-    return JSON.parse(zlib.inflateSync(file).toString());
+    return {
+      ident: file.subarray(0, 4).toString(),
+      uncompressedLength: file.readUInt32LE(4),
+      numMaps: file.readUInt32LE(8),
+      data: JSON.parse(zlib.inflateSync(file.subarray(12)).toString())
+    };
   }
 }


### PR DESCRIPTION
Adds a simple header block to static map lists storing
- ident
- length of uncompressed data
- number of maps

Makes C++ allocs faster and simpler.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
