### PR TITLE
Safer number parsing for database IDs

### DIFF
--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -1812,6 +1812,9 @@ describe('Maps', () => {
         });
       });
 
+      it('should 400 if map id is bigger then max 32-bit integer', () =>
+        req.get({ url: `maps/${2 ** 31}`, status: 400, token: u1Token }));
+
       it('should 404 if the map is not found', () =>
         req.get({ url: `maps/${NULL_ID}`, status: 404, token: u1Token }));
     });
@@ -2511,6 +2514,9 @@ describe('Maps', () => {
           })
         ).toHaveLength(1);
       });
+
+      it('should 400 if map id is bigger then max 32-bit integer', () =>
+        req.post({ url: `maps/${2 ** 31}`, status: 400, token: u1Token }));
 
       it('should 401 when no access token is provided', () =>
         req.unauthorizedTest('maps/1', 'post'));

--- a/apps/backend/src/app/modules/admin/admin.controller.ts
+++ b/apps/backend/src/app/modules/admin/admin.controller.ts
@@ -47,7 +47,7 @@ import {
   UpdateReportDto,
   UserDto
 } from '../../dto';
-import { ParseIntSafePipe } from '../../pipes';
+import { ParseInt32SafePipe } from '../../pipes';
 import { AdminService } from './admin.service';
 import { AdminActivityService } from './admin-activity.service';
 import { MapReviewService } from '../map-review/map-review.service';
