### PR TITLE
fix(back): exclude bsp and vmf download ids only from plain objects

### DIFF
--- a/apps/backend/src/app/dto/map/map-version.dto.ts
+++ b/apps/backend/src/app/dto/map/map-version.dto.ts
@@ -59,10 +59,10 @@ export class MapVersionDto implements MapVersion {
   @IsOptional() // We don't include this on /submissions GET expand=zones due to size
   readonly zones: MapZonesDto;
 
-  @Exclude()
+  @Exclude({ toPlainOnly: true })
   readonly bspDownloadId: string;
 
-  @Exclude()
+  @Exclude({ toPlainOnly: true })
   readonly vmfDownloadId: string;
 
   @ApiProperty({ type: String, description: 'URL to BSP in cloud storage' })


### PR DESCRIPTION
This fixes map list not generating download urls properly

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
