### PR TITLE
chore(meta): remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @tsa96 @GordiNoki


### PR DESCRIPTION
Okay I'm an idiot. I thought I could use this to replace the `reviewers` field in dependabot config but this makes Github request review from us for EVERY branch. Seems like more trouble than it's worth, annoying that GH is deprecating REVIEWERS.
