### PR TITLE
Update Dependabot to only handle security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,4 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# Documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
@@ -8,19 +6,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    groups:
-      prod:
-        dependency-type: "production"
-      dev:
-        dependency-type: "development"
-    ignore:
-      - dependency-name: "@nx*"
-      - dependency-name: "nx"
-      - dependency-name: "*angular*"
-      - dependency-name: "typescript"
-      - dependency-name: "*eslint*"
-      - dependency-name: "*prettier*"
+      interval: "daily"
+    open-pull-requests-limit: 0
+    reviewers:
+      - "tsa96"
+      - "GordiNoki"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "chart.js": "4.4.7",
         "class-transformer": "0.5.1",
         "class-validator": "0.14.1",
-        "discord.js": "^14.18.0",
+        "discord.js": "14.18.0",
         "dotenv-cli": "8.0.0",
         "fast-vdf": "2.0.5",
         "fast-xml-parser": "4.5.1",


### PR DESCRIPTION
Stop Dependabot from doing non-security related PRs -- they're spammy and unhelpful.