### PR TITLE
fix(front): remove animation on profile xp bar

### DIFF
--- a/apps/frontend/src/app/theme/primeng-preset.ts
+++ b/apps/frontend/src/app/theme/primeng-preset.ts
@@ -55,7 +55,8 @@ export const MomentumPreset = definePreset(Material, {
       value: {
         background:
           'linear-gradient(90deg, rgb(var(--blue-500)), rgb(var(--blue-300)))'
-      }
+      },
+      css: () => '.p-progressbar-value { transition: none !important; }'
     },
     dialog: {
       shadow: '1px 3px 8px rgb(0 0 0 / 0.5)',


### PR DESCRIPTION
Closes #1169 



Disables the value changed animation which was previously triggered when switching between two profiles with different xp values. 

### Screenshots

No visual changes to xp bar. See #1169 for original behavior.

![image](https://github.com/user-attachments/assets/3b749a36-b363-420b-8579-9cdafd276a0a)

#### Comments
NG doesn't support disabling this natively - opted for a css override. Imo it's small enough to be inline, but if it needs to be moved let me know.