### PR TITLE
Exclude prisma dependecy from constants module and check type correspondence in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,3 +176,29 @@ jobs:
           docker compose
             -f docker-compose.yml -f docker-compose.test.yml
             run backend-e2e
+
+  type-test:
+    name: Type Tests
+    runs-on: ubuntu-latest
+    needs: install-deps
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+          submodules: 'true'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: modules-${{ github.run_id }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Test Build @momentum/constants
+        run: npx nx run constants:test-types

--- a/libs/constants/.nxignore
+++ b/libs/constants/.nxignore
@@ -1,0 +1,1 @@
+src/types/models/prisma-correspondence.ts

--- a/libs/constants/project.json
+++ b/libs/constants/project.json
@@ -21,6 +21,16 @@
       "options": {
         "lintFilePatterns": ["libs/constants/**/*.ts"]
       }
+    },
+    "test-types": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/constants",
+        "main": "libs/constants/src/index.ts",
+        "tsConfig": "libs/constants/tsconfig.prisma-types.json",
+        "assets": ["libs/constants/*.md"]
+      }
     }
   }
 }

--- a/libs/constants/tsconfig.json
+++ b/libs/constants/tsconfig.json
@@ -14,6 +14,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.prisma-types.json"
     }
   ]
 }

--- a/libs/constants/tsconfig.prisma-types.json
+++ b/libs/constants/tsconfig.prisma-types.json
@@ -6,10 +6,5 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": [
-    "jest.config.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.ts",
-    "src/types/models/prisma-correspondence.ts"
-  ]
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
This reverts commit 20fd32c6b1e2579073f48255aa8eb25b30988ba1.
Moving Twitch types to constants now requires building constants module, which also includes prisma types, and there is no need for discord bot to have prisma as a dependecy

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
