### PR TITLE
Make private test invites accepted on creation

### DIFF
--- a/apps/backend-e2e/src/maps-2.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps-2.e2e-spec.ts
@@ -2154,10 +2154,11 @@ describe('Maps Part 2', () => {
         });
 
         const createdRequests = await prisma.mapTestInvite.findMany();
+        // TODO: Change states to MapTestInviteState.UNREAD once they can be manually accepted
         expect(createdRequests).toMatchObject([
-          { userID: u2.id, state: MapTestInviteState.UNREAD },
-          { userID: u3.id, state: MapTestInviteState.UNREAD },
-          { userID: u4.id, state: MapTestInviteState.UNREAD }
+          { userID: u2.id, state: MapTestInviteState.ACCEPTED },
+          { userID: u3.id, state: MapTestInviteState.ACCEPTED },
+          { userID: u4.id, state: MapTestInviteState.ACCEPTED }
         ]);
       });
 
@@ -2178,8 +2179,9 @@ describe('Maps Part 2', () => {
         });
 
         const createdRequests = await prisma.mapTestInvite.findMany();
+        // TODO: Change state to MapTestInviteState.UNREAD once they can be manually accepted
         expect(createdRequests).toMatchObject([
-          { userID: u3.id, state: MapTestInviteState.UNREAD }
+          { userID: u3.id, state: MapTestInviteState.ACCEPTED }
         ]);
       });
 
@@ -2229,7 +2231,8 @@ describe('Maps Part 2', () => {
         const createdRequests = await prisma.mapTestInvite.findMany();
         expect(createdRequests).toMatchObject([
           { userID: u3.id, state: MapTestInviteState.ACCEPTED },
-          { userID: u4.id, state: MapTestInviteState.UNREAD }
+          // TODO: Change this state to MapTestInviteState.UNREAD once they can be manually accepted
+          { userID: u4.id, state: MapTestInviteState.ACCEPTED }
         ]);
       });
 

--- a/apps/backend/src/app/modules/maps/map-test-invite.service.ts
+++ b/apps/backend/src/app/modules/maps/map-test-invite.service.ts
@@ -98,7 +98,9 @@ export class MapTestInviteService {
       data: difference(userIDs, existingInviteUserIDs).map((userID) => ({
         mapID,
         userID,
-        state: MapTestInviteState.UNREAD
+        // TODO: Change this to MapTestInviteState.UNREAD so invites can be
+        // manually accepted once we have the new notification system
+        state: MapTestInviteState.ACCEPTED
       }))
     });
 


### PR DESCRIPTION
Temporarily allows us to use private testing before adding ui to accept tests in frontend.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
