### PR TITLE
Credit map browser filter (+ backend support), improved wrapping in map browsers

### DIFF
--- a/apps/backend-e2e/src/admin.e2e-spec.ts
+++ b/apps/backend-e2e/src/admin.e2e-spec.ts
@@ -29,7 +29,6 @@ import {
   KillswitchType,
   Killswitches,
   MapTag,
-  MapSortType,
   bspPath,
   imgLargePath,
   imgMediumPath,
@@ -861,14 +860,8 @@ describe('Admin', () => {
           ]);
 
         await db.createMap({ status: MapStatus.PRIVATE_TESTING });
-        caMap = await db.createMap({
-          name: 'zebra_crossing_simulator',
-          status: MapStatus.CONTENT_APPROVAL
-        });
-        faMap = await db.createMap({
-          name: 'yes_very_good_map',
-          status: MapStatus.FINAL_APPROVAL
-        });
+        caMap = await db.createMap({ status: MapStatus.CONTENT_APPROVAL });
+        faMap = await db.createMap({ status: MapStatus.FINAL_APPROVAL });
         await db.createMap({ status: MapStatus.PUBLIC_TESTING });
         await db.createMap({ status: MapStatus.DISABLED });
       });
@@ -968,18 +961,6 @@ describe('Admin', () => {
             expect.objectContaining({ id: faMap.id })
           ])
         );
