### PR TITLE
fix(shared): allow updating only one file from map version

### DIFF
--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -2240,19 +2240,12 @@ describe('Maps', () => {
         });
       });
 
-      it('should 400 if BSP file is missing', async () => {
+      it('should succed if only the VMF file is provided', async () => {
         await req.postAttach({
           url: `maps/${map.id}`,
-          status: 400,
-          data: { changelog: 'help me' },
+          status: 201,
+          data: { changelog: 'who needs tests anyway' },
           files: [{ file: vmfBuffer, field: 'vmfs', fileName: 'surf_map.vmf' }],
-          token: u1Token
-        });
-
-        await req.post({
-          url: 'maps',
-          status: 400,
-          body: { changelog: 'im bored' },
           token: u1Token
         });
       });
@@ -2264,6 +2257,16 @@ describe('Maps', () => {
           url: `maps/${map.id}`,
           status: 201,
           data: { changelog: 'who needs tests anyway' },
+          token: u1Token
+        });
+      });
+
+      it('should succed if BSP file is missing', async () => {
+        await req.postAttach({
+          url: `maps/${map.id}`,
+          status: 201,
+          data: { changelog: 'who needs tests anyway' },
+          files: [{ file: vmfBuffer, field: 'vmfs', fileName: 'surf_map.vmf' }],
           token: u1Token
         });
       });
@@ -2282,6 +2285,15 @@ describe('Maps', () => {
               fileName: 'surf_map.vmf'
             }
           ],
+          token: u1Token
+        });
+      });
+
+      it('should 400 if neither VMF nor BSP nor zones are provided', async () => {
+        await req.postAttach({
+          url: `maps/${map.id}`,
+          status: 400,
+          data: { changelog: 'just hope it works' },
           token: u1Token
         });
       });

--- a/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.html
+++ b/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.html
@@ -31,6 +31,7 @@
         <span class="text-lg">Reset leaderboards</span>
         <input type="checkbox" class="checkbox" [formControl]="resetLbs" />
       </div>
+
       <button type="submit" class="btn btn-green self-end" [disabled]="loading || versionForm.pristine || versionForm.invalid">
         Submit
       </button>

--- a/apps/frontend/src/app/validators/index.ts
+++ b/apps/frontend/src/app/validators/index.ts
@@ -4,3 +4,4 @@ export * from './backend.validators';
 export * from './credits.validator';
 export * from './map-suggestions.validator';
 export * from './test-invites.validator';
+export * from './map-edit.validator';

--- a/apps/frontend/src/app/validators/map-edit.validator.ts
+++ b/apps/frontend/src/app/validators/map-edit.validator.ts
@@ -1,0 +1,10 @@
+import { FormGroup } from '@angular/forms';
+
+export function atLeastNRequired(numRequired: number, fieldNames: string[]) {
+  return (formGroup: FormGroup) => {
+    const hasAtLeastN =
+      fieldNames.filter((field) => formGroup.get(field)?.value !== null)
+        .length >= numRequired;
+    return hasAtLeastN ? null : { atLeastNRequired: true };
+  };
+}


### PR DESCRIPTION
Closes #1080 

Changed map version submission and added a validator in frontend;
Changed service to be prepared to not have a bsp in temp in backend;

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/87c1f5c8-237b-4df4-89a0-c32059a75db2)
![image](https://github.com/user-attachments/assets/1fb39c09-b3a8-4e5d-9fda-7250a0db6525)
![image](https://github.com/user-attachments/assets/91edbeb8-0feb-46a1-bb39-c8bbd1402e45)


### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
