### PR TITLE
Use Steam partner api url

### DIFF
--- a/apps/backend/src/app/config/config.interface.ts
+++ b/apps/backend/src/app/config/config.interface.ts
@@ -25,6 +25,7 @@ export interface ConfigInterface {
   };
   steam: {
     webAPIKey: string;
+    webAPIUrl: string;
     preventLimited: boolean;
     useSteamTicketLibrary: boolean;
     ticketsSecretKey: string;

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -45,6 +45,10 @@ export const ConfigFactory = (): ConfigInterface => {
     sessionSecret: process.env['SESSION_SECRET'] || '',
     steam: {
       webAPIKey: process.env['STEAM_WEB_API_KEY'] || "This won't work!!",
+      webAPIUrl:
+        process.env['STEAM_USE_PARTNER_URL'] === 'true'
+          ? 'https://partner.steam-api.com'
+          : 'https://api.steampowered.com',
       preventLimited: process.env['STEAM_PREVENT_LIMITED'] !== 'false' || true,
       useSteamTicketLibrary:
         process.env['STEAM_USE_ENCRYPTED_TICKETS'] === 'true' || false,

--- a/apps/backend/src/app/modules/steam/steam.service.ts
+++ b/apps/backend/src/app/modules/steam/steam.service.ts
@@ -39,7 +39,8 @@ export class SteamService {
   ): Promise<SteamUserSummaryData> {
     const getPlayerResponse = await lastValueFrom(
       this.http.get(
-        'https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/',
+        this.config.get('steam.webAPIUrl') +
+          '/ISteamUser/GetPlayerSummaries/v2/',
         {
           params: {
             key: this.config.getOrThrow('steam.webAPIKey'),
@@ -80,13 +81,16 @@ export class SteamService {
   async getSteamFriends(steamID: bigint): Promise<SteamFriendData[]> {
     return lastValueFrom(
       this.http
-        .get('https://api.steampowered.com/ISteamUser/GetFriendList/v1/', {
-          params: {
-            key: this.steamApiKey,
-            steamID: steamID,
-            relationship: 'friend'
+        .get(
+          this.config.get('steam.webAPIUrl') + '/ISteamUser/GetFriendList/v1/',
+          {
+            params: {
+              key: this.steamApiKey,
+              steamID: steamID,
+              relationship: 'friend'
+            }
           }
-        })
+        )
         .pipe(
           map((res) => res?.data?.friendslist?.friends),
           catchError((error: AxiosError) => {
@@ -123,7 +127,8 @@ export class SteamService {
     const steamResponse = await lastValueFrom(
       this.http
         .get(
-          'https://api.steampowered.com/ISteamUserAuth/AuthenticateUserTicket/v1/',
+          this.config.get('steam.webAPIUrl') +
+            '/ISteamUserAuth/AuthenticateUserTicket/v1/',
           {
             params: {
               key: this.config.getOrThrow('steam.webAPIKey'),


### PR DESCRIPTION
Adding this in another attempt to make Steam API calls not throw 429 errors.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
