### PR TITLE
fix(front): progress percentage on BSP upload

### DIFF
--- a/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.html
+++ b/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.html
@@ -57,7 +57,7 @@
     </div>
   }
   @if (isUploading) {
-    <p-progressBar class="mb-2 mt-8" [value]="uploadPercentage" [showValue]="true" />
+    <p-progressBar class="mb-2 mt-8" [value]="uploadPercentage" [showValue]="false" />
     <p class="text-center italic">{{ uploadStatusDescription }}</p>
   }
 </form>

--- a/apps/frontend/src/app/pages/maps/submission-form/map-submission-form.component.html
+++ b/apps/frontend/src/app/pages/maps/submission-form/map-submission-form.component.html
@@ -351,7 +351,7 @@
     <div class="mt-4 flex">
       @if (isUploading) {
         <div class="my-auto flex flex-grow flex-col">
-          <p-progressBar [value]="uploadPercentage" [showValue]="true" class="mr-6" />
+          <p-progressBar [value]="uploadPercentage" [showValue]="false" class="mr-6" />
           <p class="mt-2 text-center italic">{{ uploadStatusDescription }}</p>
         </div>
       }


### PR DESCRIPTION
closes #1124 

I just disabled the percentage from showing,
both when submitting map, and when updating existing submission with new bsp, since bug is for both.

Not sure if this was what I was actually supposed to do, but I think it looks good without a percentage showing somewhere (else).

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
