### PR TITLE
Feat/cycle gallery items

### DIFF
--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -917,7 +917,11 @@ describe('Maps', () => {
               leaderboards: true,
               currentVersion: true,
               versions: true,
-              submission: { include: { dates: true } }
+              submission: {
+                include: {
+                  dates: { orderBy: { date: 'asc' }, include: { user: true } }
+                }
+              }
             }
           });
         });

--- a/apps/backend/src/app/modules/maps/maps.service.ts
+++ b/apps/backend/src/app/modules/maps/maps.service.ts
@@ -351,7 +351,11 @@ export class MapsService {
       include = {
         versions: { include: { submitter: true } },
         currentVersion: true,
-        submission: { include: { dates: { include: { user: true } } } },
+        submission: {
+          include: {
+            dates: { orderBy: { date: 'asc' }, include: { user: true } }
+          }
+        },
         info: true,
         leaderboards: true,
         submitter: true,
@@ -387,11 +391,17 @@ export class MapsService {
       if (query instanceof MapsGetAllSubmissionQueryDto) {
         if (include) {
           include.submission = {
-            include: { dates: { include: { user: true } } }
+            include: {
+              dates: { orderBy: { date: 'asc' }, include: { user: true } }
+            }
           };
         } else {
           include = {
-            submission: { include: { dates: { include: { user: true } } } }
+            submission: {
+              include: {
+                dates: { orderBy: { date: 'asc' }, include: { user: true } }
+              }
+            }
           };
         }
       }
@@ -450,7 +460,11 @@ export class MapsService {
         },
         {
           expand: 'submission',
-          value: { include: { dates: { include: { user: true } } } }
+          value: {
+            include: {
+              dates: { orderBy: { date: 'asc' }, include: { user: true } }
+            }
+          }
         }
       ]
     });
@@ -686,7 +700,11 @@ export class MapsService {
       include: {
         currentVersion: true,
         versions: { omit: { zones: true }, include: { submitter: true } },
-        submission: { include: { dates: { include: { user: true } } } },
+        submission: {
+          include: {
+            dates: { orderBy: { date: 'asc' }, include: { user: true } }
+          }
+        },
         info: true
       }
     });
@@ -875,7 +893,11 @@ export class MapsService {
         include: {
           currentVersion: true,
           versions: { include: { submitter: true } },
-          submission: { include: { dates: { include: { user: true } } } }
+          submission: {
+            include: {
+              dates: { orderBy: { date: 'asc' }, include: { user: true } }
+            }
+          }
         }
       })
     );
@@ -1017,7 +1039,11 @@ export class MapsService {
         stats: true,
         currentVersion: true,
         versions: { include: { submitter: true } },
-        submission: { include: { dates: { include: { user: true } } } },
+        submission: {
+          include: {
+            dates: { orderBy: { date: 'asc' }, include: { user: true } }
+          }
+        },
         submitter: true,
         credits: { include: { user: true } }
       }
