### PR TITLE
fix(front): Fixed sorting when grouping leaderboards

### DIFF
--- a/apps/frontend/src/app/util/grouped-map-leaderboards.util.ts
+++ b/apps/frontend/src/app/util/grouped-map-leaderboards.util.ts
@@ -72,10 +72,11 @@ export function groupMapLeaderboards(
   // Then if all lbs hidden
   // Then try > number bonuses
   arr.sort((a: GroupedMapLeaderboard, b: GroupedMapLeaderboard) => {
-    if (a.tier != null && b.tier == null) return 1;
-    if (a.type > b.type) return 1;
-    if (!a.allHidden && b.allHidden) return 1;
-    if (a.bonuses?.length ?? 0 > b.bonuses?.length ?? 0) return 1;
+    if (a.tier !== b.tier) return a.tier === null ? 1 : -1;
+    if (a.type !== b.type) return a.type - b.type;
+    if (a.allHidden !== b.allHidden) return a.allHidden ? 1 : -1;
+    if (a.bonuses?.length !== b.bonuses?.length)
+      return (a.bonuses?.length ?? 0) - (b.bonuses?.length ?? 0);
     return 0;
   });
 


### PR DESCRIPTION
Closes #1084 

Makes sorting for leaderboard grouping definitive. Looks like chrome and firefox array sort implementations are a bit different, where first and second argument for sort function are switched. The issue is not just with firefox and based on how leaderboards are sorted initially when created (which is also affected by what browser map is submitted from)

### Screenshots (if applicable)

![изображение](https://github.com/user-attachments/assets/c6662543-5810-4469-90e2-6d2f0fd8341d)
![изображение](https://github.com/user-attachments/assets/1efca67e-077a-4445-bdd2-2e64f5b4787f)

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
