### PR TITLE
fix(front): anchor multi-select dropdown

### DIFF
--- a/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
@@ -26,7 +26,6 @@
           optionValue="type"
           [showHeader]="false"
           appendTo="body"
-          [maxSelectedLabels]="2"
         />
       </div>
       <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" />

--- a/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
@@ -34,7 +34,6 @@
           optionValue="type"
           [showHeader]="false"
           appendTo="body"
-          [maxSelectedLabels]="2"
         />
       </div>
       <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" />

--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
@@ -41,7 +41,7 @@
             optionLabel="label"
             optionValue="type"
             [showHeader]="false"
-            [maxSelectedLabels]="2"
+            appendTo="body"
           />
         </div>
         <m-dropdown [entries]="MapSortOptions" [entryNameFn]="MapSortNameFn" formControlName="sortType" />


### PR DESCRIPTION
fixes the multiselect dropdown in user browser from flailing about
also removed maxSelected since wrapping is better now

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
