### PR TITLE
fix(front): prevent double submit in map edit form

### DIFF
--- a/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.html
+++ b/apps/frontend/src/app/pages/maps/map-edit/map-edit.component.html
@@ -32,7 +32,11 @@
         <input type="checkbox" class="checkbox" [formControl]="resetLbs" />
       </div>
 
-      <button type="submit" class="btn btn-green self-end" [disabled]="loading || versionForm.pristine || versionForm.invalid">
+      <button
+        type="submit"
+        class="btn btn-green self-end"
+        [disabled]="loading || isSubmittingVersionForm || versionForm.pristine || versionForm.invalid"
+      >
         Submit
       </button>
     </div>
@@ -73,7 +77,7 @@
     type="button"
     (click)="submitTestInviteForm()"
     class="btn btn-green self-end"
-    [disabled]="loading || testInviteForm.pristine || testInviteForm.invalid"
+    [disabled]="loading || isSubmittingTestInviteForm || testInviteForm.pristine || testInviteForm.invalid"
   >
     Update Invites
   </button>


### PR DESCRIPTION
frontend part of #1220 

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
