### PR TITLE
Document various failure responses to game auth

### DIFF
--- a/apps/backend/src/app/modules/auth/auth.controller.ts
+++ b/apps/backend/src/app/modules/auth/auth.controller.ts
@@ -13,12 +13,18 @@ import {
   VERSION_NEUTRAL
 } from '@nestjs/common';
 import {
+  ApiBadGatewayResponse,
+  ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
+  ApiConflictResponse,
+  ApiForbiddenResponse,
   ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
-  ApiTags
+  ApiServiceUnavailableResponse,
+  ApiTags,
+  ApiUnauthorizedResponse
 } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { FastifyReply, FastifyRequest } from 'fastify';
@@ -108,6 +114,27 @@ export class AuthController {
   @ApiOkResponse({
     type: JWTResponseGameDto,
     description: 'Authorized steam user token'
+  })
+  @ApiForbiddenResponse({
+    description:
+      'For limited Steam accounts, or accounts that permanently deleted themselves'
+  })
+  @ApiServiceUnavailableResponse({
+    description:
+      'When authenticate requires us request from Steam, and Steam is down'
+  })
+  @ApiConflictResponse({
+    description:
+      "When player is a new account and we've temporarily disabled sign-ups"
+  })
+  @ApiUnauthorizedResponse({
+    description: 'When login token is invalid'
+  })
+  @ApiBadRequestResponse({
+    description: 'When provided login data is malformed'
+  })
+  @ApiBadGatewayResponse({
+    description: 'If this API is down'
   })
   async steamGameAuth(
     @Req() req: RawBodyRequest<FastifyRequest>,


### PR DESCRIPTION
C++/TS code is going to switch over various authentication failure cases so getting these documented better.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
