### PR TITLE
fix(back-e2e): order versions to get the last one properly

### DIFF
--- a/apps/backend-e2e/src/admin.e2e-spec.ts
+++ b/apps/backend-e2e/src/admin.e2e-spec.ts
@@ -2012,7 +2012,7 @@ describe('Admin', () => {
 
         const updated = await prisma.mMap.findFirst({
           where: { id: map.id },
-          include: { versions: true }
+          include: { versions: { orderBy: { versionNum: 'asc' } } }
         });
 
         expect(updated.status).toBe(MapStatus.DISABLED);


### PR DESCRIPTION
Hopefully this will finally fix the admin flaky test

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
