### PR TITLE
feat(shared): Add a flag for including a BSP in a map version

### DIFF
--- a/apps/backend/src/app/dto/map/map-version.dto.ts
+++ b/apps/backend/src/app/dto/map/map-version.dto.ts
@@ -115,4 +115,12 @@ export class CreateMapVersionDto implements CreateMapVersion {
   @IsBoolean()
   @IsOptional()
   readonly resetLeaderboards?: boolean;
+
+  @ApiProperty({
+    description: 'Version contains new BSP uploaded to a pre-signed url',
+    default: false
+  })
+  @IsBoolean()
+  @IsOptional()
+  readonly hasBSP: boolean;
 }

--- a/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.ts
+++ b/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.ts
@@ -536,7 +536,8 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
                 ? (JSON.parse(await this.zon.value.text()) as MapZones)
                 : undefined,
               changelog: this.changelog.value,
-              resetLeaderboards: this.resetLbs.value
+              resetLeaderboards: this.resetLbs.value,
+              hasBSP: Boolean(this.bsp.value)
             }
           })
           .pipe(

--- a/libs/constants/src/types/queries/map-queries.model.ts
+++ b/libs/constants/src/types/queries/map-queries.model.ts
@@ -206,6 +206,7 @@ export type MapLeaderboardGetRunQuery = PagedQuery & {
 export interface CreateMapVersion
   extends Pick<MapVersion, 'changelog' | 'zones'> {
   resetLeaderboards?: boolean;
+  hasBSP: boolean;
 }
 
 export interface CreateMapVersionWithFiles {


### PR DESCRIPTION
Fixes an issue when there is an unused temporary BSP submitted by the user, which can be unintentionally used when submitting new map version

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
