### PR TITLE
fix(lint): backend-specific linter rules not affecting files

### DIFF
--- a/apps/backend/eslint.config.cjs
+++ b/apps/backend/eslint.config.cjs
@@ -3,12 +3,12 @@ const baseConfig = require('../../eslint.config.cjs');
 module.exports = [
   ...baseConfig,
   {
-    files: ['*.ts'],
+    files: ['**/*.ts'],
     ignores: ['*.spec.ts'],
     rules: { 'no-console': ['error'] }
   },
   {
-    files: ['*.spec.ts'],
+    files: ['**/*.spec.ts'],
     rules: { 'no-console': ['off'] }
   }
 ];


### PR DESCRIPTION
Tiny linter thing I noticed affecting `main.ts` immediately after merging the big deps branch... :)