-      });
-
-      it('should sort maps in reverse alphabetical order when in sortType query', async () => {
-        const res = await req.get({
-          url: 'admin/maps',
-          status: 200,
-          query: { sortType: MapSortType.REVERSE_ALPHABETICAL },
-          token: adminToken
-        });
-
-        expect(res.body.data[0].name).toBe(caMap.name);
-        expect(res.body.data[1].name).toBe(faMap.name);
       });
 
       it('should return 403 if a regular access token is given', () =>

--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -3916,7 +3916,6 @@ describe('Maps', () => {
 
         await db.createMap({ status: MapStatus.APPROVED });
         pubMap1 = await db.createMap({
-          name: 'zesty_granola',
           status: MapStatus.PUBLIC_TESTING,
           ...mapCreate,
           reviews: {
@@ -3927,7 +3926,6 @@ describe('Maps', () => {
           }
         });
         pubMap2 = await db.createMap({
-          name: 'xtra_cool_map',
           status: MapStatus.PUBLIC_TESTING,
           ...mapCreate
         });
@@ -4075,18 +4073,6 @@ describe('Maps', () => {
           where: { id: pubMap1.id },
           data: { submitterID: null }
         });
-      });
-
-      it('should respond with maps in reverse alphabetical order when in sortType query', async () => {
-        const res = await req.get({
-          url: 'maps/submissions',
-          status: 200,
-          query: { sortType: MapSortType.REVERSE_ALPHABETICAL },
-          token: u1Token
-        });
-
-        expect(res.body.data[0].name).toBe(pubMap1.name);
-        expect(res.body.data[1].name).toBe(pubMap2.name);
       });
 
       it('should respond with expanded current version data using the currentVersion expand parameter', () =>

--- a/apps/backend-e2e/src/user.e2e-spec.ts
+++ b/apps/backend-e2e/src/user.e2e-spec.ts
@@ -25,7 +25,6 @@ import {
   Ban,
   Gamemode,
   MapCreditType,
-  MapSortType,
   ReportCategory,
   ReportType,
   Role,
@@ -1465,14 +1464,14 @@ describe('User', () => {
 
   describe('user/maps', () => {
     describe('GET', () => {
-      let u1: User, u1Token: string, u2Token: string, m1, m2;
+      let u1: User, u1Token: string, u2Token: string;
 
       beforeAll(async () => {
         [[u1, u1Token], u2Token] = await Promise.all([
           db.createAndLoginUser(),
           db.loginNewUser()
         ]);
-        [m1, m2] = await Promise.all([
+        await Promise.all([
           db.createMap({
             name: 'ahop_aaaaaaaa',
             submitter: { connect: { id: u1.id } },
@@ -1561,18 +1560,6 @@ describe('User', () => {
           searchMethod: 'contains',
           searchString: 'bbb'
         }));
-
-      it('should sort maps in reverse alphabetical order when in sortType query', async () => {
-        const res = await req.get({
-          url: 'user/maps',
-          status: 200,
-          query: { sortType: MapSortType.REVERSE_ALPHABETICAL },
-          token: u1Token
-        });
-
-        expect(res.body.data[0].name).toBe(m2.name);
-        expect(res.body.data[1].name).toBe(m1.name);
-      });
 
       it('should 401 when no access token is provided', () =>
         req.unauthorizedTest('user/maps', 'get'));

--- a/apps/backend/src/app/dto/queries/map-queries.dto.ts
+++ b/apps/backend/src/app/dto/queries/map-queries.dto.ts
@@ -19,7 +19,8 @@ import {
   MapRunsGetExpand,
   MapRunsGetFilter,
   MapLeaderboardGetRunQuery,
-  MapSortType
+  MapSortType,
+  MapCreditType
 } from '@momentum/constants';
 import {
   MapCreditsGetQuery,
@@ -67,6 +68,14 @@ class MapsGetAllBaseQueryDto extends QueryDto {
 
   @IntQueryProperty({ description: 'Filter by submitter ID' })
   readonly submitterID?: number;
+
+  @IntQueryProperty({ description: 'Filter by a user in map credits' })
+  readonly creditID?: number;
+
+  @EnumQueryProperty(MapCreditType, {
+    description: 'Type of credit for creditID field'
+  })
+  readonly creditType?: MapCreditType;
 
   @EnumQueryProperty(MapSortType, {
     description: 'Get maps in a given order with MapSortType'

--- a/apps/frontend/src/app/components/dropdown/dropdown.component.ts
+++ b/apps/frontend/src/app/components/dropdown/dropdown.component.ts
@@ -19,7 +19,7 @@ export class DropdownComponent implements ControlValueAccessor {
   // First element is used as default for dropdown button in template.
   @Input({ required: true }) entries: number[] = [];
 
-  @Input() entryNameFn?: (entry: number) => string;
+  @Input({ required: true }) entryNameFn?: (entry: number) => string;
 
   protected selectedEntry: number;
 
@@ -54,6 +54,7 @@ export class DropdownComponent implements ControlValueAccessor {
   @ViewChild('dropdown', { static: false })
   dropdownElem: ElementRef<HTMLDivElement>;
 
+  // NOTE: left-aligned; standard is right-aligned to toggle element.
   fixUnsupportedAnchorPosition() {
     if (!('anchorName' in document.documentElement.style)) {
       const toggleElemCoords =
@@ -63,8 +64,6 @@ export class DropdownComponent implements ControlValueAccessor {
         toggleElemCoords.bottom.toString() + 'px';
       this.dropdownElem.nativeElement.style.left =
         toggleElemCoords.left.toString() + 'px';
-      this.dropdownElem.nativeElement.style.width =
-        toggleElemCoords.width.toString() + 'px';
     }
   }
 }

--- a/apps/frontend/src/app/components/n-state-button/n-state-button.component.ts
+++ b/apps/frontend/src/app/components/n-state-button/n-state-button.component.ts
@@ -23,6 +23,12 @@ export type NStateButtonColor =
   | 'purple'
   | 'yellow';
 
+export type NStateButtonStates = Array<{
+  color: NStateButtonColor | null;
+  text?: string;
+  icon?: Icon;
+}>;
+
 @Component({
   template: `@if (currentState.text; as text) {
       <p [ngClass]="textClass">{{ text }}</p>
@@ -44,11 +50,7 @@ export type NStateButtonColor =
 export class NStateButtonComponent implements ControlValueAccessor {
   private readonly cdRef = inject(ChangeDetectorRef);
 
-  @Input({ required: true }) states: Array<{
-    color: NStateButtonColor | null;
-    text?: string;
-    icon?: Icon;
-  }>;
+  @Input({ required: true }) states: NStateButtonStates;
 
   @Input() type: 'button' | 'submit' = 'button';
   @Input() textClass: string;

--- a/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
@@ -1,24 +1,32 @@
-<div class="mb-4 flex flex-wrap items-end gap-4">
-  <p class="card-title flex text-48">All Maps</p>
-  <p class="w-96 pb-1 text-sm italic">
-    This page is practically the same as the main map list, except it includes maps of all statuses, including disabled.
-  </p>
-  <form class="ml-auto flex flex-wrap items-center gap-4" [formGroup]="filters">
-    <input class="textinput mr-4 w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
-    <p class="font-display text-24">Status</p>
-    <p-multiSelect
-      formControlName="status"
-      [options]="StatusDropdown"
-      optionLabel="label"
-      optionValue="type"
-      [showHeader]="false"
-      appendTo="body"
-      [maxSelectedLabels]="2"
-    />
-    <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" class="w-64" />
-    <button (click)="resetFilters()" type="button" class="btn h-8 w-8 p-0">
-      <m-icon icon="filter-remove" class="h-5 w-5" />
-    </button>
+<div class="mb-4 flex gap-4">
+  <div class="flex flex-col">
+    <p class="card-title flex text-nowrap text-48">All Maps</p>
+    <p class="max-w-96 pb-1 text-sm italic">
+      This page is practically the same as the main map list, except it includes maps of all statuses, including disabled.
+    </p>
+  </div>
+  <form class="ml-auto flex flex-col gap-2" [formGroup]="filters">
+    <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+      <input class="textinput w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
+      <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
+        <m-icon icon="filter-remove" class="size-5" />
+      </button>
+    </div>
+    <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+      <div class="flex items-center gap-2">
+        <p class="font-display text-24">Status</p>
+        <p-multiSelect
+          formControlName="status"
+          [options]="StatusDropdown"
+          optionLabel="label"
+          optionValue="type"
+          [showHeader]="false"
+          appendTo="body"
+          [maxSelectedLabels]="2"
+        />
+      </div>
+      <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" />
+    </div>
   </form>
 </div>
 <m-map-list [maps]="maps" [loadMore]="loadMore" [loading]="loading" [isAdminPage]="true" />

--- a/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
@@ -7,6 +7,10 @@
   </div>
   <form class="ml-auto flex flex-col gap-2" [formGroup]="filters">
     <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+      <div class="flex items-center gap-2">
+        <m-user-select formControlName="credit" />
+        <m-dropdown [entries]="MapCreditOptions" [entryNameFn]="MapCreditNameFn" formControlName="creditType" />
+      </div>
       <input class="textinput w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
       <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
         <m-icon icon="filter-remove" class="size-5" />

--- a/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
@@ -1,11 +1,10 @@
 <form class="mb-4 flex" [formGroup]="filters">
-  <div class="flex basis-1/2 flex-col">
-    <p class="card-title text-48">Browse Maps</p>
+  <div class="flex basis-4/10 flex-col">
     <div class="flex flex-wrap items-end gap-x-4 gap-y-1">
       <ng-template #gm let-mode="mode" let-name="name" let-size="size">
         <button type="button" (click)="gamemode.setValue(mode)">
           <p
-            class="text-left font-display text-32 font-bold leading-none text-gray-300 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)] transition-all hover:text-gray-50"
+            class="text-left font-display text-36 font-bold leading-none text-gray-300 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)] transition-all hover:text-gray-50"
             [ngClass]="{
               'text-white drop-shadow-[0_0_8px_rgb(255_255_255/0.225)]': gamemode.value === mode
             }"
@@ -43,7 +42,17 @@
       </div>
     </div>
   </div>
-  <div class="ml-auto flex basis-1/2 flex-col gap-2">
+  <div class="ml-auto flex basis-6/10 flex-col gap-2">
+    <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+      <div class="flex items-center gap-2">
+        <m-user-select formControlName="credit" />
+        <m-dropdown [entries]="MapCreditOptions" [entryNameFn]="MapCreditNameFn" formControlName="creditType" />
+      </div>
+      <input class="textinput w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
+      <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
+        <m-icon icon="filter-remove" class="size-5" />
+      </button>
+    </div>
     <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
       <div class="flex items-center gap-2">
         <p class="font-display text-24" [ngClass]="{ 'opacity-50': gamemode.value == null }">Tiers</p>
@@ -61,10 +70,7 @@
           [tooltipDisabled]="gamemode.value != null"
         />
       </div>
-      <input class="textinput w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
-      <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
-        <m-icon icon="filter-remove" class="size-5" />
-      </button>
+      <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" />
     </div>
     <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
       @if (localUserService.user | async) {
@@ -93,7 +99,6 @@
           />
         </div>
       }
-      <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" />
     </div>
   </div>
 </form>

--- a/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
@@ -1,11 +1,11 @@
 <form class="mb-4 flex" [formGroup]="filters">
-  <div class="flex flex-col">
-    <p class="card-title -mb-4 text-48">Browse Maps</p>
-    <div class="flex flex-wrap items-end gap-4">
+  <div class="flex basis-1/2 flex-col">
+    <p class="card-title text-48">Browse Maps</p>
+    <div class="flex flex-wrap items-end gap-x-4 gap-y-1">
       <ng-template #gm let-mode="mode" let-name="name" let-size="size">
         <button type="button" (click)="gamemode.setValue(mode)">
           <p
-            class="font-display text-32 font-bold leading-none text-gray-300 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)] transition-all hover:text-gray-50"
+            class="text-left font-display text-32 font-bold leading-none text-gray-300 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)] transition-all hover:text-gray-50"
             [ngClass]="{
               'text-white drop-shadow-[0_0_8px_rgb(255_255_255/0.225)]': gamemode.value === mode
             }"
@@ -22,62 +22,78 @@
       <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.SJ, name: 'Sticky Jump' }" />
       <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.AHOP, name: 'Ahop' }" />
       <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.CONC, name: 'Conc' }" />
-      <div class="grid grid-cols-2 grid-rows-1 gap-x-2">
+      <div class="grid grid-cols-3 grid-rows-1 gap-x-2">
         <p
-          class="pointer-events-none col-span-2 font-display text-24 font-bold leading-none text-gray-400 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)]"
+          class="pointer-events-none col-span-3 font-display text-24 font-bold leading-none text-gray-400 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)]"
         >
           Defrag
         </p>
         <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.DEFRAG_CPM, name: 'CPM' }" />
         <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.DEFRAG_VQ3, name: 'VQ3' }" />
+        <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.DEFRAG_VTG, name: 'VTG' }" />
+      </div>
+      <!-- TODO more climb modes when done. Currently positioned after defrag to wrap nicely with 1080p monitor and 100%-->
+      <div class="grid grid-cols-1 grid-rows-1 gap-x-2">
+        <p
+          class="pointer-events-none col-span-1 font-display text-24 font-bold leading-none text-gray-400 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)]"
+        >
+          Climb
+        </p>
+        <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.CLIMB_16, name: '1.6' }" />
       </div>
     </div>
   </div>
-  <div class="ml-auto flex flex-col justify-between gap-2">
-    <div class="flex items-center gap-2">
-      <p class="font-display text-24" [ngClass]="{ 'opacity-50': gamemode.value == null }">Tiers</p>
-      <m-slider
-        #slider
-        class="h-9 w-64"
-        [ngClass]="{ 'contrast-25 opacity-50': gamemode.value == null }"
-        formControlName="tiers"
-        [range]="true"
-        [step]="1"
-        [min]="1"
-        [max]="10"
-        [markers]="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
-        mTooltip="You must select a gamemode to use this filter"
-        [tooltipDisabled]="gamemode.value != null"
-      />
-      <input class="textinput ml-5 h-10 w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
-      <button (click)="resetFilters()" type="button" class="btn h-8 w-8 p-0">
-        <m-icon icon="filter-remove" class="h-5 w-5" />
+  <div class="ml-auto flex basis-1/2 flex-col gap-2">
+    <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+      <div class="flex items-center gap-2">
+        <p class="font-display text-24" [ngClass]="{ 'opacity-50': gamemode.value == null }">Tiers</p>
+        <m-slider
+          #slider
+          class="h-9 w-64"
+          [ngClass]="{ 'contrast-25 opacity-50': gamemode.value == null }"
+          formControlName="tiers"
+          [range]="true"
+          [step]="1"
+          [min]="1"
+          [max]="10"
+          [markers]="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+          mTooltip="You must select a gamemode to use this filter"
+          [tooltipDisabled]="gamemode.value != null"
+        />
+      </div>
+      <input class="textinput w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
+      <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
+        <m-icon icon="filter-remove" class="size-5" />
       </button>
     </div>
-    <div class="ml-auto flex items-center gap-2">
+    <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
       @if (localUserService.user | async) {
-        <p class="font-display text-24">Favorites</p>
-        <m-n-state-button
-          class="mr-4 h-8 w-8 p-0"
-          [states]="[
-            { icon: 'star', color: null },
-            { icon: 'star', color: 'blue' },
-            { icon: 'star', color: 'red' }
-          ]"
-          formControlName="favorites"
-        />
-        <p class="font-display text-24">Completed</p>
-        <m-n-state-button
-          class="mr-4 h-8 w-8 p-0"
-          [states]="[
-            { icon: 'flag-outline', color: null },
-            { icon: 'flag-outline', color: 'blue' },
-            { icon: 'flag-outline', color: 'red' }
-          ]"
-          formControlName="pb"
-        />
+        <div class="flex items-center gap-2">
+          <p class="font-display text-24">Favorites</p>
+          <m-n-state-button
+            class="size-8 p-0"
+            [states]="[
+              { icon: 'star', color: null },
+              { icon: 'star', color: 'blue' },
+              { icon: 'star', color: 'red' }
+            ]"
+            formControlName="favorites"
+          />
+        </div>
+        <div class="flex items-center gap-2">
+          <p class="font-display text-24">Completed</p>
+          <m-n-state-button
+            class="size-8 p-0"
+            [states]="[
+              { icon: 'flag-outline', color: null },
+              { icon: 'flag-outline', color: 'blue' },
+              { icon: 'flag-outline', color: 'red' }
+            ]"
+            formControlName="pb"
+          />
+        </div>
       }
-      <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" class="w-[18.5rem]" />
+      <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" />
     </div>
   </div>
 </form>

--- a/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
@@ -15,6 +15,10 @@
         <p class="font-display text-24">Submitter</p>
         <m-user-select formControlName="submitter" />
       </div>
+      <div class="flex items-center gap-2">
+        <m-user-select formControlName="credit" />
+        <m-dropdown [entries]="MapCreditOptions" [entryNameFn]="MapCreditNameFn" formControlName="creditType" />
+      </div>
       <input class="textinput w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
       <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
         <m-icon icon="filter-remove" class="size-5" />

--- a/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
@@ -1,6 +1,6 @@
-<div class="mb-4 flex flex-wrap items-end gap-4">
-  <p class="card-title flex text-48">
-    Beta Maps <m-icon class="ml-2 h-5 w-5 self-start pt-1" icon="help-circle" [mTooltip]="infoTooltip" />
+<div class="mb-4 flex items-start gap-4">
+  <p class="card-title flex text-nowrap text-48">
+    Beta Maps <m-icon class="ml-2 size-5 self-start pt-1" icon="help-circle" [mTooltip]="infoTooltip" />
   </p>
   <ng-template #infoTooltip>
     <div class="prose p-3">
@@ -9,24 +9,32 @@
       <p>However, they may be subject to change in the future, and any runs you submit will be wiped when the map is released.</p>
     </div>
   </ng-template>
-  <form class="ml-auto flex flex-wrap items-center gap-4" [formGroup]="filters">
-    <input class="textinput mr-4 w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
-    <p class="font-display text-24">Status</p>
-    <p-multiSelect
-      formControlName="status"
-      [options]="StatusDropdown"
-      optionLabel="label"
-      optionValue="type"
-      [showHeader]="false"
-      appendTo="body"
-      [maxSelectedLabels]="2"
-    />
-    <p class="ml-4 font-display text-24">Submitter</p>
-    <m-user-select formControlName="submitter" />
-    <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" class="w-64" />
-    <button (click)="resetFilters()" type="button" class="btn h-8 w-8 p-0">
-      <m-icon icon="filter-remove" class="h-5 w-5" />
-    </button>
+  <form class="ml-auto flex flex-col gap-2" [formGroup]="filters">
+    <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+      <div class="flex items-center gap-2">
+        <p class="font-display text-24">Submitter</p>
+        <m-user-select formControlName="submitter" />
+      </div>
+      <input class="textinput w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
+      <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
+        <m-icon icon="filter-remove" class="size-5" />
+      </button>
+    </div>
+    <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+      <div class="flex items-center gap-2">
+        <p class="font-display text-24">Status</p>
+        <p-multiSelect
+          formControlName="status"
+          [options]="StatusDropdown"
+          optionLabel="label"
+          optionValue="type"
+          [showHeader]="false"
+          appendTo="body"
+          [maxSelectedLabels]="2"
+        />
+      </div>
+      <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" />
+    </div>
   </form>
 </div>
 <m-map-list [maps]="maps" [loadMore]="loadMore" [loading]="loading" [isSubmissionPage]="true" />

--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
@@ -1,5 +1,5 @@
-<div class="grid grid-flow-col grid-cols-[minmax(auto,20rem)_1fr] grid-rows-[auto_auto] gap-4">
-  <p class="card-title text-48">Your Maps</p>
+<div class="grid grid-flow-col grid-cols-[minmax(auto,14rem)_1fr] grid-rows-[auto_auto] gap-4">
+  <p class="card-title text-nowrap text-48">Your Maps</p>
   <div class="flex flex-col gap-4">
     @if (hasSubmissionBan) {
       <p>You are banned from map submission</p>
@@ -20,22 +20,28 @@
     }
   </div>
 
-  <div class="flex flex-wrap items-end gap-4 self-end">
-    <form class="ml-auto flex flex-wrap items-center gap-4" [formGroup]="filters">
-      <input class="textinput mr-4 w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
-      <p class="font-display text-24">Status</p>
-      <p-multiSelect
-        formControlName="status"
-        [options]="StatusDropdown"
-        optionLabel="label"
-        optionValue="type"
-        [showHeader]="false"
-        [maxSelectedLabels]="2"
-      />
-      <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" class="w-64" />
-      <button (click)="resetFilters()" type="button" class="btn h-8 w-8 p-0">
-        <m-icon icon="filter-remove" class="h-5 w-5" />
-      </button>
+  <div class="flex items-end self-end">
+    <form class="ml-auto flex flex-col gap-2" [formGroup]="filters">
+      <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+        <input class="textinput w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
+        <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
+          <m-icon icon="filter-remove" class="size-5" />
+        </button>
+      </div>
+      <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+        <div class="flex items-center gap-2">
+          <p class="font-display text-24">Status</p>
+          <p-multiSelect
+            formControlName="status"
+            [options]="StatusDropdown"
+            optionLabel="label"
+            optionValue="type"
+            [showHeader]="false"
+            [maxSelectedLabels]="2"
+          />
+        </div>
+        <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" />
+      </div>
     </form>
   </div>
   <m-map-list [maps]="maps" [loadMore]="loadMore" [loading]="loading" [isSubmissionPage]="true" />

--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
@@ -23,6 +23,10 @@
   <div class="flex items-end self-end">
     <form class="ml-auto flex flex-col gap-2" [formGroup]="filters">
       <div class="flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-2">
+        <div class="flex items-center gap-2">
+          <m-user-select formControlName="credit" />
+          <m-dropdown [entries]="MapCreditOptions" [entryNameFn]="MapCreditNameFn" formControlName="creditType" />
+        </div>
         <input class="textinput w-64 backdrop-blur-lg" type="text" placeholder="Map Name" formControlName="name" />
         <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
           <m-icon icon="filter-remove" class="size-5" />

--- a/apps/frontend/src/app/theme/styles.css
+++ b/apps/frontend/src/app/theme/styles.css
@@ -445,11 +445,11 @@
 
     .body {
       top: anchor(bottom);
-      left: anchor(left);
+      left: initial; /* Override browser defaulting to left: 0px */
       right: anchor(right);
       margin: 0;
       padding: 0;
-      width: auto;
+      width: fit-content;
       gap: 0.5rem;
       @apply card card--fancy border border-white border-opacity-5;
       /* Display flex from card breaks popover, so remove it. */

--- a/apps/frontend/src/app/util/form-utils.util.ts
+++ b/apps/frontend/src/app/util/form-utils.util.ts
@@ -74,7 +74,13 @@ export function setupPersistentForm(
   const valueString = sessionStorage.getItem(key);
 
   if (valueString) {
-    form.setValue(JSON.parse(valueString));
+    // If form has different fields than when user last interacted with it,
+    // e.g. from new commits to main, just reset storage instead of throwing.
+    try {
+      form.setValue(JSON.parse(valueString));
+    } catch {
+      sessionStorage.removeItem(key);
+    }
   }
 
   form.valueChanges

--- a/libs/constants/src/maps/map-credit-name.map.ts
+++ b/libs/constants/src/maps/map-credit-name.map.ts
@@ -1,5 +1,12 @@
 import { MapCreditType } from '../';
 
+export const MapCreditName: ReadonlyMap<MapCreditType, string> = new Map([
+  [MapCreditType.AUTHOR, 'Author'],
+  [MapCreditType.CONTRIBUTOR, 'Contributor'],
+  [MapCreditType.TESTER, 'Tester'],
+  [MapCreditType.SPECIAL_THANKS, 'Special']
+]);
+
 export const MapCreditNames: ReadonlyMap<MapCreditType, string> = new Map([
   [MapCreditType.AUTHOR, 'Authors'],
   [MapCreditType.CONTRIBUTOR, 'Contributors'],

--- a/libs/constants/src/types/queries/map-queries.model.ts
+++ b/libs/constants/src/types/queries/map-queries.model.ts
@@ -6,6 +6,7 @@ import { PagedQuery } from './pagination.model';
 import { MapSubmissionType } from '../../enums/map-submission-type.enum';
 import {
   MapCredit,
+  MapCreditType,
   MapInfo,
   MapNotify,
   MapReview,
@@ -50,6 +51,8 @@ type MapsGetAllBaseQuery = {
   search?: string;
   searchStartsWith?: string;
   submitterID?: number;
+  creditID?: number;
+  creditType?: MapCreditType;
   sortType?: MapSortType;
 };
 


### PR DESCRIPTION
Part of #925 

Also
added VTG and KZ 1.6 to main browser
removed redundant map sort query option tests

Best to actually check out the branch, to see responsivity changes.

<img width="1842" height="439" alt="vivaldi_MvS80XfAwU" src="https://github.com/user-attachments/assets/fe1735c4-38fc-4f6a-8f9f-6024d77ba7c2" />
<img width="1824" height="302" alt="vivaldi_ru3PB8up7s" src="https://github.com/user-attachments/assets/d3bb5f9a-3651-45b3-bc45-4d6802024b99" />
<img width="1840" height="767" alt="vivaldi_g7BqRhpSj3" src="https://github.com/user-attachments/assets/909c0c02-42bc-43d9-b924-c186b27541f1" />
<img width="1815" height="334" alt="vivaldi_ofIVtsMQoC" src="https://github.com/user-attachments/assets/37159b41-5417-4682-b778-8e9bb96b95d6" />


### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
