### PR TITLE
fix(front): map filter persistence key

### DIFF
--- a/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.ts
+++ b/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.ts
@@ -85,11 +85,7 @@ export class AdminMapsBrowserComponent implements OnInit {
   protected readonly itemsPerLoad = 8;
 
   ngOnInit() {
-    setupPersistentForm(
-      this.filters,
-      this.constructor.name + '_FILTERS',
-      this.destroyRef
-    );
+    setupPersistentForm(this.filters, 'ADMIN_MAPS_FILTERS', this.destroyRef);
 
     merge(
       of(this.initialItems),

--- a/apps/frontend/src/app/pages/maps/browsers/map-browser.component.ts
+++ b/apps/frontend/src/app/pages/maps/browsers/map-browser.component.ts
@@ -100,11 +100,7 @@ export class MapBrowserComponent implements OnInit {
   protected readonly itemsPerLoad = 8;
 
   ngOnInit() {
-    setupPersistentForm(
-      this.filters,
-      this.constructor.name + '_FILTERS',
-      this.destroyRef
-    );
+    setupPersistentForm(this.filters, 'MAIN_MAPS_FILTERS', this.destroyRef);
     // Tier slider starts disabled.
     if (this.filters.value.gamemode) this.filters.controls.tiers.enable();
 

--- a/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.ts
+++ b/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.ts
@@ -94,7 +94,7 @@ export class MapSubmissionBrowserComponent implements OnInit {
   ngOnInit() {
     setupPersistentForm(
       this.filters,
-      this.constructor.name + '_FILTERS',
+      'SUBMISSION_MAPS_FILTERS',
       this.destroyRef
     );
 

--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.ts
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.ts
@@ -105,11 +105,7 @@ export class UserMapsBrowserComponent implements OnInit {
       return;
     }
 
-    setupPersistentForm(
-      this.filters,
-      this.constructor.name + '_FILTERS',
-      this.destroyRef
-    );
+    setupPersistentForm(this.filters, 'USER_MAPS_FILTERS', this.destroyRef);
 
     this.localUserService.getSubmittedMapSummary().subscribe((res) => {
       this.summaryLoading = false;


### PR DESCRIPTION
When interacting with map browser filters, the other browsers stop working.
This is because after minification, all constructors for each map browser component is called that same thing.
So persistence key for filters will be the same, for all filters/browsers.

Changed to be hard-coded strings instead of using constructor name.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
