### PR TITLE
feat(front): hide map review form if not logged in

### DIFF
--- a/apps/frontend/src/app/components/map-review/map-review-list.component.html
+++ b/apps/frontend/src/app/components/map-review/map-review-list.component.html
@@ -1,31 +1,37 @@
-@if (!isSubmitter) {
-  <m-map-review-form [map]="map" (reviewPosted)="load.next()" />
-}
-<p-select
-  class="self-end"
-  [(ngModel)]="filter"
-  [options]="Filters"
-  optionLabel="label"
-  optionValue="type"
-  (onChange)="load.next()"
-  appendTo="body"
-/>
-<div [mSpinner]="loading" class="flex flex-col gap-4">
-  @for (review of reviews; track $index) {
-    <m-map-review [review]="review" [map]="map" (updatedOrDeleted)="load.next()" />
-  } @empty {
-    @if (!loading) {
-      <p class="m-4 text-center text-lg italic text-gray-200">No reviews posted</p>
-    }
+@if (localUserService.isLoggedIn) {
+  @if (!isSubmitter) {
+    <m-map-review-form [map]="map" (reviewPosted)="load.next()" />
   }
-</div>
-<p-paginator
-  class="self-end"
-  (onPageChange)="pageChange.next($event)"
-  [first]="first"
-  [rows]="rows"
-  [totalRecords]="totalRecords"
-  [showCurrentPageReport]="true"
-  [alwaysShow]="false"
-  [rowsPerPageOptions]="[5, 10, 20]"
-/>
+  <p-select
+    class="self-end"
+    [(ngModel)]="filter"
+    [options]="Filters"
+    optionLabel="label"
+    optionValue="type"
+    (onChange)="load.next()"
+    appendTo="body"
+  />
+  <div [mSpinner]="loading" class="flex flex-col gap-4">
+    @for (review of reviews; track $index) {
+      <m-map-review [review]="review" [map]="map" (updatedOrDeleted)="load.next()" />
+    } @empty {
+      @if (!loading) {
+        <p class="m-4 text-center text-lg italic text-gray-200">No reviews posted</p>
+      }
+    }
+  </div>
+  <p-paginator
+    class="self-end"
+    (onPageChange)="pageChange.next($event)"
+    [first]="first"
+    [rows]="rows"
+    [totalRecords]="totalRecords"
+    [showCurrentPageReport]="true"
+    [alwaysShow]="false"
+    [rowsPerPageOptions]="[5, 10, 20]"
+  />
+} @else {
+  <p class="text-lg font-medium text-gray-100">
+    <a (click)="localUserService.login()" class="link cursor-pointer">Sign in</a> to see and post reviews!
+  </p>
+}

--- a/apps/frontend/src/app/components/map-review/map-review-list.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review-list.component.ts
@@ -36,7 +36,7 @@ enum FilterType {
 export class MapReviewListComponent implements OnChanges {
   private readonly mapsService = inject(MapsService);
   private readonly messageService = inject(MessageService);
-  private readonly localUserService = inject(LocalUserService);
+  protected readonly localUserService = inject(LocalUserService);
 
   protected readonly Filters = [
     { type: FilterType.NONE, label: 'All reviews' },


### PR DESCRIPTION
Closes #1253

Not gonna bother trying to debug the inconsistent redirects. It should be fine now when looking at maps in submission when not logged in since those review components won't load.

<img width="1004" height="496" alt="vivaldi_1RkU869uR8" src="https://github.com/user-attachments/assets/d80911a9-24cc-443e-8254-cbea5b5838ac" />

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
