### PR TITLE
Allow maps to be deleted before approval

### DIFF
--- a/apps/backend/src/app/modules/admin/admin.controller.ts
+++ b/apps/backend/src/app/modules/admin/admin.controller.ts
@@ -199,10 +199,10 @@ export class AdminController {
     required: true
   })
   deleteMap(
-    @LoggedInUser('id') adminID: number,
-    @Param('mapID', ParseInt32SafePipe) mapID: number
+    @Param('mapID', ParseInt32SafePipe) mapID: number,
+    @LoggedInUser('id') userID: number
   ) {
-    return this.mapsService.delete(mapID, adminID);
+    return this.mapsService.delete(mapID, userID, true);
   }
 
   @Get('/reports')

--- a/apps/backend/src/app/modules/maps/maps.controller.ts
+++ b/apps/backend/src/app/modules/maps/maps.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -276,6 +277,23 @@ export class MapsController {
         throw new BadRequestException(`VMF file too large (> ${maxVmfSize})`);
       }
     }
+  }
+
+  @Delete('/:mapID')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Deletes a map and all related files and leaderboards'
+  })
+  @ApiNoContentResponse({ description: 'Successfully deleted a map' })
+  @ApiForbiddenResponse({ description: 'User is not a map submitter' })
+  @ApiForbiddenResponse({
+    description: 'Only admins can disable maps that were previously approved'
+  })
+  async deleteMap(
+    @Param('mapID', ParseInt32SafePipe) mapID: number,
+    @LoggedInUser('id') userID: number
+  ) {
+    return this.mapsService.delete(mapID, userID);
   }
 
   @Put('/:mapID/testInvite')

--- a/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.html
+++ b/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.html
@@ -154,6 +154,10 @@
   </div>
 </form>
 
-@if (isAdmin) {
-  <button class="btn btn-red ml-auto" type="button" (click)="deleteMap()">Disable map and delete files</button>
+@if (isAdmin && map.info.approvedDate) {
+  <button class="btn btn-red ml-auto" type="button" (click)="disableMap()">Disable map and delete files</button>
+}
+
+@if (inSubmission && !map.info.approvedDate && (isSubmitter || isAdmin)) {
+  <button class="btn btn-red ml-auto" type="button" (click)="deleteMap()">Delete map</button>
 }

--- a/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.ts
+++ b/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.ts
@@ -687,7 +687,7 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
     return true;
   }
 
-  deleteMap() {
+  disableMap() {
     this.dialogService
       .open(CodeVerifyDialogComponent, {
         header: 'Delete map',
@@ -706,17 +706,48 @@ export class MapEditComponent implements OnInit, ConfirmDeactivate {
           next: () => {
             this.messageService.add({
               severity: 'success',
-              detail: 'Successfully deleted the map'
+              detail: 'Successfully disabled the map and deleted map files'
             });
             this.reload.next();
           },
           error: (error) =>
             this.messageService.add({
               severity: 'error',
-              summary: 'Failed to delete the map',
+              summary: 'Failed to disable the map',
               detail: error.message
             })
         });
+      });
+  }
+
+  deleteMap() {
+    this.dialogService
+      .open(CodeVerifyDialogComponent, {
+        header: 'Delete map',
+        data: {
+          message:
+            '<p>This will completly delete the map and all related files and data.</p>'
+        }
+      })
+      .onClose.subscribe((response) => {
+        if (!response) return;
+        (this.isSubmitter ? this.mapsService : this.adminService)
+          .deleteMap(this.map.id)
+          .subscribe({
+            next: () => {
+              this.messageService.add({
+                severity: 'success',
+                detail: 'Successfully deleted the map'
+              });
+              this.router.navigate(['/maps']);
+            },
+            error: (error) =>
+              this.messageService.add({
+                severity: 'error',
+                summary: 'Failed to delete the map',
+                detail: error.message
+              })
+          });
       });
   }
 

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -27,7 +27,7 @@
         }
       }
       <div class="ml-auto flex items-end gap-2">
-        @if (isSubmitter || localUserService.isReviewerOrAbove) {
+        @if ((isSubmitter && inSubmission) || localUserService.isReviewerOrAbove) {
           <a [routerLink]="'/map-edit/' + map.name" class="btn btn-green">Edit Map</a>
         }
         <button class="btn btn-blue pr-4 font-medium" type="button" mTooltip="Play Map - This doesn't work yet!!">

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -162,9 +162,10 @@
           </div>
           <ng-template #dateTooltip>
             <p class="text-right"><b>Created On - </b>{{ map.info?.creationDate | date }}</p>
-            @if (map.status === MapStatus.APPROVED) {
-              <p><b>Released in Momentum - </b>{{ map.info?.approvedDate | date }}</p>
+            @if (map.info?.approvedDate) {
+              <p class="text-right"><b>Released in Momentum - </b>{{ map.info?.approvedDate | date }}</p>
             }
+            <p class="text-right"><b>Submitted By - </b>{{ map.submitter?.alias }}</p>
           </ng-template>
         </div>
 

--- a/apps/frontend/src/app/services/data/maps.service.ts
+++ b/apps/frontend/src/app/services/data/maps.service.ts
@@ -59,6 +59,10 @@ export class MapsService {
     return this.http.patch(`maps/${mapID}`, { body });
   }
 
+  deleteMap(mapID: number): Observable<void> {
+    return this.http.delete(`maps/${mapID}`);
+  }
+
   getMapCredits(mapID: number): Observable<PagedResponse<MapCredit>> {
     return this.http.get<PagedResponse<MapCredit>>(`maps/${mapID}/credits`);
   }


### PR DESCRIPTION
Closes #1132

Adds a button for submitter to delete their map before it was approved.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
