### PR TITLE
Securely hash SteamID of deleted users

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Closes #<!--(issue number here)-->
 
 ### Checks
 
-- [ ] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
+- [ ] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
 - [ ] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
 - [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
 - [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit

--- a/create-migration.sh
+++ b/create-migration.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -i
+
+# Generates a migration with the given name. Nx executors still fail to run
+# in interactive mode, despite Nx claiming it's supported.
+# (https://github.com/nrwl/nx/issues/8269)
+
+export "$(grep -v '^#' .env | xargs)"
+npx prisma migrate dev --name "$1" --skip-seed --schema ./libs/db/src/schema.prisma

--- a/libs/db/src/migrations/20250617213140_hash_deleted_users/migration.sql
+++ b/libs/db/src/migrations/20250617213140_hash_deleted_users/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the `DeletedSteamID` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "DeletedSteamID";
+
+-- CreateTable
+CREATE TABLE "DeletedUser" (
+    "steamIDHash" CHAR(64) NOT NULL,
+
+    CONSTRAINT "DeletedUser_pkey" PRIMARY KEY ("steamIDHash")
+);

--- a/libs/db/src/schema.prisma
+++ b/libs/db/src/schema.prisma
@@ -72,8 +72,8 @@ model UserStats {
   userID Int  @id
 }
 
-model DeletedSteamID {
-  steamID BigInt @id @db.BigInt
+model DeletedUser {
+  steamIDHash String @id @db.Char(64) /// SHA-256 hex hash of steamID
 }
 
 model Report {


### PR DESCRIPTION
For better GDPR compliance we shouldn't know who's deleted their accounts. We *do* need to be able to stop them from new sign-ups, so they can't flood leaderboards, so we can just hash the SteamID, use that as primary key in `DeletedUser` table, and check for that for new sign-ups.

Could use an even stronger hash if needed but SHA-256 is still secure. Not salting as no two SteamIDs could ever be in this table.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] All changes requested in review have been `fixup`ed into my original commits
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
