### PR TITLE
chore(shared): remove map download stat

### DIFF
--- a/apps/backend/src/app/dto/map/map-stats.dto.ts
+++ b/apps/backend/src/app/dto/map/map-stats.dto.ts
@@ -14,10 +14,6 @@ export class MapStatsDto implements MapStats {
 
   @ApiProperty()
   @IsInt()
-  readonly downloads: number;
-
-  @ApiProperty()
-  @IsInt()
   readonly subscriptions: number;
 
   @ApiProperty()

--- a/apps/frontend/src/app/icons/packs/material-design-icons.icons.ts
+++ b/apps/frontend/src/app/icons/packs/material-design-icons.icons.ts
@@ -30,7 +30,6 @@ export {
   mdiStar,
   mdiStarOutline,
   mdiDownload,
-  mdiDownloadOutline,
   mdiPlayCircle,
   mdiPlayCircleOutline,
   mdiArrowRightThick,

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -93,7 +93,7 @@
                 <button type="button" (click)="gallery.show()" class="absolute bottom-[-3px] right-4 cursor-zoom-in">
                   <m-icon icon="fullscreen" class="h-8 w-8" />
                 </button>
-                <!-- 
+                <!--
                 Note that between this and the m-gallery component, we create two
                 different youtube iframes. This really sucks, but I don't know how to
                 avoid it. ng-template + ngTemplateOutlet isn't helpful, just creates two
@@ -127,10 +127,6 @@
           <div class="flex items-center gap-1" mTooltip="{{ map.stats?.plays | plural: 'Play' }}">
             <m-icon class="mb-0.5 text-24 drop-shadow-md" icon="play-circle-outline"></m-icon>
             <p class="font-display text-24 drop-shadow-md">{{ map.stats?.plays | thousandsSuffix: 1 }}</p>
-          </div>
-          <div class="flex items-center gap-1" mTooltip="{{ map.stats?.downloads | plural: 'Download' }}">
-            <m-icon class="text-24 leading-4 drop-shadow-md" icon="download-outline"></m-icon>
-            <p class="font-display text-24 drop-shadow-md">{{ map.stats?.downloads | thousandsSuffix: 1 }}</p>
           </div>
           <div class="flex items-center gap-1" mTooltip="{{ map.stats?.favorites | plural: 'Favorite' }}">
             <m-icon class="mb-0.5 text-24 drop-shadow-md" icon="star"></m-icon>
@@ -250,7 +246,7 @@
     <div>
       <div class="stack card card--fancy border-opacity-[0.0675] p-4">
         <m-map-leaderboard [ngClass]="{ hidden: currentSection !== MapInfoSection.LEADERBOARDS }" [map]="map" />
-        <!-- Don't insert this at all if not in submission, we don't want to 
+        <!-- Don't insert this at all if not in submission, we don't want to
              try fetch extra data/images unless we're may actually display it.
          -->
         @if (this.map.status !== MapStatus.APPROVED) {

--- a/libs/constants/src/types/models/models.ts
+++ b/libs/constants/src/types/models/models.ts
@@ -318,7 +318,6 @@ export interface MapReviewSuggestion {
 
 export interface MapStats {
   reviews: number;
-  downloads: number;
   subscriptions: number;
   plays: number;
   favorites: number;

--- a/libs/db/src/migrations/20250615214013_remove_download_stat/migration.sql
+++ b/libs/db/src/migrations/20250615214013_remove_download_stat/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `downloads` on the `MapStats` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "MapStats" DROP COLUMN "downloads";

--- a/libs/db/src/schema.prisma
+++ b/libs/db/src/schema.prisma
@@ -275,7 +275,6 @@ model MapInfo {
 
 model MapStats {
   reviews           Int    @default(0)
-  downloads         Int    @default(0)
   subscriptions     Int    @default(0)
   plays             Int    @default(0)
   favorites         Int    @default(0)

--- a/scripts/src/seed.script.ts
+++ b/scripts/src/seed.script.ts
@@ -621,7 +621,6 @@ prismaWrapper(async (prisma: PrismaClient) => {
           stats: {
             create: {
               reviews: Random.int(10000),
-              downloads: Random.int(10000),
               subscriptions: Random.int(10000),
               plays: Random.int(10000),
               favorites: Random.int(10000),


### PR DESCRIPTION
closes #585 

removes download stat from maps

haven't found anywhere where that stat is actually set, so if there is any remnants on game repo or idk, needs to be removed as well

![vivaldi_CnVDdSWnw5](https://github.com/user-attachments/assets/35a3d42a-3ee4-4d52-a30c-ac2a38a86334)

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