@@ -130,7 +130,7 @@ export class AdminController {
   @ApiBadRequestResponse({ description: 'Invalid user update data' })
   updateUser(
     @LoggedInUser('id') adminID: number,
-    @Param('userID', ParseIntSafePipe) userID: number,
+    @Param('userID', ParseInt32SafePipe) userID: number,
     @Body() body: AdminUpdateUserDto
   ) {
     return this.adminService.updateUser(adminID, userID, body);
@@ -148,7 +148,7 @@ export class AdminController {
   @ApiNoContentResponse({ description: 'The user was deleted successfully' })
   deleteUser(
     @LoggedInUser('id') adminID: number,
-    @Param('userID', ParseIntSafePipe) userID: number
+    @Param('userID', ParseInt32SafePipe) userID: number
   ) {
     return this.usersService.delete(userID, adminID);
   }
@@ -182,7 +182,7 @@ export class AdminController {
   @ApiNoContentResponse({ description: 'The map was updated successfully' })
   @ApiBadRequestResponse({ description: 'Invalid map update data' })
   updateMap(
-    @Param('mapID', ParseIntSafePipe) mapID: number,
+    @Param('mapID', ParseInt32SafePipe) mapID: number,
     @LoggedInUser('id') userID: number,
     @Body() body: UpdateMapAdminDto
   ) {
@@ -200,7 +200,7 @@ export class AdminController {
   })
   deleteMap(
     @LoggedInUser('id') adminID: number,
-    @Param('mapID', ParseIntSafePipe) mapID: number
+    @Param('mapID', ParseInt32SafePipe) mapID: number
   ) {
     return this.mapsService.delete(mapID, adminID);
   }
@@ -241,7 +241,7 @@ export class AdminController {
   @ApiNoContentResponse({ description: 'The report was updated successfully' })
   updateReport(
     @LoggedInUser('id') userID: number,
-    @Param('reportID', ParseIntSafePipe) reportID: number,
+    @Param('reportID', ParseInt32SafePipe) reportID: number,
     @Body() body: UpdateReportDto
   ) {
     return this.adminService.updateReport(userID, reportID, body);
@@ -256,7 +256,7 @@ export class AdminController {
   @ApiBody({ type: AdminUpdateMapReviewDto, required: true })
   updateMapReview(
     @Body() body: AdminUpdateMapReviewDto,
-    @Param('reviewID', ParseIntSafePipe) reviewID: number,
+    @Param('reviewID', ParseInt32SafePipe) reviewID: number,
     @LoggedInUser('id') userID: number
   ): Promise<MapReviewDto> {
     return this.mapReviewService.updateReviewAsReviewer(reviewID, userID, body);
@@ -269,7 +269,7 @@ export class AdminController {
   @ApiNoContentResponse({ description: 'Review deleted successfully' })
   @ApiNotFoundResponse({ description: 'Review not found' })
   deleteMapReview(
-    @Param('reviewID', ParseIntSafePipe) reviewID: number,
+    @Param('reviewID', ParseInt32SafePipe) reviewID: number,
     @LoggedInUser('id') userID: number
   ): Promise<void> {
     return this.mapReviewService.deleteReview(reviewID, userID, true);
@@ -308,7 +308,7 @@ export class AdminController {
     description: 'Requested user is neither admin nor moderator'
   })
   getAdminActivities(
-    @Param('userID', ParseIntSafePipe) userID: number,
+    @Param('userID', ParseInt32SafePipe) userID: number,
     @Query() query: AdminGetAdminActivitiesQueryDto
   ): Promise<PagedResponseDto<AdminActivityDto>> {
     return this.adminActivityService.getList(

--- a/apps/backend/src/app/modules/map-review/map-review.controller.ts
+++ b/apps/backend/src/app/modules/map-review/map-review.controller.ts
@@ -24,7 +24,7 @@ import {
 } from '@nestjs/swagger';
 import { MapReviewService } from './map-review.service';
 import { MapReviewCommentService } from './map-review-comment.service';
-import { ParseIntSafePipe } from '../../pipes';
+import { ParseInt32SafePipe } from '../../pipes';
 import { LoggedInUser } from '../../decorators';
 import {
   ApiOkPagedResponse,
@@ -69,7 +69,7 @@ export class MapReviewController {
     required: true
   })
   getReview(
-    @Param('reviewID', ParseIntSafePipe) reviewID: number,
+    @Param('reviewID', ParseInt32SafePipe) reviewID: number,
     @LoggedInUser('id') userID: number,
     @Query() query?: MapReviewGetIdDto
   ): Promise<MapReviewDto> {
@@ -96,7 +96,7 @@ export class MapReviewController {
   })
   updateReview(
     @Body() body: UpdateMapReviewDto,
-    @Param('reviewID', ParseIntSafePipe) reviewID: number,
+    @Param('reviewID', ParseInt32SafePipe) reviewID: number,
     @LoggedInUser('id') userID: number
   ): Promise<MapReviewDto> {
     return this.reviewService.updateReview(reviewID, userID, body);
@@ -121,7 +121,7 @@ export class MapReviewController {
     required: true
   })
   deleteReview(
-    @Param('reviewID', ParseIntSafePipe) reviewID: number,
+    @Param('reviewID', ParseInt32SafePipe) reviewID: number,
     @LoggedInUser('id') userID: number
   ): Promise<void> {
     return this.reviewService.deleteReview(reviewID, userID, false);
@@ -141,7 +141,7 @@ export class MapReviewController {
     required: true
   })
   getComments(
-    @Param('reviewID', ParseIntSafePipe) reviewID: number,
+    @Param('reviewID', ParseInt32SafePipe) reviewID: number,
     @LoggedInUser('id') userID: number,
     @Query() query: PagedQueryDto
   ): Promise<PagedResponseDto<MapReviewCommentDto>> {
@@ -165,7 +165,7 @@ export class MapReviewController {
     required: true
   })
   postComment(
-    @Param('reviewID', ParseIntSafePipe) reviewID: number,
+    @Param('reviewID', ParseInt32SafePipe) reviewID: number,
     @Body() body: CreateMapReviewCommentDto,
     @LoggedInUser('id') userID: number
   ): Promise<MapReviewCommentDto> {
@@ -188,7 +188,7 @@ export class MapReviewController {
     required: true
   })
   updateComment(
-    @Param('commentID', ParseIntSafePipe) commentID: number,
+    @Param('commentID', ParseInt32SafePipe) commentID: number,
     @Body() body: UpdateMapReviewCommentDto,
     @LoggedInUser('id') userID: number
   ): Promise<MapReviewCommentDto> {
@@ -210,7 +210,7 @@ export class MapReviewController {
     required: true
   })
   deleteComment(
-    @Param('commentID', ParseIntSafePipe) commentID: number,
+    @Param('commentID', ParseInt32SafePipe) commentID: number,
     @LoggedInUser('id') userID: number
   ): Promise<void> {
     return this.commentService.deleteComment(commentID, userID);

--- a/apps/backend/src/app/modules/maps/maps.controller.ts
+++ b/apps/backend/src/app/modules/maps/maps.controller.ts
@@ -80,14 +80,13 @@ import {
   CreateMapVersionDto
 } from '../../dto';
 import { BypassJwtAuth, LoggedInUser, Roles } from '../../decorators';
-import { ParseIntSafePipe } from '../../pipes';
+import { ParseFilesPipe } from '../../pipes';
 import { FormDataJsonInterceptor } from '../../interceptors/form-data-json.interceptor';
 import { UserJwtAccessPayload } from '../auth/auth.interface';
 import { MapCreditsService } from './map-credits.service';
 import { MapImageService } from './map-image.service';
 import { MapTestInviteService } from './map-test-invite.service';
 import { MapsService } from './maps.service';
-import { ParseFilesPipe } from '../../pipes/parse-files.pipe';
 import { ImageFileValidator } from '../../validators/image-file.validator';
 import { MapReviewService } from '../map-review/map-review.service';
 import { LeaderboardStatsDto } from '../../dto/run/leaderboard-stats.dto';

--- a/apps/backend/src/app/modules/user/user.controller.ts
+++ b/apps/backend/src/app/modules/user/user.controller.ts
@@ -46,7 +46,7 @@ import {
   MapsGetAllUserSubmissionQueryDto,
   MapsGetAllSubmissionQueryDto
 } from '../../dto';
-import { ParseIntSafePipe } from '../../pipes';
+import { ParseInt32SafePipe } from '../../pipes';
 import { UsersService } from '../users/users.service';
 import { MapsService } from '../maps/maps.service';
 
@@ -133,7 +133,7 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'Target user does not exist' })
   getFollowStatus(
     @LoggedInUser('id') localUserID: number,
-    @Param('userID', ParseIntSafePipe) targetUserID: number
+    @Param('userID', ParseInt32SafePipe) targetUserID: number
   ): Promise<FollowStatusDto> {
     return this.usersService.getFollowStatus(localUserID, targetUserID);
   }
@@ -153,7 +153,7 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'Target user does not exist' })
   followUser(
     @LoggedInUser('id') localUserID: number,
-    @Param('userID', ParseIntSafePipe) targetUserID: number
+    @Param('userID', ParseInt32SafePipe) targetUserID: number
   ): Promise<FollowDto> {
     return this.usersService.followUser(localUserID, targetUserID);
   }
@@ -179,7 +179,7 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'Target user does not exist' })
   updateFollow(
     @LoggedInUser('id') localUserID: number,
-    @Param('userID', ParseIntSafePipe) targetUserID: number,
+    @Param('userID', ParseInt32SafePipe) targetUserID: number,
     @Body() updateDto: UpdateFollowStatusDto
   ) {
     return this.usersService.updateFollow(localUserID, targetUserID, updateDto);
@@ -198,7 +198,7 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'Target user or follow does not exist' })
   unfollowUser(
     @LoggedInUser('id') localUserID: number,
-    @Param('userID', ParseIntSafePipe) targetUserID: number
+    @Param('userID', ParseInt32SafePipe) targetUserID: number
   ) {
     return this.usersService.unfollowUser(localUserID, targetUserID);
   }
@@ -224,7 +224,7 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'The map does not exist' })
   getMapNotifyStatus(
     @LoggedInUser('id') userID: number,
-    @Param('mapID', ParseIntSafePipe) mapID: number
+    @Param('mapID', ParseInt32SafePipe) mapID: number
   ): Promise<MapNotifyDto> {
     return this.usersService.getMapNotifyStatus(userID, mapID);
   }
@@ -253,7 +253,7 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'The map does not exist' })
   updateMapNotify(
     @LoggedInUser('id') userID: number,
-    @Param('mapID', ParseIntSafePipe) mapID: number,
+    @Param('mapID', ParseInt32SafePipe) mapID: number,
     @Body() updateDto: UpdateMapNotifyDto
   ) {
     return this.usersService.updateMapNotify(userID, mapID, updateDto);
@@ -274,7 +274,7 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'The map does not exist' })
   removeMapNotify(
     @LoggedInUser('id') userID: number,
-    @Param('mapID', ParseIntSafePipe) mapID: number
+    @Param('mapID', ParseInt32SafePipe) mapID: number
   ) {
     return this.usersService.removeMapNotify(userID, mapID);
   }
