### PR TITLE
Fix discord double pings

### DIFF
--- a/apps/discord-bot-internal/src/twitch-api.ts
+++ b/apps/discord-bot-internal/src/twitch-api.ts
@@ -14,11 +14,17 @@ export class TwitchAPI {
   private async apiGet(path: string, query: Record<string, any>) {
     await this.checkToken();
 
+    const searchParams = new URLSearchParams();
+    for (const [k, v] of Object.entries(query)) {
+      if (Array.isArray(v)) {
+        v.forEach((vv) => searchParams.append(k, vv));
+      } else {
+        searchParams.append(k, v);
+      }
+    }
+
     const response = await axios.get(
-      'https://api.twitch.tv/' +
-        path +
-        '?' +
-        new URLSearchParams(query).toString(),
+      'https://api.twitch.tv/' + path + '?' + searchParams.toString(),
       {
         headers: {
           Authorization: 'Bearer ' + this.token,

--- a/apps/discord-bot-internal/src/twitch-api.ts
+++ b/apps/discord-bot-internal/src/twitch-api.ts
@@ -81,13 +81,18 @@ export class TwitchAPI {
   }
 
   async getLiveMomentumModStreams(): Promise<TwitchStream[]> {
+    const additionalStreams =
+      config.twitch_momentum_mod_official_channels.length > 0
+        ? this.apiGet('helix/streams', {
+            user_id: config.twitch_momentum_mod_official_channels
+          })
+        : Promise.resolve({ data: [] });
+
     return await Promise.all([
       this.apiGet('helix/streams', {
         game_id: config.twitch_momentum_mod_game_id
       }),
-      this.apiGet('helix/streams', {
-        user_id: config.twitch_momentum_mod_official_channels.join(',')
-      })
+      additionalStreams
     ]).then((arr) => arr.flatMap(({ data }) => data));
   }
 

--- a/apps/discord-bot-internal/src/twitch-api.ts
+++ b/apps/discord-bot-internal/src/twitch-api.ts
@@ -96,6 +96,12 @@ export class TwitchAPI {
     ]).then((arr) => arr.flatMap(({ data }) => data));
   }
 
+  async getStreams(ids: string[]): Promise<TwitchStream[]> {
+    return await this.apiGet('helix/streams', {
+      user_id: ids
+    }).then(({ data }) => data);
+  }
+
   async getUser(id: string): Promise<TwitchUser | null> {
     return await this.apiGet('helix/users', { id }).then(
       ({ data }) => data[0] ?? null


### PR DESCRIPTION
Closes #1127

Made so that bot fetches ended streams to see if they actually ended since twitch api sometimes just doesn't provide some active streams when fetching them by category

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
