### PR TITLE
Feat/map info select main mode

### DIFF
--- a/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@momentum/constants';
 import * as Enum from '@momentum/enum';
 import { DropdownModule } from 'primeng/dropdown';
-import { groupMapLeaderboards } from '../../util';
+import { findMainGamemodeIndex, groupMapLeaderboards } from '../../util';
 import { Select } from 'primeng/select';
 import { IconComponent } from '../../icons';
 import { TooltipDirective } from '../../directives/tooltip.directive';
@@ -82,9 +82,9 @@ export class MapReviewSuggestionsFormComponent implements ControlValueAccessor {
         label: i + 1
       })) ?? [];
 
-    // Use leaderboards as this has sorting stuff for trying to determine
-    // most important gamemode
-    this.defaultMode = groupMapLeaderboards(map.leaderboards)[0].gamemode;
+    const lbs = groupMapLeaderboards(map.leaderboards);
+    const mainIndex = findMainGamemodeIndex(lbs, this.map.name);
+    this.defaultMode = lbs[mainIndex].gamemode;
 
     // Reset
     this.writeValue(null);

--- a/apps/frontend/src/app/pages/maps/map-info/map-leaderboard/map-leaderboard.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-leaderboard/map-leaderboard.component.html
@@ -1,21 +1,23 @@
 <div [mSpinner]="!map">
   <div class="flex gap-4">
     <div class="flex grow flex-wrap gap-x-8 gap-y-2">