@@ -357,7 +357,7 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'The notification does not exist' })
   updateNotification(
     @LoggedInUser('id') userID: number,
-    @Param('notificationID', ParseIntSafePipe) notificationID: number,
+    @Param('notificationID', ParseInt32SafePipe) notificationID: number,
     @Body() updateDto: UpdateNotificationDto
   ) {
     return this.usersService.updateNotification(
@@ -376,7 +376,7 @@ export class UserController {
   @ApiNotFoundResponse({ description: 'The notification does not exist' })
   deleteNotification(
     @LoggedInUser('id') userID: number,
-    @Param('notificationID', ParseIntSafePipe) notificationID: number
+    @Param('notificationID', ParseInt32SafePipe) notificationID: number
   ) {
     return this.usersService.deleteNotification(userID, notificationID);
   }
@@ -404,7 +404,7 @@ export class UserController {
   })
   checkFavoritedMap(
     @LoggedInUser('id') userID: number,
-    @Param('mapID', ParseIntSafePipe) mapID: number
+    @Param('mapID', ParseInt32SafePipe) mapID: number
   ) {
     return this.usersService.checkFavoritedMap(userID, mapID);
   }
@@ -423,7 +423,7 @@ export class UserController {
   @ApiBadRequestResponse({ description: 'The map is already favorited' })
   addFavoritedMap(
     @LoggedInUser('id') userID: number,
-    @Param('mapID', ParseIntSafePipe) mapID: number
+    @Param('mapID', ParseInt32SafePipe) mapID: number
   ) {
     return this.usersService.addFavoritedMap(userID, mapID);
   }
@@ -446,7 +446,7 @@ export class UserController {
   })
   removeFavoritedMap(
     @LoggedInUser('id') userID: number,
-    @Param('mapID', ParseIntSafePipe) mapID: number
+    @Param('mapID', ParseInt32SafePipe) mapID: number
   ) {
     return this.usersService.removeFavoritedMap(userID, mapID);
   }

--- a/apps/backend/src/app/modules/users/users.controller.ts
+++ b/apps/backend/src/app/modules/users/users.controller.ts
@@ -23,7 +23,7 @@ import {
   UsersGetQueryDto,
   UsersGetCreditsQueryDto
 } from '../../dto';
-import { ParseIntSafePipe } from '../../pipes';
+import { ParseInt32SafePipe } from '../../pipes';
 import { UsersService } from './users.service';
 import { BypassJwtAuth, LoggedInUser } from '../../decorators';
 
@@ -60,7 +60,7 @@ export class UsersController {
   @ApiOkResponse({ type: UserDto, description: 'The found user' })
   @ApiNotFoundResponse({ description: 'User was not found' })
   getUser(
-    @Param('userID', ParseIntSafePipe) userID: number,
+    @Param('userID', ParseInt32SafePipe) userID: number,
     @Query() query?: UsersGetQueryDto
   ): Promise<UserDto> {
     return this.usersService.get(userID, query.expand);
@@ -81,7 +81,7 @@ export class UsersController {
     required: true
   })
   getProfile(
-    @Param('userID', ParseIntSafePipe) userID: number
+    @Param('userID', ParseInt32SafePipe) userID: number
   ): Promise<ProfileDto> {
     return this.usersService.getProfile(userID);
   }
@@ -102,7 +102,7 @@ export class UsersController {
     description: "Paginated list of the user's activites"
   })
   getActivities(
-    @Param('userID', ParseIntSafePipe) userID: number,
+    @Param('userID', ParseInt32SafePipe) userID: number,
     @Query() query?: UsersGetActivitiesQueryDto
   ): Promise<PagedResponseDto<ActivityDto>> {
     return this.usersService.getActivities(
@@ -130,7 +130,7 @@ export class UsersController {
     description: 'Paginated list of the follows targeting the user'
   })
   getFollowers(
-    @Param('userID', ParseIntSafePipe) userID: number,
+    @Param('userID', ParseInt32SafePipe) userID: number,
     @Query() query?: PagedQueryDto
   ): Promise<PagedResponseDto<FollowDto>> {
     return this.usersService.getFollowers(userID, query.skip, query.take);
@@ -148,7 +148,7 @@ export class UsersController {
     description: 'Paginated list of the follows for the user'
   })
   getFollowed(
-    @Param('userID', ParseIntSafePipe) userID: number,
+    @Param('userID', ParseInt32SafePipe) userID: number,
     @Query() query: PagedQueryDto
   ): Promise<PagedResponseDto<FollowDto>> {
     return this.usersService.getFollowing(userID, query.skip, query.take);
@@ -170,7 +170,7 @@ export class UsersController {
     description: 'Paginated list of map credits attributed to the user'
   })
   getMapCredits(
-    @Param('userID', ParseIntSafePipe) userID: number,
+    @Param('userID', ParseInt32SafePipe) userID: number,
     @Query() query: UsersGetCreditsQueryDto,
     @LoggedInUser('id') localUserID?: number
   ): Promise<PagedResponseDto<MapCreditDto>> {

--- a/apps/backend/src/app/pipes/index.ts
+++ b/apps/backend/src/app/pipes/index.ts
@@ -1,2 +1,3 @@
 export * from './parse-int-safe.pipe';
 export * from './parse-files.pipe';
+export * from './parse-int-32-safe.pipe';

--- a/apps/backend/src/app/pipes/index.ts
+++ b/apps/backend/src/app/pipes/index.ts
@@ -1,1 +1,2 @@
 export * from './parse-int-safe.pipe';
+export * from './parse-files.pipe';

--- a/apps/backend/src/app/pipes/parse-int-32-safe.pipe.ts
+++ b/apps/backend/src/app/pipes/parse-int-32-safe.pipe.ts
@@ -2,10 +2,15 @@
 
 /**
  * Extension of the built-in `ParseIntPipe` to restrict to numbers less than
- * `MAX_SAFE_INTEGER`.
+ * `2^31 - 1`.
+ *
+ * This is most useful for params that correspond to database IDs (as most do);
+ * since most of our IDs are stored as 32-bit signed integers and prisma would
+ * throw an error if a param has a value above maximum 32-bit number, rather than
+ * handle that in service logic, we can simply `400` immediately for any such request.
  */
 @Injectable()
-export class ParseIntSafePipe extends ParseIntPipe {
+export class ParseInt32SafePipe extends ParseIntPipe {
   override async transform(
     value: string,
     _metadata: ArgumentMetadata
@@ -16,9 +21,9 @@ export class ParseIntSafePipe extends ParseIntPipe {
       );
 
     const parsed = Number.parseInt(value, 10);
-    if (parsed > Number.MAX_SAFE_INTEGER)
+    if (parsed > 2 ** 31 - 1)
       throw this.exceptionFactory(
-        'Validation failed (numeric string must be a number less than 2^53)'
+        'Validation failed (numeric string must be a number less than 2^31)'
       );
 
     return parsed;


### PR DESCRIPTION
Created `ParseInt32SafePipe` and changed every usage of `ParseIntSafePipe` for database IDs (where IDs are actually INT4) to new pipe

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
