### PR TITLE
fix(back-e2e): disconnect Prisma clients in teardownE2ETestEnvironment

### DIFF
--- a/apps/backend-e2e/src/activities.e2e-spec.ts
+++ b/apps/backend-e2e/src/activities.e2e-spec.ts
@@ -22,7 +22,7 @@ describe('Activities', () => {
     db = env.db;
   });
 
-  afterAll(() => teardownE2ETestEnvironment(app));
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
 
   describe('activities', () => {
     describe('GET', () => {

--- a/apps/backend-e2e/src/admin.e2e-spec.ts
+++ b/apps/backend-e2e/src/admin.e2e-spec.ts
@@ -79,7 +79,7 @@ describe('Admin', () => {
     fileStore = env.fileStore;
   });
 
-  afterAll(() => teardownE2ETestEnvironment(app));
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
 
   describe('admin/users', () => {
     describe('POST', () => {

--- a/apps/backend-e2e/src/auth.e2e-spec.ts
+++ b/apps/backend-e2e/src/auth.e2e-spec.ts
@@ -22,7 +22,10 @@ import {
   JWTResponseGameDto,
   JWTResponseWebDto
 } from '../../backend/src/app/dto';
-import { setupE2ETestEnvironment } from './support/environment';
+import {
+  setupE2ETestEnvironment,
+  teardownE2ETestEnvironment
+} from './support/environment';
 import { Role } from '@momentum/constants';
 
 describe('Auth', () => {
@@ -43,7 +46,10 @@ describe('Auth', () => {
     req = env.req;
   });
 
-  afterAll(() => db.cleanup('user'));
+  afterAll(async () => {
+    await db.cleanup('user');
+    await teardownE2ETestEnvironment(app, prisma);
+  });
 
   describe('auth/web/return', () => {
     describe('GET', () => {

--- a/apps/backend-e2e/src/map-review.e2e-spec.ts
+++ b/apps/backend-e2e/src/map-review.e2e-spec.ts
@@ -38,7 +38,7 @@ describe('Map Reviews', () => {
     fileStore = env.fileStore;
   });
 
-  afterAll(() => teardownE2ETestEnvironment(app));
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
 
   describe('map-review/{reviewID}', () => {
     describe('GET', () => {

--- a/apps/backend-e2e/src/maps-2.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps-2.e2e-spec.ts
@@ -70,7 +70,7 @@ describe('Maps Part 2', () => {
     auth = env.auth;
   });
 
-  afterAll(() => teardownE2ETestEnvironment(app));
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
 
   describe('maps/maplist', () => {
     describe('GET', () => {

--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -67,6 +67,8 @@ describe('Maps', () => {
     fileStore = env.fileStore;
   });
 
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
+
   async function uploadBspToPreSignedUrl(bspBuffer: Buffer, token: string) {
     const preSignedUrlRes = await req.get({
       url: 'maps/getMapUploadUrl',
@@ -79,8 +81,6 @@ describe('Maps', () => {
 
     await fileStore.putToPreSignedUrl(preSignedUrlRes.body.url, bspBuffer);
   }
-
-  afterAll(() => teardownE2ETestEnvironment(app));
 
   describe('maps', () => {
     describe('GET', () => {

--- a/apps/backend-e2e/src/multi-stage.e2e-spec.ts
+++ b/apps/backend-e2e/src/multi-stage.e2e-spec.ts
@@ -45,7 +45,7 @@ describe('Multi-stage E2E tests', () => {
     fileStore = env.fileStore;
   });
 
-  afterAll(() => teardownE2ETestEnvironment(app));
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
 
   afterEach(() => db.cleanup('mMap', 'user'));
 

--- a/apps/backend-e2e/src/reports.e2e-spec.ts
+++ b/apps/backend-e2e/src/reports.e2e-spec.ts
@@ -22,7 +22,7 @@ describe('Reports', () => {
     db = env.db;
   });
 
-  afterAll(() => teardownE2ETestEnvironment(app));
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
 
   describe('reports/', () => {
     describe('POST', () => {

--- a/apps/backend-e2e/src/runs.e2e-spec.ts
+++ b/apps/backend-e2e/src/runs.e2e-spec.ts
@@ -28,7 +28,7 @@ describe('Runs', () => {
     auth = env.auth;
   });
 
-  afterAll(() => teardownE2ETestEnvironment(app));
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
 
   describe('runs', () => {
     describe('GET', () => {

--- a/apps/backend-e2e/src/session.e2e-spec.ts
+++ b/apps/backend-e2e/src/session.e2e-spec.ts
@@ -50,7 +50,7 @@ describe('Session', () => {
 
   afterAll(async () => {
     await db.cleanup('mMap');
-    await teardownE2ETestEnvironment(app);
+    await teardownE2ETestEnvironment(app, prisma);
   });
 
   describe('session/run', () => {

--- a/apps/backend-e2e/src/support/environment.ts
+++ b/apps/backend-e2e/src/support/environment.ts
@@ -93,6 +93,10 @@ export async function setupE2ETestEnvironment(
   };
 }
 
-export async function teardownE2ETestEnvironment(app: NestFastifyApplication) {
+export async function teardownE2ETestEnvironment(
+  app: NestFastifyApplication,
+  prisma: PrismaClient
+) {
   await app.close();
+  await prisma.$disconnect();
 }

--- a/apps/backend-e2e/src/user.e2e-spec.ts
+++ b/apps/backend-e2e/src/user.e2e-spec.ts
@@ -1,4 +1,4 @@
-// noinspection DuplicatedCode
+﻿// noinspection DuplicatedCode
 
 import {
   ActivityDto,
@@ -50,7 +50,7 @@ describe('User', () => {
     auth = env.auth;
   });
 
-  afterAll(() => teardownE2ETestEnvironment(app));
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
 
   describe('user', () => {
     describe('GET', () => {

--- a/apps/backend-e2e/src/users.e2e-spec.ts
+++ b/apps/backend-e2e/src/users.e2e-spec.ts
@@ -41,7 +41,7 @@ describe('Users', () => {
     auth = env.auth;
   });
 
-  afterAll(() => teardownE2ETestEnvironment(app));
+  afterAll(() => teardownE2ETestEnvironment(app, prisma));
 
   describe('users/', () => {
     describe('GET', () => {

--- a/apps/backend/src/app/modules/database/db.service.ts
+++ b/apps/backend/src/app/modules/database/db.service.ts
@@ -1,9 +1,19 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class DbService extends PrismaClient implements OnModuleInit {
+export class DbService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
   async onModuleInit() {
     await this.$connect();
+  }
+
+  // Prisma supposedly has some some magic built-in support for this, don't
+  // understand exactly how it works, and doesn't seem to work with our client
+  // extension setup in E2E tests. Easier to just do ourselves like this.
+  async onModuleDestroy() {
+    await this.$disconnect();
   }
 }


### PR DESCRIPTION
Prisma started complaing about having too many clients open when trying to run all E2E tests local after recent dependency upgrades. Turns out I'm a complete moron and was never disconnecting the Prisma clients used by each test.

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
