### PR TITLE
feat(front): Save and restore path when logging in

### DIFF
--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -4,11 +4,13 @@ import { NotFoundComponent } from './pages/not-found/not-found.component';
 import { HomeComponent } from './pages/home/home.component';
 import { AuthGuard } from './guards/auth.guard';
 import { RoleGuard } from './guards/role.guard';
+import { RedirectGuard } from './guards/redirect.guard';
 
 export const APP_ROUTES: Route[] = [
   {
     path: '',
     component: HomeComponent,
+    canActivate: [RedirectGuard],
     title: 'Dashboard'
   },
   {

--- a/apps/frontend/src/app/guards/auth.guard.ts
+++ b/apps/frontend/src/app/guards/auth.guard.ts
@@ -1,34 +1,15 @@
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
+import { CanActivateFn } from '@angular/router';
 import { LocalUserService } from '../services/data/local-user.service';
 
-const POST_AUTH_REDIRECT_KEY = 'postAuthLocation';
-
 export const AuthGuard: CanActivateFn = () => {
-  const router = inject(Router);
   const userService = inject(LocalUserService);
 
-  // Check whether redirect URL exists in session storage. If this is the case,
-  // this is the second time this function has been called: the user failed auth
-  // once, the URL was stored, then they were redirected back to the dashboard.
-  // So, now we redirect remove the token (so no infinite loop), and redirect
-  // back to their original requested URL on this site.
-  const redirect = sessionStorage.getItem(POST_AUTH_REDIRECT_KEY);
-  if (redirect) {
-    sessionStorage.removeItem(POST_AUTH_REDIRECT_KEY);
-    return router.parseUrl('/' + redirect);
-  }
-
-  // This guard passes iff the client is logged in (essentially, if they
+  // This guard passes if the client is logged in (essentially, if they
   // have an access token in local storage).
   if (userService.isLoggedIn) {
     return true;
   }
-
-  // They're not logged in, so store current path in session storage and send
-  // them over to Steam
-  if (window.location.pathname !== '/')
-    sessionStorage.setItem(POST_AUTH_REDIRECT_KEY, window.location.pathname);
 
   userService.login();
   return false;

--- a/apps/frontend/src/app/guards/redirect.guard.ts
+++ b/apps/frontend/src/app/guards/redirect.guard.ts
@@ -1,0 +1,18 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+export const POST_AUTH_REDIRECT_KEY = 'postAuthLocation';
+
+export const RedirectGuard: CanActivateFn = () => {
+  const router = inject(Router);
+
+  // Check whether redirect URL exists in session storage. If this is the case,
+  // we redirect to this path and remove it from storage (to prevent infinite loop)
+  const redirect = sessionStorage.getItem(POST_AUTH_REDIRECT_KEY);
+  if (redirect) {
+    sessionStorage.removeItem(POST_AUTH_REDIRECT_KEY);
+    return router.parseUrl('/' + redirect);
+  }
+
+  return true;
+};

--- a/apps/frontend/src/app/services/data/local-user.service.ts
+++ b/apps/frontend/src/app/services/data/local-user.service.ts
@@ -27,6 +27,7 @@ import * as Bitflags from '@momentum/bitflags';
 import { AuthService } from './auth.service';
 import { HttpService } from './http.service';
 import { env } from '../../env/environment';
+import { POST_AUTH_REDIRECT_KEY } from '../../guards/redirect.guard';
 
 export type FullUser = User & { profile?: Profile; userStats?: UserStats };
 
@@ -62,6 +63,7 @@ export class LocalUserService {
   }
 
   public login() {
+    sessionStorage.setItem(POST_AUTH_REDIRECT_KEY, window.location.pathname);
     window.location.href = env.auth + '/web';
   }
 


### PR DESCRIPTION
Redirects user back to the path they were at when logging in. This was partially implemented in AuthGuard before, but didn't work well since AuthGuard only works on paths that require authentication.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
