### PR TITLE
Add Kosovo to country list and use local list for validation

### DIFF
--- a/apps/backend/src/app/dto/user/user.dto.ts
+++ b/apps/backend/src/app/dto/user/user.dto.ts
@@ -13,7 +13,6 @@ import { ApiProperty, ApiPropertyOptional, PickType } from '@nestjs/swagger';
 import {
   IsBoolean,
   IsInt,
-  IsISO31661Alpha2,
   IsOptional,
   IsString,
   Matches,
@@ -23,10 +22,9 @@ import { Exclude, Expose } from 'class-transformer';
 import { Ban } from '@momentum/constants';
 import * as Bitflags from '@momentum/bitflags';
 import { CreatedAtProperty, IdProperty, NestedProperty } from '../decorators';
-import { IsSteamCommunityID } from '../../validators';
+import { IsCountryCode, IsSteamCommunityID } from '../../validators';
 import { ProfileDto } from './profile.dto';
 import { UserStatsDto } from './user-stats.dto';
-
 import { UpdateSocialsDto } from './socials.dto';
 
 export class UserDto implements User {
@@ -58,7 +56,7 @@ export class UserDto implements User {
     description: 'Two-letter (ISO 3166-1 Alpha-2) country code for the user'
   })
   @IsOptional()
-  @IsISO31661Alpha2()
+  @IsCountryCode()
   readonly country: string | null;
 
   @Exclude({ toPlainOnly: true })
@@ -123,7 +121,7 @@ export class UpdateUserDto {
     type: String,
     description: 'The country code to set (requires ISO Alpha-2 code)'
   })
-  @IsISO31661Alpha2()
+  @IsCountryCode()
   @IsOptional()
   country?: string;
 

--- a/apps/backend/src/app/validators/index.ts
+++ b/apps/backend/src/app/validators/index.ts
@@ -6,3 +6,4 @@ export * from './is-number-string.validator';
 export * from './is-positive-number-string.validator';
 export * from './is-optional-with-empty-string.validator';
 export * from './is-vector.validator';
+export * from './is-country-code.validator';

--- a/apps/backend/src/app/validators/is-country-code.validator.ts
+++ b/apps/backend/src/app/validators/is-country-code.validator.ts
@@ -1,0 +1,25 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { ISOCountryCode } from '@momentum/constants';
+
+export function IsCountryCode(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isCountryCode',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown) {
+          return (
+            typeof value === 'string' &&
+            Object.keys(ISOCountryCode).includes(value)
+          );
+        },
+
+        defaultMessage() {
+          return `${propertyName} must be a valid ISO31661 Alpha2 code`;
+        }
+      }
+    });
+  };
+}

--- a/libs/constants/src/enums/country-codes.enum.ts
+++ b/libs/constants/src/enums/country-codes.enum.ts
@@ -245,6 +245,7 @@ export enum ISOCountryCode {
   VU = 'Vanuatu',
   WF = 'Wallis and Futuna',
   WS = 'Samoa',
+  XK = 'Kosovo', // Is not officially assigned, but supported by Steam
   YE = 'Yemen',
   YT = 'Mayotte',
   ZA = 'South Africa',


### PR DESCRIPTION
Steam supports Kosovo (XK) country code, while we and class-validator don't

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [ ] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
