### PR TITLE
fix(back): use main track segements for defrag bonuses

### DIFF
--- a/apps/backend/src/app/modules/session/run/run-processor.class.spec.ts
+++ b/apps/backend/src/app/modules/session/run/run-processor.class.spec.ts
@@ -610,6 +610,33 @@ describe('RunProcessor', () => {
           zones
         });
       });
+
+      it('should use main track segments if defragModifiers are used', () => {
+        zones.tracks.bonuses = [{ defragModifiers: 8 }];
+
+        expectPass({
+          session: {
+            trackType: TrackType.BONUS,
+            timestamps: [
+              { createdAt: cat(0), time: 0, majorNum: 1, minorNum: 1 },
+              { createdAt: cat(10000), time: 10, majorNum: 1, minorNum: 2 }
+            ]
+          },
+          zones
+        });
+
+        expectFail({
+          session: {
+            trackType: TrackType.BONUS,
+            timestamps: [
+              { createdAt: cat(0), time: 0, majorNum: 1, minorNum: 1 },
+              { createdAt: cat(10000), time: 10, majorNum: 1, minorNum: 2 },
+              { createdAt: cat(20000), time: 20, majorNum: 1, minorNum: 3 }
+            ]
+          },
+          zones
+        });
+      });
     });
   });
 

--- a/apps/backend/src/app/modules/session/run/run-processor.class.ts
+++ b/apps/backend/src/app/modules/session/run/run-processor.class.ts
@@ -122,7 +122,10 @@ export class RunProcessor {
       const segment =
         trackType === TrackType.STAGE
           ? this.zones.tracks.main.zones.segments[trackNum - 1]
-          : this.zones.tracks.bonuses[trackNum - 1].zones.segments[0];
+          : this.zones.tracks.bonuses[trackNum - 1].defragModifiers !==
+              undefined
+            ? this.zones.tracks.main.zones.segments[0]
+            : this.zones.tracks.bonuses[trackNum - 1].zones.segments[0];
 
       this.validateSegment(segment, timestamps);
 


### PR DESCRIPTION
Closes #1171

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
