### PR TITLE
fix(front): update review list in the case we comment on a deleted review

### DIFF
--- a/apps/backend-e2e/src/map-review.e2e-spec.ts
+++ b/apps/backend-e2e/src/map-review.e2e-spec.ts
@@ -489,6 +489,18 @@ describe('Map Reviews', () => {
 
       afterAll(() => db.cleanup('mMap', 'user'));
 
+      it('should 400 if commenting on non-existing review', () =>
+        req.post({
+          url: `map-review/${NULL_ID}/comments`,
+          status: 400,
+          body: {
+            data: {
+              text: 'Not disgusting!!'
+            }
+          },
+          token: token
+        }));
+
       it('should 503 if the killswitch is true', async () => {
         await req.patch({
           url: 'admin/killswitch',

--- a/apps/backend/src/app/modules/map-review/map-review-comment.service.ts
+++ b/apps/backend/src/app/modules/map-review/map-review-comment.service.ts
@@ -137,6 +137,12 @@ export class MapReviewCommentService {
       include: { mmap: true }
     });
 
+    if (!review) {
+      throw new BadRequestException(
+        'Review not found, maybe it has been deleted?'
+      );
+    }
+
     await this.mapsService.getMapAndCheckReadAccess({
       map: review.mmap,
       userID,

--- a/apps/frontend/src/app/components/map-review/map-review.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review.component.ts
@@ -236,12 +236,15 @@ export class MapReviewComponent {
           this._review.comments.unshift(res);
           this._review.numComments++;
         },
-        error: (httpError: HttpErrorResponse) =>
+        error: (httpError: HttpErrorResponse) => {
           this.messageService.add({
             severity: 'error',
             detail: httpError.error.message,
             summary: 'Failed to post comment!'
-          })
+          });
+          this.loadingComments = false;
+          this.updatedOrDeleted.next();
+        }
       });
     this.commentInput.reset();
   }


### PR DESCRIPTION
Added an adecuate message when the review has been deleted, also made it so the review list updates in case the error is triggered.