### PR TITLE
Don't remove last version when approving a map

### DIFF
--- a/apps/backend-e2e/src/multi-stage.e2e-spec.ts
+++ b/apps/backend-e2e/src/multi-stage.e2e-spec.ts
@@ -173,6 +173,28 @@ describe('Multi-stage E2E tests', () => {
         {
           file: vmf2Buffer,
           field: 'vmfs',
+          fileName: 'surf_todd_howard_main_0.vmf'
+        },
+        {
+          file: vmf2Buffer,
+          field: 'vmfs',
+          fileName: 'surf_todd_howard_instance_0.vmf'
+        }
+      ],
+      validate: MapDto,
+      token
+    });
+
+    // Update VMFs once again without a new BSP file so we could test
+    // if last version file stays there
+    await req.postAttach({
+      url: `maps/${mapID}`,
+      status: 201,
+      data: { changelog: 'it just works' },
+      files: [
+        {
+          file: vmf2Buffer,
+          field: 'vmfs',
           fileName: 'surf_todd_howard_main.vmf'
         },
         {

--- a/apps/frontend/src/app/components/map-list/map-list-item.component.html
+++ b/apps/frontend/src/app/components/map-list/map-list-item.component.html
@@ -80,7 +80,7 @@
     class="border-t-none flex grow flex-col rounded-b border border-white border-opacity-5 bg-white bg-opacity-5 p-4 pt-3.5 backdrop-blur-xl transition-colors group-hover:bg-opacity-10"
   >
     <div class="mb-2 flex min-h-[2rem] flex-wrap items-center gap-y-2">
-      <p class="contents min-h-[2rem]" [fontSizeLerp]="{ chars: name.length, maxChars: 29, startAt: 16, baseRem: 2, minRem: 1.75 }">
+      <p class="contents min-h-[2rem]" [fontSizeLerp]="{ chars: name.length + prefix?.length, startAt: 26, baseRem: 2 }">
         @if (prefix) {
           <span class="mr-1 font-display font-bold leading-none text-gray-250">{{ prefix }}</span>
         }

--- a/apps/frontend/src/app/directives/font-size-lerp.directive.ts
+++ b/apps/frontend/src/app/directives/font-size-lerp.directive.ts
@@ -15,20 +15,17 @@ import { Directive, HostBinding, Input, OnChanges } from '@angular/core';
 export class FontSizeLerpDirective implements OnChanges {
   @Input('fontSizeLerp') options: {
     chars: number;
-    maxChars: number;
     startAt: number;
     baseRem: number;
-    minRem: number;
   };
 
   @HostBinding('style.font-size') fontSize: string;
 
   ngOnChanges() {
-    const { chars, maxChars, startAt, baseRem, minRem } = this.options;
+    const { chars, startAt, baseRem } = this.options;
     let val = baseRem;
     if (chars > startAt) {
-      const k = (chars - startAt) / (maxChars - startAt);
-      val -= (baseRem - minRem) * k;
+      val = (baseRem * startAt) / chars;
     }
     this.fontSize = `${val}rem`;
   }

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -5,7 +5,7 @@
            padding. But vertical space is so precious here! -->
       <div class="-mt-4 flex h-24 flex-[1_1_auto] flex-col">
         <p class="card-title -mb-1 mt-auto text-[2rem] text-gray-200">{{ prefix }}</p>
-        <p class="card-title" [fontSizeLerp]="{ chars: name.length, maxChars: 29, startAt: 16, baseRem: 4.5, minRem: 2.5 }">
+        <p class="card-title" [fontSizeLerp]="{ chars: name.length, startAt: 16, baseRem: 4.5 }">
           {{ name }}
         </p>
       </div>

--- a/apps/frontend/src/app/pages/profile/profile.component.html
+++ b/apps/frontend/src/app/pages/profile/profile.component.html
@@ -17,7 +17,7 @@
           <div class="flex gap-1">
             <h1
               class="flex flex-grow items-center gap-2 font-medium"
-              [fontSizeLerp]="{ chars: user.alias.length, maxChars: 29, startAt: 16, baseRem: 2.25, minRem: 1.5 }"
+              [fontSizeLerp]="{ chars: user.alias.length, startAt: 16, baseRem: 2.25 }"
             >
               {{ user.alias }}
               @if (user.country && user.country.length === 2) {


### PR DESCRIPTION
Fixes an issue where a map file would be deleted if the last version didn't include the file, but was referencing the older one.

This PR also includes a commit with better text scaling algorithm. I just had it lying around for a while.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
