### PR TITLE
feat(shared): add "Mixed" map tag

### DIFF
--- a/libs/constants/src/enums/map-tag.enum.ts
+++ b/libs/constants/src/enums/map-tag.enum.ts
@@ -107,5 +107,6 @@ export enum MapTag {
   _Num2__Way_Sym = 83,
   _Num4__Way_Sym = 84,
   Staged__Linear = 85,
-  Funkyboost = 86
+  Funkyboost = 86,
+  Mixed = 87
 }

--- a/libs/constants/src/maps/map-tags.map.ts
+++ b/libs/constants/src/maps/map-tags.map.ts
@@ -10,7 +10,8 @@ export const GlobalTags = [
   MapTag.Anti_Grav,
   MapTag.Moving_Surfaces,
   MapTag.Increased_Maxvel,
-  MapTag.Progressive_Difficulty
+  MapTag.Progressive_Difficulty,
+  MapTag.Mixed
 ];
 
 export const GamemodeTags = {


### PR DESCRIPTION
Discussed in today's meeting, often maps don't have any identifying mechanics so we're calling them "Mixed". But vague, but seems helpful for filtration so worth having.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
