### PR TITLE
In memory run sessions

### DIFF
--- a/apps/backend-e2e/src/admin.e2e-spec.ts
+++ b/apps/backend-e2e/src/admin.e2e-spec.ts
@@ -700,14 +700,6 @@ describe('Admin', () => {
             },
             mapNotifies: {
               create: { mmap: { connect: { id: map.id } }, notifyOn: 8 }
-            },
-            runSessions: {
-              create: {
-                mapID: map.id,
-                gamemode: Gamemode.AHOP,
-                trackNum: 2,
-                trackType: TrackType.MAIN
-              }
             }
           }
         });
@@ -763,7 +755,6 @@ describe('Admin', () => {
             followers: true,
             mapNotifies: true,
             notifications: true,
-            runSessions: true,
             reportSubmitted: true,
             reportResolved: true
           }
@@ -793,7 +784,6 @@ describe('Admin', () => {
             followers: true,
             mapNotifies: true,
             notifications: true,
-            runSessions: true,
             reportSubmitted: true,
             reportResolved: true
           }
@@ -822,7 +812,6 @@ describe('Admin', () => {
           followers: [],
           mapNotifies: userBeforeDeletion.mapNotifies,
           notifications: [],
-          runSessions: [],
           leaderboardRuns: userBeforeDeletion.leaderboardRuns,
           pastRuns: userBeforeDeletion.pastRuns,
           reportSubmitted: userBeforeDeletion.reportSubmitted,

--- a/apps/backend-e2e/src/session.e2e-spec.ts
+++ b/apps/backend-e2e/src/session.e2e-spec.ts
@@ -87,6 +87,7 @@ describe('Session', () => {
         }
       });
 
+      // TODO: This is gonna take some evil mocking!!
       it('should delete any sessions not matching the given mapID or gamemode', async () => {
         const otherMap = await db.createMapWithFullLeaderboards(
           {

--- a/apps/backend-e2e/src/user.e2e-spec.ts
+++ b/apps/backend-e2e/src/user.e2e-spec.ts
@@ -450,14 +450,6 @@ describe('User', () => {
             },
             mapNotifies: {
               create: { mmap: { connect: { id: map.id } }, notifyOn: 8 }
-            },
-            runSessions: {
-              create: {
-                mapID: map.id,
-                trackNum: 1,
-                gamemode: Gamemode.AHOP,
-                trackType: 0
-              }
             }
           }
         });
@@ -519,7 +511,6 @@ describe('User', () => {
             followers: true,
             mapNotifies: true,
             notifications: true,
-            runSessions: true,
             reportSubmitted: true,
             reportResolved: true
           }
@@ -549,7 +540,6 @@ describe('User', () => {
             followers: true,
             mapNotifies: true,
             notifications: true,
-            runSessions: true,
             reportSubmitted: true,
             reportResolved: true
           }
@@ -580,7 +570,6 @@ describe('User', () => {
           followers: [],
           mapNotifies: userBeforeDeletion.mapNotifies,
           notifications: [],
-          runSessions: [],
           reportSubmitted: userBeforeDeletion.reportSubmitted,
           reportResolved: userBeforeDeletion.reportResolved
         });

--- a/apps/backend/src/app/dto/run/run-session.dto.ts
+++ b/apps/backend/src/app/dto/run/run-session.dto.ts
@@ -7,11 +7,12 @@
   UpdateRunSession
 } from '@momentum/constants';
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { IsInt, IsPositive, Min } from 'class-validator';
+import { IsInt, IsPositive, Min, Max } from 'class-validator';
 import { CreatedAtProperty, EnumProperty, IdProperty } from '../decorators';
+import { MAX_TRACK_SEGMENTS } from '@momentum/formats/zone';
 
 export class RunSessionDto implements RunSession {
-  @IdProperty({ bigint: true })
+  @IdProperty()
   readonly id: number;
 
   @ApiProperty({
@@ -41,6 +42,7 @@ export class RunSessionDto implements RunSession {
   })
   @IsInt()
   @Min(1)
+  @Max(MAX_TRACK_SEGMENTS + 1)
   readonly trackNum: number;
 
   @ApiProperty({

--- a/apps/backend/src/app/modules/session/run/run-processor.class.spec.ts
+++ b/apps/backend/src/app/modules/session/run/run-processor.class.spec.ts
@@ -36,7 +36,7 @@ describe('RunProcessor', () => {
     timestamps: [],
     mapID: 1,
     userID: 1,
-    id: 1n,
+    id: 1,
     mmap: {
       id: 1,
       name: 'bhop_map',

--- a/apps/backend/src/app/modules/session/run/run-processor.class.ts
+++ b/apps/backend/src/app/modules/session/run/run-processor.class.ts
@@ -1,4 +1,4 @@
-﻿import { RunSessionTimestamp, User } from '@momentum/db';
+﻿import { User } from '@momentum/db';
 import { Logger } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import {
@@ -13,6 +13,7 @@ import * as ReplayFile from '@momentum/formats/replay';
 import {
   CompletedRunSession,
   ProcessedRun,
+  RunSessionTimestamp,
   Splits
 } from './run-session.interface';
 import { findWithIndex } from '@momentum/util-fn';

--- a/apps/backend/src/app/modules/session/run/run-session.interface.ts
+++ b/apps/backend/src/app/modules/session/run/run-session.interface.ts
@@ -1,29 +1,48 @@
-﻿import { Prisma, LeaderboardRun } from '@momentum/db';
-import { RunSplits, Style } from '@momentum/constants';
+﻿import { MapVersion, MMap, User } from '@momentum/db';
+import { Gamemode, RunSplits, Style, TrackType } from '@momentum/constants';
 import { InputJsonObject } from '@prisma/client/runtime/library';
 
-export const RUN_SESSION_COMPLETED_INCLUDE = {
-  timestamps: true,
-  user: true,
-  mmap: { include: { currentVersion: true } }
-};
+// Note that use a plain Map + fact we're using HTTP means run sessions can
+// only work on a single backend instance (without some fancy reverse proxy
+// routing or something), and sessions  are not persistent across restarts.
+// Upshot of this is that session IDs can just use a simple incrementing counter.
+export type SessionID = number;
 
-const _runSessionCompletedIncludeValidator =
-  Prisma.validator<Prisma.RunSessionDefaultArgs>()({
-    include: RUN_SESSION_COMPLETED_INCLUDE
-  });
+export interface RunSession extends Record<string, unknown> {
+  id: SessionID;
+  userID: number;
+  mapID: number;
+  gamemode: Gamemode;
+  trackType: TrackType;
+  trackNum: number;
+  timestamps: RunSessionTimestamp[];
+  // Tom: I would've moved this to plain unix timestamp during moving to
+  // in-memory sessions but would require updating a game api model, not worth
+  // it rn.
+  createdAt: Date;
+}
 
-export type CompletedRunSession = Prisma.RunSessionGetPayload<
-  typeof _runSessionCompletedIncludeValidator
->;
+export interface CompletedRunSession extends RunSession {
+  mmap: MMap & { currentVersion: MapVersion };
+  user: User;
+}
+
+export interface RunSessionTimestamp extends Record<string, unknown> {
+  majorNum: number;
+  minorNum: number;
+  time: number;
+  createdAt: Date;
+}
 
 export type Splits = RunSplits.Splits & InputJsonObject;
 
-export interface ProcessedRun
-  extends Pick<
-    LeaderboardRun,
-    'userID' | 'mapID' | 'gamemode' | 'trackType' | 'trackNum' | 'time'
-  > {
+export interface ProcessedRun {
+  userID: number;
+  mapID: number;
+  gamemode: Gamemode;
+  trackType: TrackType;
+  trackNum: number;
+  time: number;
   splits: Splits;
   flags: Style[];
 }

--- a/apps/backend/src/app/modules/session/session.controller.ts
+++ b/apps/backend/src/app/modules/session/session.controller.ts
@@ -83,7 +83,7 @@ export class SessionController {
   invalidateSession(
     @LoggedInUser('id') userID: number,
     @Param('sessionID', ParseIntSafePipe) sessionID: number
-  ): Promise<void> {
+  ): void {
     return this.runSessionService.invalidateSession(userID, sessionID);
   }
 
@@ -104,7 +104,7 @@ export class SessionController {
     @LoggedInUser('id') userID: number,
     @Param('sessionID', ParseIntSafePipe) sessionID: number,
     @Body() body: UpdateRunSessionDto
-  ): Promise<void> {
+  ): void {
     return this.runSessionService.updateSession(userID, sessionID, body);
   }
 

--- a/apps/backend/src/app/modules/users/users.service.ts
+++ b/apps/backend/src/app/modules/users/users.service.ts
@@ -283,8 +283,7 @@ export class UsersService {
       activities: { deleteMany: {} },
       follows: { deleteMany: {} },
       followers: { deleteMany: {} },
-      notifications: { deleteMany: {} },
-      runSessions: { deleteMany: {} }
+      notifications: { deleteMany: {} }
     };
 
     const [deletedUser] = await this.db.$transaction([

--- a/apps/frontend/src/app/services/data/maps.service.ts
+++ b/apps/frontend/src/app/services/data/maps.service.ts
@@ -111,13 +111,6 @@ export class MapsService {
     });
   }
 
-  // TODO: Remove this endpoint, we should never stream from S3 -> backend -> consumer.
-  downloadMapFile(id: number): Observable<Blob> {
-    return this.http.get(`maps/${id}/download`, {
-      responseType: 'blob'
-    });
-  }
-
   updateMapImages(
     mapID: number,
     update: UpdateMapImagesWithFiles

--- a/libs/constants/src/types/models/prisma-correspondence.ts
+++ b/libs/constants/src/types/models/prisma-correspondence.ts
@@ -154,18 +154,6 @@ import { PastRun } from './models';
 import { PastRun as PPastRun } from '@momentum/db';
 assertTypeCorrespondence<PastRun, PPastRun, { id: number }>();
 
-import { RunSession } from './models';
-import { RunSession as PRunSession } from '@momentum/db';
-assertTypeCorrespondence<RunSession, PRunSession, { id: number }>();
-
-import { RunSessionTimestamp } from './models';
-import { RunSessionTimestamp as PRunSessionTimestamp } from '@momentum/db';
-assertTypeCorrespondence<
-  RunSessionTimestamp,
-  PRunSessionTimestamp,
-  { id: number; sessionID: number }
->();
-
 //#endregion
 //#region Utils
 

--- a/libs/constants/src/types/queries/run-queries.model.ts
+++ b/libs/constants/src/types/queries/run-queries.model.ts
@@ -3,7 +3,6 @@ import { TrackType } from '../../enums/track-type.enum';
 import { Style } from '../../enums/style.enum';
 import { PagedQuery } from './pagination.model';
 import { Order } from './order.model';
-import { RunSession } from '../../';
 
 export type RunsGetAllExpand = Array<'user' | 'map' | 'leaderboardRun'>;
 export enum RunsGetAllOrder {
@@ -33,10 +32,12 @@ export type RunsGetQuery = {
   expand?: RunsGetExpand;
 };
 
-export type CreateRunSession = Pick<
-  RunSession,
-  'mapID' | 'gamemode' | 'trackType' | 'trackNum'
->;
+export interface CreateRunSession {
+  mapID: number;
+  gamemode: Gamemode;
+  trackType: TrackType;
+  trackNum: number;
+}
 
 export interface UpdateRunSession {
   majorNum: number;

--- a/libs/db/src/migrations/20250725142421_remove_run_sesssions/migration.sql
+++ b/libs/db/src/migrations/20250725142421_remove_run_sesssions/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the `RunSession` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `RunSessionTimestamp` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "RunSession" DROP CONSTRAINT "RunSession_mapID_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RunSession" DROP CONSTRAINT "RunSession_userID_fkey";
+
+-- DropForeignKey
+ALTER TABLE "RunSessionTimestamp" DROP CONSTRAINT "RunSessionTimestamp_sessionID_fkey";
+
+-- DropTable
+DROP TABLE "RunSession";
+
+-- DropTable
+DROP TABLE "RunSessionTimestamp";

--- a/libs/db/src/schema.prisma
+++ b/libs/db/src/schema.prisma
@@ -32,7 +32,6 @@ model User {
   followers            Follow[]           @relation("follow_follower")
   mapNotifies          MapNotify[]
   notifications        Notification[]
-  runSessions          RunSession[]
   leaderboardRuns      LeaderboardRun[]
   pastRuns             PastRun[]
   reportSubmitted      Report[]           @relation("report_submitter")
@@ -189,7 +188,6 @@ model MMap {
   leaderboards    Leaderboard[]
   leaderboardRuns LeaderboardRun[]
   pastRuns        PastRun[]
-  runSessions     RunSession[]
   credits         MapCredit[]
   favorites       MapFavorite[]
   notifies        MapNotify[]
@@ -527,44 +525,6 @@ model PastRun {
   // queried *very* frequently and is user-specific so bad caching), indexing
   // over [userID, gamemode, createdAt(desc)] would make a lot of sense.
   @@index([userID])
-}
-
-/// This model doesn't have a unique constraint on
-/// (userID, mapID, gamemode, trackType, trackNum) due to the cost of an
-/// index on a table that we insert into so frequently.
-model RunSession {
-  id BigInt @id @default(autoincrement())
-
-  trackType Int @db.SmallInt
-  trackNum  Int @db.SmallInt
-  gamemode  Int @db.SmallInt
-
-  timestamps RunSessionTimestamp[]
-
-  user   User @relation(fields: [userID], references: [id], onDelete: Cascade)
-  userID Int
-
-  mmap  MMap @relation(fields: [mapID], references: [id], onDelete: Cascade)
-  mapID Int
-
-  createdAt DateTime @default(now())
-
-  @@index([userID])
-}
-
-model RunSessionTimestamp {
-  id BigInt @id @default(autoincrement())
-
-  majorNum Int   @db.SmallInt
-  minorNum Int   @db.SmallInt
-  time     Float @db.DoublePrecision
-
-  session   RunSession @relation(fields: [sessionID], references: [id], onDelete: Cascade)
-  sessionID BigInt
-
-  createdAt DateTime @default(now())
-
-  @@index([sessionID])
 }
 
 model AdminActivity {


### PR DESCRIPTION
Uses a plain JS map for run sessions in SQL. Discussed in meetings/Discord.

Based on top of https://github.com/momentum-mod/website/pull/1241, that needs merging before this.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migrations.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
