### PR TITLE
fix(back): use map name rather than id in url in map announce webhook

### DIFF
--- a/apps/backend/src/app/modules/maps/map-webhooks.service.ts
+++ b/apps/backend/src/app/modules/maps/map-webhooks.service.ts
@@ -122,7 +122,7 @@ export class MapWebhooksService {
         {
           title: extendedMap.name,
           description: 'By ' + authors.map((a) => `**${a}**`).join(', '),
-          url: `${frontendUrl}/maps/${extendedMap.id}`,
+          url: `${frontendUrl}/maps/${extendedMap.name}`,
           timestamp: extendedMap.info.creationDate.toISOString(),
           color: 1611475,
           image: {


### PR DESCRIPTION
E
### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
