### PR TITLE
Fix map review dropdown styling

### DIFF
--- a/apps/frontend/src/app/components/map-review/map-review-form.component.html
+++ b/apps/frontend/src/app/components/map-review/map-review-form.component.html
@@ -1,6 +1,12 @@
 <form [formGroup]="form" class="flex flex-col" (ngSubmit)="submit()">
   <div class="mb-4 flex gap-2">
-    <textarea [formControl]="mainText" class="textinput grow" rows="6" (keydown.control.enter)="submit()"></textarea>
+    <textarea
+      [formControl]="mainText"
+      placeholder="... (Required)"
+      class="textinput grow"
+      rows="6"
+      (keydown.control.enter)="submit()"
+    ></textarea>
     @if (!editing) {
       <m-multi-file-upload
         class="h-auto max-w-[20%]"

--- a/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.html
+++ b/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.html
@@ -5,7 +5,10 @@
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Gamemode</th>
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Track Type</th>
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Track Number</th>
-        <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Tier</th>
+        <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">
+          Tier
+          <m-icon icon="asterisk" class="mb-0.5 p-1 align-middle" mTooltip="Required" />
+        </th>
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Rating</th>
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Tags</th>
         <th></th>

--- a/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.ts
@@ -20,6 +20,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import { groupMapLeaderboards } from '../../util';
 import { Select } from 'primeng/select';
 import { IconComponent } from '../../icons';
+import { TooltipDirective } from '../../directives/tooltip.directive';
 import { ChipsComponent } from '../chips/chips.component';
 
 @Component({
@@ -32,7 +33,14 @@ import { ChipsComponent } from '../chips/chips.component';
       multi: true
     }
   ],
-  imports: [DropdownModule, Select, FormsModule, IconComponent, ChipsComponent]
+  imports: [
+    DropdownModule,
+    Select,
+    FormsModule,
+    ChipsComponent,
+    IconComponent,
+    TooltipDirective
+  ]
 })
 export class MapReviewSuggestionsFormComponent implements ControlValueAccessor {
   protected readonly TrackType = TrackType;


### PR DESCRIPTION
fixes map review form/dropdown styling issue

Also adds signifiers to required parts of review form.
Since you can't omit the fields with dropdowns, I think it's nicer to only put an asterisk on the Tier which is an actual string input.

Before:
![vivaldi_DfIVFKO930](https://github.com/user-attachments/assets/48e79be5-c4c2-4c53-87c4-5fe501734c5f)
After:
![vivaldi_S7Bz9yxUGD](https://github.com/user-attachments/assets/23901bd5-a543-41aa-a556-1d3bb3dc29d0)


### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
