### PR TITLE
Fix/double submit again

### DIFF
--- a/apps/frontend/src/app/components/map-review/map-review-form.component.html
+++ b/apps/frontend/src/app/components/map-review/map-review-form.component.html
@@ -57,6 +57,6 @@
         </p>
       </div>
     </ng-template>
-    <button type="submit" class="btn btn-green btn-thin self-end" [disabled]="form.invalid || form.pristine">Post</button>
+    <button type="submit" class="btn btn-green btn-thin self-end" [disabled]="loading || form.invalid || form.pristine">Post</button>
   </div>
 </form>

--- a/apps/frontend/src/app/components/map-review/map-review-form.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review-form.component.ts
@@ -17,7 +17,7 @@ import {
   ReactiveFormsModule,
   Validators
 } from '@angular/forms';
-import { take, tap } from 'rxjs/operators';
+import { finalize, take } from 'rxjs/operators';
 import { FileValidators, suggestionsValidator } from '../../validators';
 import { MapReviewSuggestionsFormComponent } from './map-review-suggestions-form.component';
 import { SuggestionType } from '@momentum/formats/zone';
@@ -112,11 +112,11 @@ export class MapReviewFormComponent {
   protected loading = false;
 
   submit() {
-    if (this.form.invalid || this.form.pristine) return;
+    if (this.loading || this.form.invalid || this.form.pristine) return;
     this.loading = true;
+
     const suggestions =
       this.suggestions.value?.length > 0 ? this.suggestions.value : undefined;
-
     // Ignore any empty suggestions
     if (suggestions) {
       suggestions.forEach(({ tier, gameplayRating, tags }, i) => {
@@ -144,7 +144,7 @@ export class MapReviewFormComponent {
     req
       .pipe(
         take(1),
-        tap(() => (this.loading = false))
+        finalize(() => (this.loading = false))
       )
       .subscribe({
         next: () => {

--- a/apps/frontend/src/app/components/map-review/map-review.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review.component.ts
@@ -29,7 +29,7 @@ import {
   ReactiveFormsModule,
   Validators
 } from '@angular/forms';
-import { switchMap, take, tap } from 'rxjs/operators';
+import { finalize, switchMap, take, tap } from 'rxjs/operators';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { Subject } from 'rxjs';
 import { ConfirmPopupModule } from 'primeng/confirmpopup';
@@ -272,7 +272,9 @@ export class MapReviewComponent {
   }
 
   editComment(commentID: number): void {
+    if (this.loadingComments) return;
     this.loadingComments = true;
+
     this.mapsService
       .updateMapReviewComment(
         commentID,
@@ -280,7 +282,7 @@ export class MapReviewComponent {
       )
       .pipe(
         take(1),
-        tap(() => (this.loadingComments = false))
+        finalize(() => (this.loadingComments = false))
       )
       .subscribe({
         next: (res) => {

--- a/apps/frontend/src/app/components/map-review/map-review.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review.component.ts
@@ -50,6 +50,7 @@ import { UnsortedKeyvaluePipe } from '../../pipes/unsorted-keyvalue.pipe';
 import { DatePipe } from '@angular/common';
 import { SpinnerDirective } from '../../directives/spinner.directive';
 import { PluralPipe } from '../../pipes/plural.pipe';
+import { TooltipDirective } from '../../directives/tooltip.directive';
 
 @Component({
   selector: 'm-map-review',
@@ -66,7 +67,8 @@ import { PluralPipe } from '../../pipes/plural.pipe';
     DatePipe,
     SpinnerDirective,
     PluralPipe,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    TooltipDirective
   ],
   templateUrl: './map-review.component.html'
 })


### PR DESCRIPTION
fixes #1129 again... sorry

Playing around with settimeout I was able to for example post a review twice, even with the `loading` check.
The `tap` function gets called before the code in `next/error` meaning a user could press post again just after loading was set to false in tap.
I've fixed the cases where I could actually prompt a double submit/delete/etc, but there are a few other functions left that still set a bool to false in tap. Not sure If we want to change these, as well.

Also fixed some tooltips not showing cause directive was missing.

Regarding setting the disabled attribute on the buttons (which I also did in 2 previous PRs), it's not necessary.
But, it will gray out the button to give feedback to the user that it is currently not clickable.
If you want that behaviour, I can change those buttons so that they gray out when loading. But it's up to you.
Currently, some of them do, some of them don't.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
