### PR TITLE
fix(front): remove placeholder credit ordering

### DIFF
--- a/apps/frontend/src/app/components/map-forms/map-credits-selection/map-credits-selection.component.html
+++ b/apps/frontend/src/app/components/map-forms/map-credits-selection/map-credits-selection.component.html
@@ -31,7 +31,7 @@
           <div class="flex flex-grow flex-col">
             <div class="flex">
               <span class="mr-3 flex-grow">{{ credit.alias }}</span>
-              <button type="button" (click)="removeUser(type.key, credit.userID)">
+              <button type="button" (click)="removeUser(type.key, credit.userID, credit.alias)">
                 <m-icon icon="close-thick" class="h-5 w-5 transition-colors hover:text-red-400" />
               </button>
             </div>

--- a/apps/frontend/src/app/components/map-forms/map-credits-selection/map-credits-selection.component.ts
+++ b/apps/frontend/src/app/components/map-forms/map-credits-selection/map-credits-selection.component.ts
@@ -91,10 +91,11 @@ export class MapCreditsSelectionComponent implements ControlValueAccessor {
     }
   }
 
-  removeUser(type: MapCreditType, userID: number) {
-    const userIndex = this.value
-      .get(type)
-      .findIndex((credit) => credit.userID === userID);
+  removeUser(type: MapCreditType, userID: number, alias: string) {
+    const userIndex = this.value.get(type).findIndex(
+      // If multiple placeholders have the same alias, the first gets removed.
+      (credit) => credit.userID === userID && credit.alias === alias
+    );
     if (userIndex === -1) return;
     this.value[type].splice(userIndex, 1);
     this.onChange(this.value);


### PR DESCRIPTION
Closes #1231

I could have changed to use $index instead of id and alias, which would have made the function 2 LoC.
But it seems like a terrible idea to rely on the drag-and-drop functionality mutating the credits array to match the rendered index.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