@@ -1178,7 +1204,11 @@ export class MapsService {
     const map = (await this.db.mMap.findUnique({
       where: { id: mapID },
       include: {
-        submission: { include: { dates: { include: { user: true } } } },
+        submission: {
+          include: {
+            dates: { orderBy: { date: 'asc' }, include: { user: true } }
+          }
+        },
         currentVersion: true,
         versions: { include: { submitter: true } },
         info: true
@@ -1243,7 +1273,11 @@ export class MapsService {
             where: { id: map.id },
             include: {
               info: true,
-              submission: { include: { dates: { include: { user: true } } } },
+              submission: {
+                include: {
+                  dates: { orderBy: { date: 'asc' }, include: { user: true } }
+                }
+              },
               submitter: true,
               credits: { include: { user: true } }
             }
@@ -1304,7 +1338,11 @@ export class MapsService {
       include: {
         currentVersion: true,
         versions: { include: { submitter: true } },
-        submission: { include: { dates: { include: { user: true } } } },
+        submission: {
+          include: {
+            dates: { orderBy: { date: 'asc' }, include: { user: true } }
+          }
+        },
         info: true
       }
     })) as unknown as MapWithSubmission; // TODO: #855;
@@ -1388,7 +1426,11 @@ export class MapsService {
             where: { id: map.id },
             include: {
               info: true,
-              submission: { include: { dates: { include: { user: true } } } },
+              submission: {
+                include: {
+                  dates: { orderBy: { date: 'asc' }, include: { user: true } }
+                }
+              },
               submitter: true,
               credits: { include: { user: true } }
             }

--- a/apps/frontend/src/app/components/gallery/gallery.component.html
+++ b/apps/frontend/src/app/components/gallery/gallery.component.html
@@ -29,12 +29,12 @@
     @if (items.length > 1) {
       <!-- Make sure high in z-order so clicking in between thumbnails doesn't trigger close (annoying!)-->
       <div class="z-10 mt-[1.5vh] flex min-h-0 basis-[12.5%] items-center justify-center gap-[1.5vh] overflow-x-auto">
-        @for (item of items; track $index) {
+        @for (item of items; track $index; let i = $index) {
           <!-- Needed for hover effect -->
           <button
             type="button"
             class="hover-white-overlay h-full w-max shrink-0 items-center overflow-hidden rounded shadow-lg"
-            (click)="selectItem(item)"
+            (click)="selectItem(i)"
           >
             <img class="h-full min-h-0" [src]="item.type === 'image' ? item.thumbnail : item.safeThumbnail" />
           </button>

--- a/apps/frontend/src/app/components/gallery/gallery.component.html
+++ b/apps/frontend/src/app/components/gallery/gallery.component.html
@@ -6,19 +6,34 @@
     ></div>
     <button
       type="button"
-      class="absolute right-0 top-0 z-20 m-[1.5vh] h-16 w-16 rounded-full bg-white bg-opacity-0 transition-colors hover:bg-opacity-10"
+      class="absolute right-0 top-0 z-20 m-[1.5vh] size-20 rounded-full bg-white bg-opacity-0 transition-colors hover:bg-opacity-10"
       (click)="popover.hidePopover()"
     >
-      <m-icon class="h-16 w-16 p-2" icon="close" />
+      <m-icon class="size-full p-2" icon="close" />
+    </button>
+
+    <button
+      type="button"
+      class="absolute left-4 z-20 size-32 rounded-full bg-white bg-opacity-0 transition-colors hover:bg-opacity-5"
+      (click)="cycleLeft()"
+    >
+      <m-icon icon="menu-left" class="size-full opacity-85" />
+    </button>
+    <button
+      type="button"
+      class="absolute right-4 z-20 size-32 rounded-full bg-white bg-opacity-0 transition-colors hover:bg-opacity-5"
+      (click)="cycleRight()"
+    >
+      <m-icon icon="menu-right" class="size-full opacity-85" />
     </button>
 
     <div #parent class="pointer-events-none z-10 grid aspect-video min-h-0 basis-[87.5%] place-items-center">
       @if (selectedItem && selectedItem.type === 'image') {
-        <img class="pointer-events-auto rounded shadow-lg" [src]="selectedItem.full" />
+        <img class="pointer-events-auto size-full rounded shadow-lg" [src]="selectedItem.full" />
       } @else if (selectedItem && selectedItem.type === 'youtube') {
         <iframe
           #youtubeIframe
-          class="pointer-events-auto h-full w-full shadow-lg"
+          class="pointer-events-auto size-full shadow-lg"
           type="text/html"
           [src]="selectedItem.safeUrl"
           allowfullscreen="true"
@@ -33,7 +48,8 @@
           <!-- Needed for hover effect -->
           <button
             type="button"
-            class="hover-white-overlay h-full w-max shrink-0 items-center overflow-hidden rounded shadow-lg"
+            class="hover-white-overlay h-full w-max shrink-0 items-center overflow-hidden rounded shadow-lg outline-none"
+            [ngClass]="{ 'border-2': i === selectedItemIndex }"
             (click)="selectItem(i)"
           >
             <img class="h-full min-h-0" [src]="item.type === 'image' ? item.thumbnail : item.safeThumbnail" />

--- a/apps/frontend/src/app/components/gallery/gallery.component.ts
+++ b/apps/frontend/src/app/components/gallery/gallery.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  HostListener,
   Input,
   OnInit,
   Output,
@@ -36,10 +37,35 @@ export type GalleryItem = GalleryImageItem | GalleryYouTubeItem;
 export class GalleryComponent implements OnInit, AfterViewInit {
   @Input({ required: true }) items: GalleryItem[] = [];
   @Input() selectedItem: GalleryItem;
+  private selectedItemIndex = 0;
   @Output() selectedItemChange = new EventEmitter<GalleryItem>();
 
   @ViewChild('popover') popover: ElementRef<HTMLDivElement>;
   @ViewChild('youtubeIframe') youtubeIframe: ElementRef<HTMLIFrameElement>;
+
+  @HostListener('window:keydown.ArrowLeft')
+  @HostListener('window:keydown.a')
+  cycleLeft() {
+    if (!this.popover.nativeElement.matches(':popover-open')) return;
+
+    if (this.selectedItemIndex === 0) {
+      this.selectItem(this.items.length - 1);
+    } else {
+      this.selectItem(this.selectedItemIndex - 1);
+    }
+  }
+
+  @HostListener('window:keydown.ArrowRight')
+  @HostListener('window:keydown.d')
+  cycleRight() {
+    if (!this.popover.nativeElement.matches(':popover-open')) return;
+
+    if (this.selectedItemIndex === this.items.length - 1) {
+      this.selectItem(0);
+    } else {
+      this.selectItem(this.selectedItemIndex + 1);
+    }
+  }
 
   ngOnInit(): void {
     this.selectedItem ??= this.items[0];
@@ -60,8 +86,9 @@ export class GalleryComponent implements OnInit, AfterViewInit {
     this.popover.nativeElement.showPopover();
   }
 
-  selectItem(item: GalleryItem): void {
-    this.selectedItem = item;
-    this.selectedItemChange.emit(item);
+  selectItem(index: number): void {
+    this.selectedItemIndex = index;
+    this.selectedItem = this.items[index];
+    this.selectedItemChange.emit(this.selectedItem);
   }
 }

--- a/apps/frontend/src/app/components/gallery/gallery.component.ts
+++ b/apps/frontend/src/app/components/gallery/gallery.component.ts
@@ -11,6 +11,7 @@ import {
 } from '@angular/core';
 import { IconComponent } from '../../icons';
 import { SafeUrl } from '@angular/platform-browser';
+import { NgClass } from '@angular/common';
 
 export interface GalleryImageItem {
   type: 'image';
@@ -31,13 +32,13 @@ export type GalleryItem = GalleryImageItem | GalleryYouTubeItem;
  */
 @Component({
   selector: 'm-gallery',
-  imports: [IconComponent],
+  imports: [NgClass, IconComponent],
   templateUrl: './gallery.component.html'
 })
 export class GalleryComponent implements OnInit, AfterViewInit {
   @Input({ required: true }) items: GalleryItem[] = [];
   @Input() selectedItem: GalleryItem;
-  private selectedItemIndex = 0;
+  protected selectedItemIndex = 0;
   @Output() selectedItemChange = new EventEmitter<GalleryItem>();
 
   @ViewChild('popover') popover: ElementRef<HTMLDivElement>;

--- a/apps/frontend/src/app/components/map-review/map-review.component.html
+++ b/apps/frontend/src/app/components/map-review/map-review.component.html
@@ -64,8 +64,12 @@
       @if (review.images?.length > 0) {
         <m-gallery #gallery [items]="images" />
         <div class="grid grid-cols-6 gap-2 rounded bg-black bg-opacity-20 p-1.5">
-          @for (image of images; track $index) {
-            <button type="button" class="hover-white-overlay rounded-sm shadow-lg" (click)="gallery.selectItem(image); gallery.show()">
+          @for (image of images; track $index; let galleryImageIndex = $index) {
+            <button
+              type="button"
+              class="hover-white-overlay rounded-sm shadow-lg"
+              (click)="gallery.selectItem(galleryImageIndex); gallery.show()"
+            >
               <img [src]="image.thumbnail" />
             </button>
           }

--- a/apps/frontend/src/app/icons/packs/material-design-icons.icons.ts
+++ b/apps/frontend/src/app/icons/packs/material-design-icons.icons.ts
@@ -8,6 +8,8 @@ export {
   mdiCloseOutline,
   mdiCloseCircleOutline,
   mdiMenu,
+  mdiMenuLeft,
+  mdiMenuRight,
   mdiPanorama,
   mdiPanoramaOutline,
   mdiPanoramaVariantOutline,

--- a/libs/test-utils/src/utils/db.util.ts
+++ b/libs/test-utils/src/utils/db.util.ts
@@ -251,7 +251,11 @@ export class DbUtil {
         versions: true,
         currentVersion: true,
         leaderboards: true,
-        submission: { include: { dates: { include: { user: true } } } }
+        submission: {
+          include: {
+            dates: { orderBy: { date: 'asc' }, include: { user: true } }
+          }
+        }
       }
     });
   }

--- a/scripts/src/seed.script.ts
+++ b/scripts/src/seed.script.ts
@@ -9,7 +9,10 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import zlib from 'node:zlib';
-import { PrismaClient } from '@momentum/db';
+import {
+  MapSubmissionDateCreateWithoutSubmissionInput,
+  PrismaClient
+} from '@momentum/db';
 import { faker } from '@faker-js/faker';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import {
@@ -262,9 +265,9 @@ prismaWrapper(async (prisma: PrismaClient) => {
       imageBuffers = await Promise.all(
         arrayFrom(randRange(vars.imageFetches), () =>
           axios
-            // Sometimes picsum will fail and break script.
-            // Temp substitute; pictures are very low res, and wrong format.
+            // Sometimes picsum will fail and break script; temp substitutes:
             // .get('https://placedog.net/480/360', {
+            // .get('http://placebeard.it/2560/1440', {
             .get('https://picsum.photos/2560/1440', {
               responseType: 'arraybuffer'
             })
@@ -415,7 +418,7 @@ prismaWrapper(async (prisma: PrismaClient) => {
         );
 
       const submissionsDates = () => {
-        const dates = [];
+        const dates: MapSubmissionDateCreateWithoutSubmissionInput[] = [];
 
         let currStatus: MapStatus = Random.chance()
           ? MapStatus.PRIVATE_TESTING
@@ -430,7 +433,7 @@ prismaWrapper(async (prisma: PrismaClient) => {
           });
 
           currDate = new Date(
-            new Date(currDate).getTime() + Random.int(1000 * 60 * 60 * 24 * 30) // Monf
+            currDate.getTime() + Random.int(1000 * 60 * 60 * 24 * 30) // Monf
           );
           currStatus = Random.weighted(
             weights.submissionGraphWeights[currStatus]


### PR DESCRIPTION
Closes #1120

Gallery item cycling, brought to you by beards.

For the new buttons, I tried without using position absolute but it ended up creating a bunch of scrollbars and was overall less responsive.
BTW the left/right icons have an absurd padding in the SVG, which I don't think I can get rid of so the resulting button areas are massive :(

Unrelated, but also saw this:
changed all backend requests to always return MapSubmissionDates array ordered. Currently we only create one date at a time, and internally prisma/postgress adds it to the end, but I don't think we shouldn't rely on this for ordering.

### Screenshots (if applicable)

![vivaldi_ZdbNz44Gzh](https://github.com/user-attachments/assets/9a177d6e-e92e-41e2-825d-b670df694b3f)

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
