### PR TITLE
chore(shared): added changelog field to map submission when type is port

### DIFF
--- a/apps/backend/src/app/dto/map/map.dto.ts
+++ b/apps/backend/src/app/dto/map/map.dto.ts
@@ -197,6 +197,15 @@ export class CreateMapDto
   @IsArray()
   @IsOptional()
   readonly credits: CreateMapCreditDto[];
+
+  @ApiProperty({
+    type: String,
+    description: 'Porting Changelog for the map',
+    example: 'Initial release'
+  })
+  @ApiProperty({ description: 'Porting Changelog for the map' })
+  @IsOptional()
+  readonly portingChangelog: string;
 }
 
 export class CreateMapWithFilesDto implements CreateMapWithFiles {
@@ -216,7 +225,9 @@ export class CreateMapWithFilesDto implements CreateMapWithFiles {
 }
 
 export class UpdateMapDto
-  extends PartialType(PickType(CreateMapDto, ['name', 'suggestions'] as const))
+  extends PartialType(
+    PickType(CreateMapDto, ['name', 'suggestions', 'portingChangelog'] as const)
+  )
   implements UpdateMap
 {
   @NestedProperty(MapSubmissionPlaceholderDto)

--- a/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.html
+++ b/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.html
@@ -1,5 +1,5 @@
 <div class="flex gap-4 md:flex-wrap" [formGroup]="formGroup">
-  <div class="grid h-fit flex-grow gap-4 [grid-template-columns:auto_1fr]">
+  <div class="grid h-fit gap-4 [grid-template-columns:auto_1fr]">
     <div class="flex flex-col">
       <label class="my-auto text-lg leading-4">
         Map Name
@@ -80,7 +80,8 @@
       (change)="stripYoutubeUrl()"
     />
   </div>
-  <div class="flex grow-5 flex-col">
+
+  <div class="flex flex-1 flex-col">
     <div class="mb-2 flex">
       <div class="my-auto flex flex-grow items-center">
         <label for="description" class="text-lg">
@@ -111,4 +112,26 @@
       [maxLength]="MAX_MAP_DESCRIPTION_LENGTH"
     ></textarea>
   </div>
+
+  @if (submissionType.value === MapSubmissionType.PORT) {
+    <div class="flex flex-1 flex-col">
+      <div class="mb-2 flex">
+        <div class="my-auto flex flex-grow items-center">
+          <label for="portingChangelog" class="text-lg">
+            Porting Changelog
+
+            <m-icon icon="tooltip-question-outline" class="ml-1 align-middle" [mTooltip]="changelogInfo" />
+
+            <ng-template #changelogInfo>
+              <div class="prose p-3">
+                <p>Any major changes made when porting from the original game to Momentum.</p>
+                <p>Changes that required a recompile, especially altering map geometry, must be listed here.</p>
+              </div>
+            </ng-template>
+          </label>
+        </div>
+      </div>
+      <textarea id="portingChangelog" class="textinput textinput-validated flex-grow" rows="4" [formControl]="portingChangelog"></textarea>
+    </div>
+  }
 </div>

--- a/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.ts
+++ b/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.ts
@@ -44,6 +44,7 @@ export class MapDetailsFormComponent implements OnInit {
   @Input({ required: true }) formGroup: FormGroup<{
     name: FormControl<string>;
     description: FormControl<string>;
+    portingChangelog: FormControl<string>;
     creationDate: FormControl<Date>;
     submissionType: FormControl<MapSubmissionType>;
     youtubeID: FormControl<string>;
@@ -128,6 +129,10 @@ export class MapDetailsFormComponent implements OnInit {
 
   get description() {
     return this.formGroup.get('description') as FormControl<string>;
+  }
+
+  get portingChangelog() {
+    return this.formGroup.get('portingChangelog') as FormControl<string>;
   }
 
   get creationDate() {

--- a/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.ts
+++ b/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.ts
@@ -148,6 +148,7 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
         '',
         [Validators.required, Validators.maxLength(MAX_MAP_DESCRIPTION_LENGTH)]
       ],
+      portingChangelog: [''],
       creationDate: [
         new Date(),
         [Validators.required, Validators.max(Date.now())]
@@ -287,6 +288,9 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
     this.description.setValue(this.map.info.description);
     this.creationDate.setValue(new Date(this.map.info.creationDate));
     this.youtubeID.setValue(this.map.info.youtubeID);
+    this.portingChangelog.setValue(
+      this.map.versions.find((v) => v.versionNum === 1)?.changelog
+    );
 
     this.images.reset();
 
@@ -344,6 +348,12 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
     if (this.description.dirty) {
       body.info ??= {};
       body.info.description = this.description.value;
+    }
+    if (
+      this.portingChangelog.dirty &&
+      this.submissionType.value === MapSubmissionType.PORT
+    ) {
+      body.portingChangelog = this.portingChangelog.value;
     }
     if (this.creationDate.dirty) {
       body.info ??= {};
@@ -696,6 +706,10 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
 
   get description() {
     return this.mainForm.get('details.description') as FormControl<string>;
+  }
+
+  get portingChangelog() {
+    return this.mainForm.get('details.portingChangelog') as FormControl<string>;
   }
 
   get creationDate() {

--- a/apps/frontend/src/app/pages/maps/submission-form/map-submission-form.component.ts
+++ b/apps/frontend/src/app/pages/maps/submission-form/map-submission-form.component.ts
@@ -148,6 +148,7 @@ export class MapSubmissionFormComponent implements OnInit, ConfirmDeactivate {
           Validators.maxLength(MAX_MAP_DESCRIPTION_LENGTH)
         ]
       ],
+      portingChangelog: [''],
       creationDate: [
         new Date(),
         [Validators.required, Validators.max(Date.now())]
@@ -335,6 +336,10 @@ export class MapSubmissionFormComponent implements OnInit, ConfirmDeactivate {
               wantsPrivateTesting: this.wantsPrivateTesting.value,
               testInvites: this.testInvites.value ?? [],
               zones: this.zones,
+              portingChangelog:
+                this.submissionType.value === MapSubmissionType.PORT
+                  ? this.portingChangelog.value
+                  : undefined,
               credits: this.credits.value.getSubmittableRealUsers(),
               placeholders: this.credits.value.getSubmittablePlaceholders(),
               suggestions: this.suggestions.value,
@@ -467,6 +472,10 @@ export class MapSubmissionFormComponent implements OnInit, ConfirmDeactivate {
 
   get description() {
     return this.form.get('details.description') as FormControl<string>;
+  }
+
+  get portingChangelog() {
+    return this.form.get('details.portingChangelog') as FormControl<string>;
   }
 
   get creationDate() {

--- a/libs/constants/src/types/queries/map-queries.model.ts
+++ b/libs/constants/src/types/queries/map-queries.model.ts
@@ -104,6 +104,7 @@ export interface CreateMap extends Pick<MMap, 'name'> {
   info: CreateMapInfo;
   zones: MapZones;
   credits: CreateMapCredit[];
+  portingChangelog?: string;
 }
 
 export interface UpdateMap
@@ -121,6 +122,7 @@ export interface UpdateMap
   status?: MapStatus.CONTENT_APPROVAL | MapStatus.FINAL_APPROVAL;
   info?: UpdateMapInfo;
   zones?: MapZones;
+  portingChangelog?: string;
   resetLeaderboards?: boolean;
 }
 


### PR DESCRIPTION
Closes #1097

Added field to map submission form to add changelog when submission type is Port

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/02b02ef5-ba73-4c11-ae0b-7d2d0c61ce4b)
![image](https://github.com/user-attachments/assets/496ef3bf-02d1-4425-9b8d-262fb2f51436)

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
