### PR TITLE
feat(shared): Pogo, Gauntlet tags

### DIFF
--- a/libs/constants/src/enums/map-tag.enum.ts
+++ b/libs/constants/src/enums/map-tag.enum.ts
@@ -108,5 +108,7 @@ export enum MapTag {
   _Num4__Way_Sym = 84,
   Staged__Linear = 85,
   Funkyboost = 86,
-  Mixed = 87
+  Mixed = 87,
+  Pogo = 88,
+  Gauntlet = 89
 }

--- a/libs/constants/src/maps/map-tags.map.ts
+++ b/libs/constants/src/maps/map-tags.map.ts
@@ -71,7 +71,8 @@ export const GamemodeTags = {
     MapTag.Buttons,
     MapTag.Limited_Ammo,
     MapTag.Water,
-    MapTag.Teledoor
+    MapTag.Teledoor,
+    MapTag.Pogo
   ],
   [GamemodeCategory.SJ]: [
     MapTag.Airpogo,
@@ -82,7 +83,8 @@ export const GamemodeTags = {
     MapTag.Downair,
     MapTag.Slanted_Walls,
     MapTag.Teledoor,
-    MapTag.Holes
+    MapTag.Holes,
+    MapTag.Pogo
   ],
   [GamemodeCategory.AHOP]: [
     MapTag.HL2,
@@ -121,7 +123,8 @@ export const GamemodeTags = {
     MapTag.Strafe_Pads,
     MapTag.Lightning_Gun,
     MapTag.Staged__Linear,
-    MapTag.Funkyboost
+    MapTag.Funkyboost,
+    MapTag.Gauntlet
   ]
 } satisfies Record<GamemodeCategory, number[]>;
 


### PR DESCRIPTION
follows same order as the tags spreadsheet

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
