### PR TITLE
Even more map status notification changes

### DIFF
--- a/apps/backend/src/app/config/config.interface.ts
+++ b/apps/backend/src/app/config/config.interface.ts
@@ -54,7 +54,7 @@ export interface ConfigInterface {
     token: string;
     guild: string;
     contentApprovalChannel: string;
-    portingChannel: string;
+    reviewChannel: string;
     statusChannels: Record<GamemodeCategory, string>;
   };
   mapListUpdateSchedule: string;

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -80,7 +80,7 @@ export const ConfigFactory = (): ConfigInterface => {
       guild: process.env['DISCORD_GUILD'] ?? '',
       contentApprovalChannel:
         process.env['DISCORD_CONTENT_APPROVAL_CHANNEL'] ?? '',
-      portingChannel: process.env['DISCORD_PORTING_CHANNEL'] ?? '',
+      reviewChannel: process.env['DISCORD_REVIEW_CHANNEL'] ?? '',
       statusChannels: Object.fromEntries(
         Enum.values(GamemodeCategory).map((cat) => [
           cat,

--- a/apps/backend/src/app/modules/discord/discord.service.ts
+++ b/apps/backend/src/app/modules/discord/discord.service.ts
@@ -22,12 +22,12 @@ export class DiscordService {
 
   static async factory(config: ConfigService) {
     const client = new DiscordService();
-    client.enabled = true;
-
-    if (!client.isEnabled()) return client;
 
     const token = config.getOrThrow('discord.token');
     if (!token) return client;
+    client.enabled = true;
+
+    if (!client.isEnabled()) return client;
 
     client.token = token;
     client.rest.setToken(token);

--- a/apps/backend/src/app/modules/maps/map-status-notifications.service.ts
+++ b/apps/backend/src/app/modules/maps/map-status-notifications.service.ts
@@ -97,11 +97,12 @@ export class MapStatusNotifications {
     );
 
     const thread = await reviewChannel.threads.create({
-      name: extendedMap.name
-    });
-    await thread.send({
-      content: ':warning: A new map is available for public testing! :warning:',
-      embeds: [mapEmbed]
+      name: extendedMap.name,
+      message: {
+        content:
+          ':warning: A new map is available for public testing! :warning:',
+        embeds: [mapEmbed]
+      }
     });
 
     const categories = this.getGamemodeCategories(

--- a/apps/backend/src/app/modules/maps/map-status-notifications.service.ts
+++ b/apps/backend/src/app/modules/maps/map-status-notifications.service.ts
@@ -111,12 +111,12 @@ export class MapStatusNotifications {
     );
 
     await this.broadcastToCategories(
-      `:warning: A new map is available for public testing! :warning: ${thread.url}`,
+      `:warning: A new map is available for public testing! :warning: Post feedback in ${thread.url}`,
       mapEmbed,
       categories.ranked
     );
     await this.broadcastToCategories(
-      `:warning: A new **UNRANKED** map is available for public testing! :warning: ${thread.url}`,
+      `:warning: A new **UNRANKED** map is available for public testing! :warning: Post feedback in ${thread.url}`,
       mapEmbed,
       categories.unranked
     );

--- a/apps/backend/src/app/modules/maps/map-status-notifications.service.ts
+++ b/apps/backend/src/app/modules/maps/map-status-notifications.service.ts
@@ -76,14 +76,14 @@ export class MapStatusNotifications {
   async sendPublicTestingNotification(extendedMap: MapWithInfoInSubmission) {
     if (!this.discord.isEnabled()) return;
 
-    const portingChannelID = this.config.getOrThrow('discord.portingChannel');
-    if (!portingChannelID) return;
+    const reviewChannelID = this.config.getOrThrow('discord.reviewChannel');
+    if (!reviewChannelID) return;
 
     // Cached in Discord.js
-    const portingChannel = await this.discord.channels.fetch(portingChannelID);
-    if (!portingChannel || portingChannel.type !== ChannelType.GuildText) {
+    const reviewChannel = await this.discord.channels.fetch(reviewChannelID);
+    if (!reviewChannel || reviewChannel.type !== ChannelType.GuildForum) {
       this.logger.error(
-        "Porting channel doesn't exist or is not a guild text channel."
+        "Review channel doesn't exist or is not a guild forum channel."
       );
       return;
     }
@@ -96,7 +96,7 @@ export class MapStatusNotifications {
       info.leaderboards
     );
 
-    const thread = await portingChannel.threads.create({
+    const thread = await reviewChannel.threads.create({
       name: extendedMap.name
     });
     await thread.send({


### PR DESCRIPTION
Now uses a forum channel instead of threads in a porting channel and fixes a bug where multiple notifications were sent if there are both ranked and unranked gamemodes in the same category. Also includes a small wording change.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
