### PR TITLE
Make auth call Steam's GetPlayerSummaries much less

### DIFF
--- a/apps/backend-e2e/src/auth.e2e-spec.ts
+++ b/apps/backend-e2e/src/auth.e2e-spec.ts
@@ -174,7 +174,8 @@ describe('Auth', () => {
             data: {
               steamID: steamID,
               alias: steamData.personaname,
-              avatar: steamData.avatarhash
+              avatar: steamData.avatarhash,
+              country: steamData.loccountrycode
             }
           });
 
@@ -334,6 +335,7 @@ describe('Auth', () => {
       it('should create a new user and respond with a game JWT', async () => {
         const userSteamID = 1n;
         const userSteamSummary = {
+          profilestate: 1,
           steamid: userSteamID,
           personaname: 'Dogathan',
           avatarhash: 'ac7305567f93a4c9eec4d857df993191c61fb240_full.jpg',
@@ -380,7 +382,12 @@ describe('Auth', () => {
 
       it('should find an existing user and respond with a game JWT', async () => {
         const userDB = await prisma.user.create({
-          data: { steamID: 1, alias: 'Dogathan', country: 'QA' }
+          data: {
+            steamID: 1,
+            alias: 'Dogathan',
+            avatar: 'bbbbb5567f93a4c9eec4d857df993191c61fb240',
+            country: 'QA'
+          }
         });
         const userSteamSummary = {
           steamid: userDB.steamID,
@@ -418,14 +425,6 @@ describe('Auth', () => {
         expect(decrypted.steamID).toBe(userDB.steamID.toString());
 
         expect(decrypted.exp - decrypted.iat).toBe(60);
-
-        const updatedUserDB = await prisma.user.findFirst();
-        expect(updatedUserDB).toMatchObject({
-          steamID: userDB.steamID,
-          alias: userDB.alias,
-          country: userSteamSummary.loccountrycode,
-          avatar: 'bbbbb5567f93a4c9eec4d857df993191c61fb240'
-        });
       });
 
       it('should 400 when header is missing ID', async () => {
@@ -535,6 +534,7 @@ describe('Auth', () => {
       it('should create a new user and respond with a game JWT', async () => {
         const userSteamID = 1n;
         const userSteamSummary = {
+          profilestate: 1,
           steamid: userSteamID,
           personaname: 'Dogathan',
           avatarhash: 'ac7305567f93a4c9eec4d857df993191c61fb240_full.jpg',
@@ -584,7 +584,12 @@ describe('Auth', () => {
 
       it('should find an existing user and respond with a game JWT', async () => {
         const userDB = await prisma.user.create({
-          data: { steamID: 1, alias: 'Dogathan', country: 'QA' }
+          data: {
+            steamID: 1,
+            alias: 'Dogathan',
+            avatar: 'bbbbb5567f93a4c9eec4d857df993191c61fb240',
+            country: 'QA'
+          }
         });
         const userSteamSummary = {
           steamid: userDB.steamID,
@@ -625,14 +630,6 @@ describe('Auth', () => {
         expect(decrypted.steamID).toBe(userDB.steamID.toString());
 
         expect(decrypted.exp - decrypted.iat).toBe(60);
-
-        const updatedUserDB = await prisma.user.findFirst();
-        expect(updatedUserDB).toMatchObject({
-          steamID: userDB.steamID,
-          alias: userDB.alias, // Alias should not change after logging in if Alias is defined.
-          country: userDB.country, // Country should not change after logging in if Country is defined.
-          avatar: 'bbbbb5567f93a4c9eec4d857df993191c61fb240'
-        });
       });
 
       it('should 400 when header is missing ID', async () => {

--- a/apps/backend/src/app/dto/user/user.dto.ts
+++ b/apps/backend/src/app/dto/user/user.dto.ts
@@ -11,6 +11,7 @@ import {
 } from '@momentum/constants';
 import { ApiProperty, ApiPropertyOptional, PickType } from '@nestjs/swagger';
 import {
+  IsBoolean,
   IsInt,
   IsISO31661Alpha2,
   IsOptional,
@@ -125,6 +126,14 @@ export class UpdateUserDto {
   @IsISO31661Alpha2()
   @IsOptional()
   country?: string;
+
+  @ApiPropertyOptional({
+    type: Boolean,
+    description: 'Whether we need to get a new user avatar from Steam'
+  })
+  @IsBoolean()
+  @IsOptional()
+  resetAvatar?: boolean;
 
   @NestedProperty(UpdateSocialsDto)
   socials: UpdateSocialsDto;

--- a/apps/backend/src/app/modules/auth/steam/steam-game.guard.ts
+++ b/apps/backend/src/app/modules/auth/steam/steam-game.guard.ts
@@ -60,7 +60,7 @@ export class SteamGameGuard implements CanActivate {
       );
     }
 
-    const user = await this.userService.findOrCreateFromGame(steamID);
+    const user = await this.userService.findOrCreateUser(steamID);
 
     if (!user)
       throw new InternalServerErrorException('Could not get or create user');

--- a/apps/backend/src/app/modules/auth/steam/steam-openid.service.ts
+++ b/apps/backend/src/app/modules/auth/steam/steam-openid.service.ts
@@ -6,8 +6,6 @@ import {
 import { ConfigService } from '@nestjs/config';
 import openid from 'openid';
 import { FastifyRequest } from 'fastify';
-import { SteamService } from '../../steam/steam.service';
-import { SteamUserSummaryData } from '../../steam/steam.interface';
 
 /**
  * Handles OpenID calls to Steam. Unfortunately, Steam still uses OpenID 2.0
@@ -20,10 +18,7 @@ import { SteamUserSummaryData } from '../../steam/steam.interface';
 export class SteamOpenIDService {
   private readonly relyingParty: openid.RelyingParty;
 
-  constructor(
-    private readonly config: ConfigService,
-    private readonly steam: SteamService
-  ) {
+  constructor(private readonly config: ConfigService) {
     const authUrl = `${this.config.getOrThrow('url.backend')}/auth`;
     const apiKey = this.config.getOrThrow('steam.webAPIKey');
 
@@ -53,7 +48,7 @@ export class SteamOpenIDService {
     });
   }
 
-  async authenticate(request: FastifyRequest): Promise<SteamUserSummaryData> {
+  async authenticate(request: FastifyRequest): Promise<bigint> {
     return new Promise((resolve) =>
       this.relyingParty.verifyAssertion(
         request,
@@ -88,9 +83,7 @@ export class SteamOpenIDService {
             )
           );
 
-          return this.steam
-            .getSteamUserSummaryData(steamID)
-            .then((data) => resolve(data));
+          return resolve(steamID);
         }
       )
     );

--- a/apps/backend/src/app/modules/auth/steam/steam-web.guard.ts
+++ b/apps/backend/src/app/modules/auth/steam/steam-web.guard.ts
@@ -15,9 +15,9 @@ export class SteamWebGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request: FastifyRequest = context.switchToHttp().getRequest();
 
-    const userData = await this.steamOpenID.authenticate(request);
+    const steamID = await this.steamOpenID.authenticate(request);
 
-    request.user = await this.userService.findOrCreateFromWeb(userData);
+    request.user = await this.userService.findOrCreateUser(steamID);
 
     return true;
   }

--- a/apps/backend/src/app/modules/users/users.service.spec.ts
+++ b/apps/backend/src/app/modules/users/users.service.spec.ts
@@ -10,11 +10,9 @@ import { BadRequestException } from '@nestjs/common/exceptions/bad-request.excep
 import {
   ConflictException,
   ForbiddenException,
-  InternalServerErrorException,
   ServiceUnavailableException
 } from '@nestjs/common';
 import { User } from '@prisma/client';
-import { AuthenticatedUser } from '../auth/auth.interface';
 import { SteamUserSummaryData } from '../steam/steam.interface';
 import { KillswitchService } from '../killswitch/killswitch.service';
 
@@ -40,187 +38,6 @@ describe('UserService', () => {
     expect(db).toBeDefined();
   });
 
-  describe('findOrCreateFromGame', () => {
-    it("should throw an error when the steamid's don't match", async () => {
-      const steamUserSummaryData: SteamUserSummaryData = {
-        avatar: '',
-        avatarfull: '',
-        avatarhash: '',
-        avatarmedium: '',
-        communityvisibilitystate: 0,
-        lastlogoff: 0,
-        loccountrycode: '',
-        personaname: '',
-        personastate: 0,
-        personastateflags: 0,
-        primaryclanid: '',
-        profilestate: 0,
-        profileurl: '',
-        realname: '',
-        timecreated: 0,
-        steamid: '123456789'
-      };
-      jest
-        .spyOn(usersService['steamService'], 'getSteamUserSummaryData')
-        .mockResolvedValueOnce(steamUserSummaryData);
-      await expect(
-        usersService.findOrCreateFromGame(BigInt(999999999))
-      ).rejects.toThrow(BadRequestException);
-    });
-
-    it('should throw an error when getSteamUserSummaryData throws and error', async () => {
-      jest
-        .spyOn(usersService['steamService'], 'getSteamUserSummaryData')
-        .mockRejectedValueOnce('failed to start');
-      await expect(
-        usersService.findOrCreateFromGame(BigInt(123456789))
-      ).rejects.toThrow(ServiceUnavailableException);
-    });
-
-    it('should call findOrCreateUser', async () => {
-      const steamUserSummaryData: SteamUserSummaryData = {
-        avatar: 'avatar',
-        avatarfull: 'avatar full',
-        avatarhash: 'avatar hash',
-        avatarmedium: 'avatar medium',
-        communityvisibilitystate: 0,
-        lastlogoff: 1567,
-        loccountrycode: 'loc country code',
-        personaname: 'persona name',
-        personastate: 6534,
-        personastateflags: 343,
-        primaryclanid: 'primary clan id',
-        profilestate: 1,
-        profileurl: 'profile url',
-        realname: 'real name',
-        steamid: '123456789',
-        timecreated: 999887
-      };
-      jest
-        .spyOn(usersService['steamService'], 'getSteamUserSummaryData')
-        .mockResolvedValueOnce(steamUserSummaryData);
-      const spy = jest.spyOn(usersService, 'findOrCreateUser');
-      await usersService.findOrCreateFromGame(
-        BigInt(steamUserSummaryData.steamid)
-      );
-      expect(spy).toHaveBeenCalledWith({
-        steamID: BigInt(steamUserSummaryData.steamid),
-        alias: steamUserSummaryData.personaname,
-        avatar: steamUserSummaryData.avatarhash,
-        country: steamUserSummaryData.loccountrycode
-      });
-    });
-  });
-
-  describe('findOrCreateFromWeb', () => {
-    it('should error when profile state is not 1', async () => {
-      await expect(
-        usersService.findOrCreateFromWeb({
-          avatar: '',
-          avatarfull: '',
-          avatarhash: '',
-          avatarmedium: '',
-          communityvisibilitystate: 0,
-          lastlogoff: 0,
-          loccountrycode: '',
-          personaname: '',
-          personastate: 0,
-          personastateflags: 0,
-          primaryclanid: '',
-          profilestate: 2,
-          profileurl: '',
-          realname: '',
-          steamid: '',
-          timecreated: 0
-        })
-      ).rejects.toThrow(ForbiddenException);
-    });
-
-    it('should error when steamid is deleted', async () => {
-      db.deletedSteamID.findUnique.mockResolvedValueOnce({
-        steamID: BigInt(123456789)
-      } as any);
-      await expect(
-        usersService.findOrCreateFromWeb({
-          avatar: '',
-          avatarfull: '',
-          avatarhash: '',
-          avatarmedium: '',
-          communityvisibilitystate: 0,
-          lastlogoff: 0,
-          loccountrycode: '',
-          personaname: '',
-          personastate: 0,
-          personastateflags: 0,
-          primaryclanid: '',
-          profilestate: 1,
-          profileurl: '',
-          realname: '',
-          steamid: '123456789',
-          timecreated: 0
-        })
-      ).rejects.toThrow(ForbiddenException);
-    });
-
-    it('should call findOrCreateUser', async () => {
-      const spy = jest.spyOn(usersService, 'findOrCreateUser');
-      spy.mockResolvedValueOnce({
-        id: 0,
-        steamID: 0n
-      });
-      const steamUserSummaryData: SteamUserSummaryData = {
-        avatar: 'avatar',
-        avatarfull: 'avatar full',
-        avatarhash: 'avatar hash',
-        avatarmedium: 'avatar medium',
-        communityvisibilitystate: 0,
-        lastlogoff: 1567,
-        loccountrycode: 'loc country code',
-        personaname: 'persona name',
-        personastate: 6534,
-        personastateflags: 343,
-        primaryclanid: 'primary clan id',
-        profilestate: 1,
-        profileurl: 'profile url',
-        realname: 'real name',
-        steamid: '123456789',
-        timecreated: 999887
-      };
-      await usersService.findOrCreateFromWeb(steamUserSummaryData);
-      expect(spy).toHaveBeenCalledWith({
-        steamID: BigInt(steamUserSummaryData.steamid),
-        alias: steamUserSummaryData.personaname,
-        avatar: steamUserSummaryData.avatarhash,
-        country: steamUserSummaryData.loccountrycode
-      });
-    });
-
-    it('should error when no user is returned by findOrCreateUser', async () => {
-      const spy = jest.spyOn(usersService, 'findOrCreateUser');
-      spy.mockResolvedValueOnce(undefined);
-      await expect(
-        usersService.findOrCreateFromWeb({
-          avatar: '',
-          avatarfull: '',
-          avatarhash: '',
-          avatarmedium: '',
-          communityvisibilitystate: 0,
-          lastlogoff: 0,
-          loccountrycode: '',
-          personaname: '',
-          personastate: 0,
-          personastateflags: 0,
-          primaryclanid: '',
-          profilestate: 1,
-          profileurl: '',
-          realname: '',
-          steamid: '123456789',
-          timecreated: 0
-        })
-      ).rejects.toThrow(InternalServerErrorException);
-    });
-  });
-
   describe('findOrCreateUser', () => {
     it('should return an existing user', async () => {
       const existingUser: User = {
@@ -234,32 +51,11 @@ describe('UserService', () => {
         createdAt: undefined
       };
       db.user.findUnique.mockResolvedValueOnce(existingUser as any);
-      const authUser: AuthenticatedUser = {
-        id: 1234,
-        steamID: 123456789n
-      };
-      db.user.update.mockResolvedValueOnce(authUser as any);
 
-      const userData = {
-        steamID: BigInt(123456789),
-        alias: 'new alias',
-        avatar: 'new avatar',
-        country: 'new country'
-      };
-      const spy = jest.spyOn(db['user'], 'update');
-      await usersService.findOrCreateUser(userData);
-      expect(spy).toHaveBeenCalledWith({
-        where: { id: existingUser.id },
-        data: {
-          alias: existingUser.alias,
-          avatar: userData.avatar.replace('_full.jpg', ''),
-          country: existingUser.country
-        },
-        select: { id: true, steamID: true }
-      });
+      await usersService.findOrCreateUser(BigInt(123456789));
     });
 
-    it('should not create a new  if the killswitch is active', async () => {
+    it('should not create a new user if the killswitch is active', async () => {
       await killswitchService.updateKillswitches({
         NEW_SIGNUPS: true,
         MAP_REVIEWS: false,
@@ -270,16 +66,9 @@ describe('UserService', () => {
       const fakeUser: User = undefined;
       db.user.findUnique.mockResolvedValueOnce(fakeUser as any);
 
-      const userData = {
-        steamID: BigInt(123456789),
-        alias: 'alias',
-        avatar: 'avatar',
-        country: 'country'
-      };
-
-      await expect(usersService.findOrCreateUser(userData)).rejects.toThrow(
-        ConflictException
-      );
+      await expect(
+        usersService.findOrCreateUser(BigInt(123456789))
+      ).rejects.toThrow(ConflictException);
 
       // reset killswitches
       await killswitchService.updateKillswitches({
@@ -303,19 +92,6 @@ describe('UserService', () => {
       };
 
       db.user.findUnique.mockResolvedValueOnce(existingUser as any);
-      const authUser: AuthenticatedUser = {
-        id: 81237293,
-        steamID: 123456799n
-      };
-
-      db.user.update.mockResolvedValueOnce(authUser as any);
-
-      const userData = {
-        steamID: BigInt(123456799n),
-        alias: 'new alias',
-        avatar: 'new avatar',
-        country: 'new country'
-      };
 
       await killswitchService.updateKillswitches({
         NEW_SIGNUPS: true,
@@ -324,17 +100,7 @@ describe('UserService', () => {
         RUN_SUBMISSION: false
       });
 
-      const spy = jest.spyOn(db['user'], 'update');
-      await usersService.findOrCreateUser(userData);
-      expect(spy).toHaveBeenCalledWith({
-        where: { id: existingUser.id },
-        data: {
-          alias: existingUser.alias,
-          avatar: userData.avatar.replace('_full.jpg', ''),
-          country: existingUser.country
-        },
-        select: { id: true, steamID: true }
-      });
+      await usersService.findOrCreateUser(BigInt(123456799n));
 
       // reset killswitches
       await killswitchService.updateKillswitches({
@@ -351,20 +117,36 @@ describe('UserService', () => {
 
       const spy = jest.spyOn(db['user'], 'create');
 
-      const userData = {
-        steamID: BigInt(123456789),
-        alias: 'alias',
+      const steamUserSummaryData: SteamUserSummaryData = {
         avatar: 'avatar',
-        country: 'country'
+        avatarfull: 'avatar full',
+        avatarhash: 'avatar hash',
+        avatarmedium: 'avatar medium',
+        communityvisibilitystate: 0,
+        lastlogoff: 1567,
+        loccountrycode: 'loc country code',
+        personaname: 'persona name',
+        personastate: 6534,
+        personastateflags: 343,
+        primaryclanid: 'primary clan id',
+        profilestate: 1,
+        profileurl: 'profile url',
+        realname: 'real name',
+        steamid: '123456789',
+        timecreated: 999887
       };
-      await usersService.findOrCreateUser(userData);
+      jest
+        .spyOn(usersService['steamService'], 'getSteamUserSummaryData')
+        .mockResolvedValueOnce(steamUserSummaryData);
+
+      await usersService.findOrCreateUser(BigInt(123456789));
 
       expect(spy).toHaveBeenCalledWith({
         data: {
-          alias: userData.alias,
-          avatar: userData.avatar.replace('_full.jpg', ''),
-          country: userData.country,
-          steamID: userData.steamID
+          alias: steamUserSummaryData.personaname,
+          avatar: steamUserSummaryData.avatarhash.replace('_full.jpg', ''),
+          country: steamUserSummaryData.loccountrycode,
+          steamID: BigInt(123456789)
         },
         select: { id: true, steamID: true }
       });
@@ -381,15 +163,82 @@ describe('UserService', () => {
         .spyOn(usersService['steamService'], 'isAccountLimited')
         .mockResolvedValueOnce(true);
 
-      const userData = {
-        steamID: BigInt(123456789),
-        alias: '',
+      await expect(
+        usersService.findOrCreateUser(BigInt(123456789))
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw an error when getSteamUserSummaryData throws and error', async () => {
+      jest
+        .spyOn(usersService['steamService'], 'getSteamUserSummaryData')
+        .mockRejectedValueOnce('failed to start');
+      await expect(
+        usersService.findOrCreateUser(BigInt(123456789))
+      ).rejects.toThrow(ServiceUnavailableException);
+    });
+
+    it("should throw an error when the steamid's don't match", async () => {
+      const steamUserSummaryData: SteamUserSummaryData = {
         avatar: '',
-        country: ''
+        avatarfull: '',
+        avatarhash: '',
+        avatarmedium: '',
+        communityvisibilitystate: 0,
+        lastlogoff: 0,
+        loccountrycode: '',
+        personaname: '',
+        personastate: 0,
+        personastateflags: 0,
+        primaryclanid: '',
+        profilestate: 0,
+        profileurl: '',
+        realname: '',
+        timecreated: 0,
+        steamid: '123456789'
       };
-      await expect(usersService.findOrCreateUser(userData)).rejects.toThrow(
-        ForbiddenException
-      );
+      jest
+        .spyOn(usersService['steamService'], 'getSteamUserSummaryData')
+        .mockResolvedValueOnce(steamUserSummaryData);
+      await expect(
+        usersService.findOrCreateUser(BigInt(999999999))
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should error when profile state is not 1', async () => {
+      const steamUserSummaryData: SteamUserSummaryData = {
+        avatar: '',
+        avatarfull: '',
+        avatarhash: '',
+        avatarmedium: '',
+        communityvisibilitystate: 0,
+        lastlogoff: 0,
+        loccountrycode: '',
+        personaname: '',
+        personastate: 0,
+        personastateflags: 0,
+        primaryclanid: '',
+        profilestate: 2,
+        profileurl: '',
+        realname: '',
+        steamid: '123456789',
+        timecreated: 0
+      };
+      jest
+        .spyOn(usersService['steamService'], 'getSteamUserSummaryData')
+        .mockResolvedValueOnce(steamUserSummaryData);
+
+      await expect(
+        usersService.findOrCreateUser(BigInt(123456789))
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should error when steamid is deleted', async () => {
+      db.deletedSteamID.findUnique.mockResolvedValueOnce({
+        steamID: BigInt(123456789)
+      } as any);
+      await expect(
+        usersService.findOrCreateUser(BigInt(123456789))
+      ).rejects.toThrow(ForbiddenException);
     });
   });
 });

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -145,7 +145,7 @@
             <div class="flex items-center" [mTooltip]="requiredGamesTooltip">
               @for (gameImage of requiredGamesImages; track $index) {
                 <img
-                  class="-mr-3 aspect-square h-6 rounded-md drop-shadow-[0_0_0.175rem_#000]"
+                  class="{{ !$last ? '-mr-3' : '' }} aspect-square h-6 rounded-md drop-shadow-[0_0_0.175rem_#000]"
                   [style]="{ zIndex: -$index }"
                   [src]="gameImage"
                 />

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -214,7 +214,7 @@
                     @for (credit of credits.get(type); track $index) {
                       @if (!credit.placeholder) {
                         <a routerLink="/profile/{{ credit.userID }}" class="flex items-center">
-                          <m-avatar class="mr-4 h-8 w-8" [url]="credit.avatarURL" />
+                          <m-avatar class="mr-4 h-8 w-8 shrink-0" [url]="credit.avatarURL" />
                           <div class="flex flex-col justify-center">
                             <p class="text-shadow font-medium leading-none">{{ credit.alias }}</p>
                             <p class="font-gray-100 text-shadow col-start-2 text-sm italic">{{ credit.description }}</p>
@@ -222,7 +222,7 @@
                         </a>
                       } @else {
                         <div class="flex items-center">
-                          <div class="mr-4 inline-grid h-8 w-8 place-content-center" mTooltip="Placeholder user">
+                          <div class="mr-4 inline-grid h-8 w-8 shrink-0 place-content-center" mTooltip="Placeholder user">
                             <p class="text-shadow-strong pointer-events-none font-display text-32 font-bold">?</p>
                           </div>
                           <div class="flex flex-col justify-center">

--- a/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.html
+++ b/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.html
@@ -5,7 +5,7 @@
       <div class="mb-4 flex flex-col gap-4">
         <div [ngClass]="{ 'has-error': !alias.valid }">
           <p class="text-lg">Alias</p>
-          <div class="relative flex w-full items-stretch">
+          <div class="relative flex w-full items-stretch gap-2">
             <input class="textinput mb-1" formControlName="alias" type="text" />
             @if (!hasBan(Ban.ALIAS) || isModOrAdmin) {
               <div class="input-group-append">
@@ -38,6 +38,13 @@
             [filter]="true"
           />
         </div>
+
+        @if (!hasBan(Ban.AVATAR) || isModOrAdmin) {
+          <div>
+            <p class="text-lg">Avatar</p>
+            <button class="btn" type="button" (click)="resetAvatar()">Update from Steam</button>
+          </div>
+        }
 
         <div [ngClass]="{ 'has-error': !bio.valid }">
           <div class="flex items-end justify-between">

--- a/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.ts
+++ b/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.ts
@@ -191,6 +191,14 @@ export class ProfileEditComponent implements OnInit {
     this.checkUserPermissions();
   }
 
+  updateUser() {
+    this.usersService
+      .getUser(this.user.id, {
+        expand: ['profile', 'userStats']
+      })
+      .subscribe((user) => this.setUser(user));
+  }
+
   onSubmit(): void {
     if (!this.form.valid) return;
 
@@ -407,9 +415,13 @@ export class ProfileEditComponent implements OnInit {
   }
 
   resetAlias() {
-    this.localUserService.resetAliasToSteamAlias().subscribe({
+    (this.isLocal
+      ? this.localUserService.resetAliasToSteamAlias()
+      : this.adminService.resetUserAliasToSteamAlias(this.user.id)
+    ).subscribe({
       next: () => {
-        this.localUserService.refreshLocalUser();
+        if (this.isLocal) this.localUserService.refreshLocalUser();
+        else this.updateUser();
         this.messageService.add({
           severity: 'success',
           detail: 'Successfully reset alias to Steam name!'

--- a/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.ts
+++ b/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.ts
@@ -131,7 +131,8 @@ export class ProfileEditComponent implements OnInit {
       ],
       bio: ['', [Validators.maxLength(MAX_BIO_LENGTH)]],
       country: [''],
-      socials: this.fb.group(socialsForm)
+      socials: this.fb.group(socialsForm),
+      resetAvatar: [false]
     });
 
     this.adminEditForm = this.fb.group({
@@ -418,6 +419,27 @@ export class ProfileEditComponent implements OnInit {
         this.messageService.add({
           severity: 'error',
           summary: 'Failed to reset alias to Steam alias!',
+          detail: httpError.error.message
+        })
+    });
+  }
+
+  resetAvatar() {
+    (this.isLocal
+      ? this.localUserService.updateAvatarFromSteam()
+      : this.adminService.updateUserAvatarFromSteam(this.user.id)
+    ).subscribe({
+      next: () => {
+        if (this.isLocal) this.localUserService.refreshLocalUser();
+        this.messageService.add({
+          severity: 'success',
+          detail: 'Successfully updated avatar!'
+        });
+      },
+      error: (httpError: HttpErrorResponse) =>
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Failed to update avatar!',
           detail: httpError.error.message
         })
     });

--- a/apps/frontend/src/app/services/data/admin.service.ts
+++ b/apps/frontend/src/app/services/data/admin.service.ts
@@ -35,6 +35,11 @@ export class AdminService {
   updateUser(userID: number, body: AdminUpdateUser): Observable<void> {
     return this.http.patch(`admin/users/${userID}`, { body });
   }
+  updateUserAvatarFromSteam(userID: number): Observable<void> {
+    return this.http.patch(`admin/users/${userID}`, {
+      body: { resetAvatar: true }
+    });
+  }
 
   getReports(query?: AdminGetReportsQuery): Observable<PagedResponse<Report>> {
     return this.http.get<PagedResponse<Report>>('admin/reports', { query });

--- a/apps/frontend/src/app/services/data/admin.service.ts
+++ b/apps/frontend/src/app/services/data/admin.service.ts
@@ -35,6 +35,11 @@ export class AdminService {
   updateUser(userID: number, body: AdminUpdateUser): Observable<void> {
     return this.http.patch(`admin/users/${userID}`, { body });
   }
+
+  resetUserAliasToSteamAlias(userID: number): Observable<void> {
+    return this.http.patch(`admin/users/${userID}`, { body: { alias: '' } });
+  }
+
   updateUserAvatarFromSteam(userID: number): Observable<void> {
     return this.http.patch(`admin/users/${userID}`, {
       body: { resetAvatar: true }

--- a/apps/frontend/src/app/services/data/local-user.service.ts
+++ b/apps/frontend/src/app/services/data/local-user.service.ts
@@ -211,6 +211,10 @@ export class LocalUserService {
     return this.http.patch('user', { body: { alias: '' } });
   }
 
+  public updateAvatarFromSteam(): Observable<void> {
+    return this.http.patch('user', { body: { resetAvatar: true } });
+  }
+
   public getSteamFriends(): Observable<User[]> {
     return this.http.get<User[]>('user/steamfriends');
   }

--- a/libs/constants/src/types/queries/user-queries.model.ts
+++ b/libs/constants/src/types/queries/user-queries.model.ts
@@ -8,6 +8,7 @@ export interface UpdateUser {
   alias?: string;
   bio?: string;
   socials?: Socials;
+  resetAvatar?: boolean;
 }
 
 export interface AdminUpdateUser extends UpdateUser {


### PR DESCRIPTION
Before we were calling steam for user data every time user tries to authenticate to update out saved data, but it doesn't make much sense. So now we would call steam only for user account creation

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
