### PR TITLE
feat(front): dynamically change textarea height

### DIFF
--- a/apps/frontend/src/app/components/map-review/map-review-form.component.html
+++ b/apps/frontend/src/app/components/map-review/map-review-form.component.html
@@ -3,9 +3,10 @@
     <textarea
       [formControl]="mainText"
       placeholder="... (Required)"
-      class="textinput grow"
+      class="textinput grow resize-none overflow-hidden"
       rows="6"
       (keydown.control.enter)="submit()"
+      dynamicTextareaHeight
     ></textarea>
     @if (!editing) {
       <m-multi-file-upload

--- a/apps/frontend/src/app/components/map-review/map-review-form.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review-form.component.ts
@@ -27,6 +27,7 @@ import { MapsService } from '../../services/data/maps.service';
 import { LocalUserService } from '../../services/data/local-user.service';
 import { IconComponent } from '../../icons';
 import { TooltipDirective } from '../../directives/tooltip.directive';
+import { DynamicTextareaHeightDirective } from '../../directives/dynamic-textarea-height.directive';
 
 @Component({
   selector: 'm-map-review-form',
@@ -35,7 +36,8 @@ import { TooltipDirective } from '../../directives/tooltip.directive';
     MultiFileUploadComponent,
     ReactiveFormsModule,
     IconComponent,
-    TooltipDirective
+    TooltipDirective,
+    DynamicTextareaHeightDirective
   ],
   templateUrl: './map-review-form.component.html'
 })

--- a/apps/frontend/src/app/components/map-review/map-review.component.html
+++ b/apps/frontend/src/app/components/map-review/map-review.component.html
@@ -133,7 +133,8 @@
                 (keydown.control.enter)="editComment(comment.id)"
                 [formControl]="editForm.controls.textInput"
                 placeholder="Update comment"
-                class="textinput my-1 grow px-2 py-1"
+                class="textinput my-1 grow resize-none overflow-hidden px-2 py-1"
+                dynamicTextareaHeight
               ></textarea>
               <div class="ml-auto flex gap-1">
                 <button
@@ -161,7 +162,8 @@
       (keydown.control.enter)="postComment()"
       [formControl]="commentInput.controls.textInput"
       placeholder="Leave a comment"
-      class="textinput grow px-2 py-1"
+      class="textinput grow resize-none overflow-hidden px-2 py-1"
+      dynamicTextareaHeight
     ></textarea>
     @if (commentInput.dirty) {
       <div>

--- a/apps/frontend/src/app/components/map-review/map-review.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review.component.ts
@@ -51,6 +51,7 @@ import { DatePipe } from '@angular/common';
 import { SpinnerDirective } from '../../directives/spinner.directive';
 import { PluralPipe } from '../../pipes/plural.pipe';
 import { TooltipDirective } from '../../directives/tooltip.directive';
+import { DynamicTextareaHeightDirective } from '../../directives/dynamic-textarea-height.directive';
 
 @Component({
   selector: 'm-map-review',
@@ -68,7 +69,8 @@ import { TooltipDirective } from '../../directives/tooltip.directive';
     SpinnerDirective,
     PluralPipe,
     ReactiveFormsModule,
-    TooltipDirective
+    TooltipDirective,
+    DynamicTextareaHeightDirective
   ],
   templateUrl: './map-review.component.html'
 })

--- a/apps/frontend/src/app/directives/dynamic-textarea-height.directive.ts
+++ b/apps/frontend/src/app/directives/dynamic-textarea-height.directive.ts
@@ -1,0 +1,30 @@
+import {
+  Directive,
+  HostListener,
+  Renderer2,
+  ElementRef,
+  inject
+} from '@angular/core';
+
+@Directive({
+  selector: '[dynamicTextareaHeight]'
+})
+export class DynamicTextareaHeightDirective {
+  private readonly renderer = inject(Renderer2);
+  private elRef = inject<ElementRef<HTMLTextAreaElement>>(ElementRef);
+
+  @HostListener('input')
+  // Also reset if textarea gets cleared, e.g. on submit.
+  // NOTE: does not catch enter submit for some browsers.
+  @HostListener('selectionchange')
+  updateHeight() {
+    // This is needed to contract height if text was removed.
+    this.renderer.setStyle(this.elRef.nativeElement, 'height', 'auto');
+
+    this.renderer.setStyle(
+      this.elRef.nativeElement,
+      'height',
+      `${this.elRef.nativeElement.scrollHeight}px`
+    );
+  }
+}


### PR DESCRIPTION
Adds directive that changes height automatically for textarea elements.
Didn't add to all of the existing ones, as they work fine and it would screw up some styling.

There is an edgecase where on first interaction with an empty textarea, the box shrinks by about 1px.
Not too bad I think.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
