### PR TITLE
refactor(shared): update to zone types to allow for more missing fields

### DIFF
--- a/libs/constants/src/types/models/models.ts
+++ b/libs/constants/src/types/models/models.ts
@@ -390,12 +390,12 @@ export interface MapZones {
 }
 
 export interface GlobalRegions {
-  allowBhop: Region[];
-  overbounce: Region[];
+  allowBhop?: Region[];
+  overbounce?: Region[];
 }
 
 export interface MapTracks {
-  main: MainTrack;
+  main?: MainTrack;
   bonuses?: BonusTrack[];
 }
 
@@ -427,7 +427,7 @@ export interface Segment {
 }
 
 export interface Zone {
-  regions: Region[];
+  regions?: Region[];
   filtername?: string;
 }
 

--- a/libs/constants/src/types/models/models.ts
+++ b/libs/constants/src/types/models/models.ts
@@ -392,6 +392,7 @@ export interface MapZones {
 export interface GlobalRegions {
   allowBhop?: Region[];
   overbounce?: Region[];
+  cancel?: Region[];
 }
 
 export interface MapTracks {

--- a/libs/formats/zone/src/zone-util.ts
+++ b/libs/formats/zone/src/zone-util.ts
@@ -8,6 +8,8 @@ import {
 import { arrayFrom } from '@momentum/util-fn';
 
 export function isLinearMainTrack(zoneData: MapZones): boolean {
+  if (!zoneData.tracks.main) return false;
+
   return zoneData.tracks.main.zones.segments.length === 1;
 }
 

--- a/libs/formats/zone/src/zone-validator.spec.ts
+++ b/libs/formats/zone/src/zone-validator.spec.ts
@@ -45,6 +45,12 @@ describe('validateZoneFile', () => {
       expect(() => validateZoneFile(input)).toThrow('Missing tracks');
     });
 
+    it('should throw if main track is missing', () => {
+      input.tracks.main = undefined;
+
+      expect(() => validateZoneFile(input)).toThrow('Missing main track');
+    });
+
     it('should throw if formatVersion is not CURRENT_ZONE_FORMAT_VERSION', () => {
       input.formatVersion = CURRENT_ZONE_FORMAT_VERSION + 1;
 

--- a/libs/formats/zone/src/zone-validator.ts
+++ b/libs/formats/zone/src/zone-validator.ts
@@ -54,6 +54,8 @@ export function validateZoneFile(input: MapZones): void {
 
   if (!tracks) throw new ZoneValidationError('Missing tracks');
 
+  if (!tracks.main) throw new ZoneValidationError('Missing main track');
+
   if (formatVersion !== CURRENT_ZONE_FORMAT_VERSION)
     throw new ZoneValidationError('Bad format version');
 


### PR DESCRIPTION
This change was already made to the types file in the panorama repo, I didn't review the PR so didn't see that rio had modified types in the generated file directly.
