### PR TITLE
fix(ci): Force scopes in commits to not be empty

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -49,6 +49,7 @@ module.exports = {
       'never',
       ['sentence-case', 'start-case', 'pascal-case', 'upper-case']
     ],
-    'body-max-line-length': [0, 'always', 0]
+    'body-max-line-length': [0, 'always', 0],
+    'scope-empty': [2, 'never']
   }
 };


### PR DESCRIPTION
### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
