### PR TITLE
fix(front): map browser author count

### DIFF
--- a/apps/frontend/src/app/components/map-list/map-list-item.component.html
+++ b/apps/frontend/src/app/components/map-list/map-list-item.component.html
@@ -30,7 +30,7 @@
           }"
           [mTooltip]="'Tier ' + lb.tier"
         >
-          <p 
+          <p
           class="text-shadow-strong m-auto font-display font-bold text-28 leading-none">T{{ lb.tier }}</p>
         </div>
           @if (lb.bonuses?.length > 0) {
@@ -89,6 +89,7 @@
     </div>
     <div class="flex grow flex-col !text-14">
       <p class="inline-block text-gray-300" (click)="$event.stopPropagation(); $event.preventDefault()">
+        <!-- At least 1 author is always required. -->
         By
         @if (authors[0]?.id) {
           <a class="link text-gray-50" [routerLink]="'/profile/' + authors[0]?.id">{{ authors[0].alias }}</a>
@@ -104,7 +105,7 @@
             }
           }
         <!-- prettier-ignore -->
-        @if (authors.length > 2) {, + {{ authors.length - 1 | plural: 'author' }}}
+        @if (authors.length > 2) {, + {{ authors.length - 2 | plural: 'author' }}}
       </p>
       @if (isSubmission) {
         @if (!isSubmitterAnAuthor(map)) {


### PR DESCRIPTION
Fix author count being +1 too many in map browser map items.
Reported by Natan in # website on Discord


### Checks
- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
