### PR TITLE
fix(back): remove role guard from credits update endpoint

### DIFF
--- a/apps/backend/src/app/modules/maps/maps.controller.ts
+++ b/apps/backend/src/app/modules/maps/maps.controller.ts
@@ -42,7 +42,6 @@ import {
   MAX_MAP_IMAGE_SIZE,
   MAX_MAP_IMAGES,
   MAX_REVIEW_IMAGES,
-  Role,
   KillswitchType
 } from '@momentum/constants';
 import { ConfigService } from '@nestjs/config';
@@ -79,7 +78,7 @@ import {
   VALIDATION_PIPE_CONFIG,
   CreateMapVersionDto
 } from '../../dto';
-import { BypassJwtAuth, LoggedInUser, Roles } from '../../decorators';
+import { BypassJwtAuth, LoggedInUser } from '../../decorators';
 import { ParseInt32SafePipe, ParseFilesPipe } from '../../pipes';
 import { FormDataJsonInterceptor } from '../../interceptors/form-data-json.interceptor';
 import { UserJwtAccessPayload } from '../auth/auth.interface';
@@ -399,7 +398,6 @@ export class MapsController {
   }
 
   @Put('/:mapID/credits')
-  @Roles(Role.MAPPER, Role.MODERATOR, Role.ADMIN)
   @UseGuards(KillswitchGuard)
   @Killswitch(KillswitchType.MAP_SUBMISSION)
   @HttpCode(HttpStatus.CREATED)


### PR DESCRIPTION
Fixes forbidden exception when trying to update map credits as a user without mapper role

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