-      @for (groupedLeaderboard of getLeaderboards(); track $index) {
-        <button
-          type="button"
-          class="flex gap-2 opacity-70 drop-shadow transition-opacity hover:opacity-90"
-          (click)="selectMode($index)"
-          [ngClass]="{ '!opacity-100': activeModeIndex === $index, 'pointer-events-none': leaderboards.length === 1 }"
-        >
-          <img
-            class="aspect-square h-11"
-            [src]="'assets/images/gamemodes/' + GamemodeInfo.get(groupedLeaderboard.gamemode).icon + '.png'"
-          />
-          <p class="font-display text-5xl font-bold leading-none">
-            {{ groupedLeaderboard.gamemodeName }}
-          </p>
-        </button>
+      @for (groupedLeaderboard of leaderboards; track $index) {
+        @if (!groupedLeaderboard.allHidden || showHiddenLeaderboards) {
+          <button
+            type="button"
+            class="flex gap-2 opacity-70 drop-shadow transition-opacity hover:opacity-90"
+            (click)="selectMode($index)"
+            [ngClass]="{ '!opacity-100': activeModeIndex === $index, 'pointer-events-none': leaderboards.length === 1 }"
+          >
+            <img
+              class="aspect-square h-11"
+              [src]="'assets/images/gamemodes/' + GamemodeInfo.get(groupedLeaderboard.gamemode).icon + '.png'"
+            />
+            <p class="font-display text-5xl font-bold leading-none">
+              {{ groupedLeaderboard.gamemodeName }}
+            </p>
+          </button>
+        }
       }
     </div>
     @if (map.status === MapStatus.APPROVED && hasHiddenLeaderboards()) {

--- a/apps/frontend/src/app/pages/maps/map-info/map-leaderboard/map-leaderboard.component.ts
+++ b/apps/frontend/src/app/pages/maps/map-info/map-leaderboard/map-leaderboard.component.ts
@@ -19,6 +19,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import {
   GroupedMapLeaderboard,
   GroupedMapLeaderboards,
+  findMainGamemodeIndex,
   groupMapLeaderboards
 } from '../../../../util';
 import { distinctUntilChanged, map } from 'rxjs/operators';
@@ -156,9 +157,14 @@ export class MapLeaderboardComponent implements OnChanges {
   ngOnChanges(): void {
     if (!this.map) return;
 
-    this.leaderboards = groupMapLeaderboards(this.map.leaderboards);
-    this.activeMode = this.leaderboards[0];
-    this.activeModeIndex = 0;
+    this.leaderboards = groupMapLeaderboards(this.map.leaderboards).sort(
+      (a, b) => a.gamemodeName.localeCompare(b.gamemodeName)
+    );
+    this.activeModeIndex = findMainGamemodeIndex(
+      this.leaderboards,
+      this.map.name
+    );
+    this.activeMode = this.leaderboards[this.activeModeIndex];
     this.activeType = LeaderboardFilterType.TOP10;
     this.activeTrack.type = TrackType.MAIN;
     this.activeTrack.num = 1;
@@ -184,12 +190,6 @@ export class MapLeaderboardComponent implements OnChanges {
     return this.leaderboardService
       .getRuns(this.map.id, query)
       .pipe(mapHttpError(410, { data: [], totalCount: 0, returnCount: 0 }));
-  }
-
-  getLeaderboards() {
-    return this.showHiddenLeaderboards
-      ? this.leaderboards
-      : this.leaderboards.filter(({ allHidden }) => !allHidden);
   }
 
   hasHiddenLeaderboards() {

--- a/apps/frontend/src/app/util/grouped-map-leaderboards.util.spec.ts
+++ b/apps/frontend/src/app/util/grouped-map-leaderboards.util.spec.ts
@@ -1,0 +1,111 @@
+import { Gamemode, GamemodeInfo, LeaderboardType } from '@momentum/constants';
+import {
+  findMainGamemodeIndex,
+  getSpecificGroupedLeaderboard,
+  GroupedMapLeaderboards
+} from './grouped-map-leaderboards.util';
+
+describe('grouped-map-leaderboards', () => {
+  function testLbs(): GroupedMapLeaderboards {
+    return [
+      {
+        gamemode: Gamemode.DEFRAG_VQ3,
+        gamemodeName: GamemodeInfo.get(Gamemode.DEFRAG_VQ3).name,
+        allHidden: true,
+        tier: 3,
+        type: LeaderboardType.HIDDEN,
+        tags: [],
+        linear: true,
+        stages: 5
+      },
+      {
+        gamemode: Gamemode.DEFRAG_CPM,
+        gamemodeName: GamemodeInfo.get(Gamemode.DEFRAG_CPM).name,
+        allHidden: false,
+        tier: 3,
+        type: LeaderboardType.UNRANKED,
+        tags: [],
+        linear: true,
+        stages: 5
+      },
+      {
+        gamemode: Gamemode.SJ,
+        gamemodeName: GamemodeInfo.get(Gamemode.SJ).name,
+        allHidden: false,
+        tier: 4,
+        type: LeaderboardType.RANKED,
+        tags: [],
+        linear: true,
+        stages: 5
+      },
+      {
+        gamemode: Gamemode.SURF,
+        gamemodeName: GamemodeInfo.get(Gamemode.SURF).name,
+        allHidden: true,
+        tier: 2,
+        type: LeaderboardType.HIDDEN,
+        tags: [],
+        linear: true,
+        stages: 5
+      },
+      {
+        gamemode: Gamemode.RJ,
+        gamemodeName: GamemodeInfo.get(Gamemode.RJ).name,
+        allHidden: false,
+        tier: 5,
+        type: LeaderboardType.RANKED,
+        tags: [],
+        linear: true,
+        stages: 5
+      }
+    ];
+  }
+
+  describe('getSpecificGroupedLeaderboard', () => {
+    it('should find the correct leaderboard if it exists', () => {
+      const lb = getSpecificGroupedLeaderboard(testLbs(), Gamemode.RJ);
+      expect(lb).toBeDefined();
+      expect(lb.gamemode).toBe(Gamemode.RJ);
+    });
+
+    it('should return undefined if leaderboard not found', () => {
+      const lb = getSpecificGroupedLeaderboard(testLbs(), Gamemode.AHOP);
+      expect(lb).toBeUndefined();
+    });
+  });
+
+  describe('findMainGamemodeIndex', () => {
+    it('should find a leaderboard based on mapname prefix if available', () => {
+      expect(findMainGamemodeIndex(testLbs(), 'surf_the_dog')).toBe(3);
+    });
+
+    it('should find first ranked leaderboard if no prefix exists', () => {
+      expect(findMainGamemodeIndex(testLbs(), 'pls_play_this')).toBe(2);
+    });
+
+    it('should find first ranked leaderboard if no prefix exists for existing leaderboards', () => {
+      expect(findMainGamemodeIndex(testLbs(), 'ahop_coast_improved')).toBe(2);
+    });
+
+    it('should find first unranked leaderboard if no prefix nor ranked leaderboard exists', () => {
+      const lbs = testLbs().map((lb) => {
+        if (lb.type === LeaderboardType.RANKED)
+          lb.type = LeaderboardType.HIDDEN;
+        return lb;
+      });
+      expect(findMainGamemodeIndex(lbs, 'mr_blobby_horrorhouse')).toBe(1);
+    });
+
+    it('should default to 0 when no prefix, no ranked, no unranked maintrack', () => {
+      const lbs = testLbs().map((lb) => {
+        if (
+          lb.type === LeaderboardType.RANKED ||
+          lb.type === LeaderboardType.UNRANKED
+        )
+          lb.type = LeaderboardType.HIDDEN;
+        return lb;
+      });
+      expect(findMainGamemodeIndex(lbs, 'twas_a_thrupence')).toBe(0);
+    });
+  });
+});

--- a/apps/frontend/src/app/util/grouped-map-leaderboards.util.ts
+++ b/apps/frontend/src/app/util/grouped-map-leaderboards.util.ts
@@ -8,6 +8,7 @@ import {
   MMap,
   TrackType
 } from '@momentum/constants';
+import { extractPrefixFromMapName } from '@momentum/util-fn';
 import { RequireAllOrNone } from 'type-fest';
 
 export type GroupedMapLeaderboards = Array<GroupedMapLeaderboard>;
@@ -32,6 +33,20 @@ export type GroupedMapLeaderboard = {
   stages: number;
 }>;
 
+export type MapWithGroupedLeaderboard = MMap & {
+  groupedLeaderboards: GroupedMapLeaderboards;
+};
+
+export type MapWithSpecificLeaderboard = MapWithGroupedLeaderboard & {
+  currentModeLeaderboards?: GroupedMapLeaderboard;
+};
+
+/**
+ * Creates a new collection of leaderboards
+ * by removing unnecessary fields and
+ * adding new ones for utility.
+ * Keeps the same element order from input.
+ */
 export function groupMapLeaderboards(
   leaderboards: Leaderboard[]
 ): GroupedMapLeaderboards {
@@ -74,35 +89,51 @@ export function groupMapLeaderboards(
       !group.bonuses?.some((bonus) => bonus.type !== LeaderboardType.HIDDEN);
   }
 
-  // Try to guess at what mode the map is primarily intended for:
-  // If no tier, it has no main track, only bonuses (impossible to have stages
-  // but no main track), so rank stuff with main track higher.
-  // Then try main ranked > main unranked > main hidden
-  // Then if all lbs hidden
-  // Then try > number bonuses
-  arr.sort((a: GroupedMapLeaderboard, b: GroupedMapLeaderboard) => {
-    if (a.tier !== b.tier) return a.tier === null ? 1 : -1;
-    if (a.type !== b.type) return a.type - b.type;
-    if (a.allHidden !== b.allHidden) return a.allHidden ? 1 : -1;
-    if (a.bonuses?.length !== b.bonuses?.length)
-      return (a.bonuses?.length ?? 0) - (b.bonuses?.length ?? 0);
-    return 0;
-  });
-
   return arr;
 }
 
-export type MapWithGroupedLeaderboard = MMap & {
-  groupedLeaderboards: GroupedMapLeaderboards;
-};
-
-export type MapWithSpecificLeaderboard = MapWithGroupedLeaderboard & {
-  currentModeLeaderboards?: GroupedMapLeaderboard;
-};
-
+/**
+ * Returns the leaderboard corresponding to given gamemode,
+ * undefined if not found.
+ */
 export function getSpecificGroupedLeaderboard(
   leaderboards: GroupedMapLeaderboards,
   mode: Gamemode
-): GroupedMapLeaderboard {
+): GroupedMapLeaderboard | undefined {
   return leaderboards.find(({ gamemode }) => gamemode === mode);
+}
+
+/**
+ * Finds index for main gamemode in leaderboards collection.
+ * First looks at map name to test for gamemode prefix,
+ * then picks first ranked gamemode, then tries first unranked.
+ * If nothing found, returns 0.
+ */
+export function findMainGamemodeIndex(
+  leaderboards: GroupedMapLeaderboards,
+  mapname: string
+): number {
+  const [, prefix] = extractPrefixFromMapName(mapname);
+  for (const [, info] of GamemodeInfo) {
+    if (info.prefix === prefix) {
+      const lbIndex = leaderboards.findIndex(
+        ({ gamemodeName }) => gamemodeName === info.name
+      );
+
+      if (lbIndex !== -1) return lbIndex;
+      else break;
+    }
+  }
+
+  const rankedIndex = leaderboards.findIndex(
+    ({ type }) => type === LeaderboardType.RANKED
+  );
+  if (rankedIndex !== -1) return rankedIndex;
+
+  const unrankedIndex = leaderboards.findIndex(
+    ({ type }) => type === LeaderboardType.UNRANKED
+  );
+  if (unrankedIndex !== -1) return unrankedIndex;
+
+  return 0;
 }


### PR DESCRIPTION
Closes #1216 

In map info section, now sort alphabetically and preselect the (believed to be) main gamemode.
Added some docs, and tests.

I decided to yeet the leaderboard sorting, as nothing using it actually needed it.
But could instead rely on new findIndex func or just sort alphabetically instead.

Used a standard function instead of beforeEach or similar to improve purity, also then not all tests generate the test data unless they need it.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
