### PR TITLE
fix(back): send map submission data when getting user submissions

### DIFF
--- a/apps/backend/src/app/modules/maps/maps.service.ts
+++ b/apps/backend/src/app/modules/maps/maps.service.ts
@@ -432,7 +432,10 @@ export class MapsService {
         ]
       });
 
-      if (query instanceof MapsGetAllSubmissionQueryDto) {
+      if (
+        query instanceof MapsGetAllSubmissionQueryDto ||
+        query instanceof MapsGetAllUserSubmissionQueryDto
+      ) {
         if (include) {
           include.submission = {
             include: {


### PR DESCRIPTION
Fixes this
<img width="1646" height="395" alt="изображение" src="https://github.com/user-attachments/assets/72f7dd27-7f14-4958-843e-9d85e0e1e139" />

Since user submissions query is not using submission query as parent now we need to explicitly add map submission data to the request as well

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
