### PR TITLE
feat(front): display map submission version dates

### DIFF
--- a/apps/frontend/src/app/pages/maps/map-info/map-submission/map-submission.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-submission/map-submission.component.html
@@ -52,7 +52,10 @@
   <legend class="text-shadow-strong font-display text-4xl font-bold text-gray-50">Versions</legend>
 
   @for (version of versions.slice(0, visibleVersions); track version.versionNum) {
-    <p class="mt-1 text-sm font-medium uppercase text-gray-200">Version {{ version.versionNum }}</p>
+    <div class="mt-1 flex gap-3">
+      <p class="text-sm font-medium uppercase">Version {{ version.versionNum }}</p>
+      <p class="text-sm font-medium text-gray-200">{{ version.createdAt | date }}</p>
+    </div>
     @if (version.changelog) {
       <p class="mt-2 whitespace-pre-wrap text-sm">{{ version.changelog }}</p>
     }


### PR DESCRIPTION
Now displays (local) date for each map version in map submission page.

<img width="683" height="350" alt="vivaldi_BikruEgQVV" src="https://github.com/user-attachments/assets/2c941f99-9690-4399-9177-e921fc0dd287" />

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
