### PR TITLE
fix(front): Change track num to 1 when main track type is selected

### DIFF
--- a/apps/frontend/src/app/components/map-forms/map-leaderboard-selection/map-leaderboard-selection.component.ts
+++ b/apps/frontend/src/app/components/map-forms/map-leaderboard-selection/map-leaderboard-selection.component.ts
@@ -134,6 +134,13 @@ export class MapLeaderboardSelectionComponent implements ControlValueAccessor {
     this.disabled = isDisabled;
   }
 
+  onTrackTypeChange(item: MapSubmissionSuggestion) {
+    if (item.trackType === TrackType.MAIN) {
+      item.trackNum = 1;
+    }
+    this.onChange(this.value);
+  }
+
   onChange: (value: MapSubmissionSuggestion[]) => void = () => void 0;
   registerOnChange(fn: () => void): void {
     this.onChange = fn;

--- a/apps/frontend/src/app/components/map-forms/map-leaderboard-selection/map-leaderboards-selection.component.html
+++ b/apps/frontend/src/app/components/map-forms/map-leaderboard-selection/map-leaderboards-selection.component.html
@@ -47,7 +47,7 @@
             optionLabel="label"
             optionValue="type"
             (blur)="onTouched()"
-            (onChange)="onChange(value)"
+            (onChange)="onTrackTypeChange(item)"
             appendTo="body"
           />
         </td>


### PR DESCRIPTION
When adding second main leaderboard suggestion for different gamemode, the track num of this suggestion can become different from one if there are any bonuses present, because of https://github.com/momentum-mod/website/blob/1da3c4d6fb3e6933e9500862e4b37d3a2dc1d80f/apps/frontend/src/app/components/map-forms/map-leaderboard-selection/map-leaderboard-selection.component.ts#L90

This PR fixes this by making sure that every suggestion with main track type will have track num 1

### Screenshots

Before 
![image](https://github.com/user-attachments/assets/b8bb6ab8-ba4a-4686-9571-00643b583ed5)

After
![изображение](https://github.com/user-attachments/assets/842b2b3c-c5f9-4bd7-93bf-34ce13ed1d60)


### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits