### PR TITLE
fix(front): enter key not working in <textarea> elements

### DIFF
--- a/apps/frontend/src/app/directives/textarea-allow-enter.directive.ts
+++ b/apps/frontend/src/app/directives/textarea-allow-enter.directive.ts
@@ -1,0 +1,11 @@
+import { Directive, HostListener } from '@angular/core';
+
+@Directive({ selector: 'textarea', standalone: true })
+export class TextareaAllowEnterDirective {
+  @HostListener('keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.stopPropagation();
+    }
+  }
+}

--- a/apps/frontend/src/app/shared.module.ts
+++ b/apps/frontend/src/app/shared.module.ts
@@ -17,7 +17,6 @@ import { CardHeaderComponent } from './components/card/card-header.component';
 import { CardBodyComponent } from './components/card/card-body.component';
 import { TooltipDirective } from './directives/tooltip.directive';
 import { SpinnerDirective } from './directives/spinner.directive';
-
 import { RangePipe } from './pipes/range.pipe';
 import { EnumValuePipe } from './pipes/enum-value.pipe';
 import { NumberWithCommasPipe } from './pipes/number-with-commas.pipe';
@@ -26,6 +25,7 @@ import { ThousandsSuffixPipe } from './pipes/thousands-suffix.pipe';
 import { TimeAgoPipe } from './pipes/time-ago.pipe';
 import { TimingPipe } from './pipes/timing.pipe';
 import { UnsortedKeyvaluePipe } from './pipes/unsorted-keyvalue.pipe';
+import { TextareaAllowEnterDirective } from './directives/textarea-allow-enter.directive';
 
 const SHARED = [
   CommonModule,
@@ -50,7 +50,8 @@ const SHARED = [
   ThousandsSuffixPipe,
   TimeAgoPipe,
   TimingPipe,
-  UnsortedKeyvaluePipe
+  UnsortedKeyvaluePipe,
+  TextareaAllowEnterDirective
 ];
 
 /**


### PR DESCRIPTION
This is because forms can eat the input, really gross. Made a global directive so this is never an issue in the future.
- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
