### PR TITLE
Add `/tell` command to Discord Bot

### DIFF
--- a/apps/discord-bot-internal/src/interaction-modules/custom.ts
+++ b/apps/discord-bot-internal/src/interaction-modules/custom.ts
@@ -769,6 +769,48 @@ export class SayModule implements InteractionModule {
   }
 }
 
+export class TellModule implements InteractionModule {
+  static commandName = 'tell';
+  userFilter = isTrusted;
+  commandBuilder = new SlashCommandBuilder()
+    .setName(TellModule.commandName)
+    .setDescription('Executes a custom command (only visible to you)')
+    .addStringOption((option) =>
+      option
+        .setName('option')
+        .setDescription('Name of the custom command')
+        .setRequired(true)
+        .setAutocomplete(true)
+    );
+
+  async executeCommand(interaction: ChatInputCommandInteraction) {
+    const commandName = interaction.options.getString('option');
+    if (!commandName || !config.custom_commands[commandName]) {
+      await replyDescriptionEmbed(
+        interaction,
+        `Command '${commandName}' doesn't exist!`,
+        MomentumColor.Red,
+        true
+      );
+      return;
+    }
+
+    const command = config.custom_commands[commandName];
+    const { embed, components } = buildCustomCommandResponse(command);
+
+    await interaction.reply({
+      embeds: [embed],
+      components,
+      flags: MessageFlags.Ephemeral
+    });
+  }
+
+  async autocomplete(interaction: AutocompleteInteraction) {
+    const focused = interaction.options.getFocused(true);
+    await customCommandAutocomplete(interaction, focused.value);
+  }
+}
+
 async function customCommandAutocomplete(
   interaction: AutocompleteInteraction,
   value: string

--- a/apps/discord-bot-internal/src/interaction-modules/index.ts
+++ b/apps/discord-bot-internal/src/interaction-modules/index.ts
@@ -1,11 +1,12 @@
 import { InteractionModule } from '../types/interaction-module';
-import { CustomModule, SayModule } from './custom';
+import { CustomModule, SayModule, TellModule } from './custom';
 import { LiveStreamModule } from './live-stream';
 import { TrustedModule } from './trust';
 import { RestartModule } from './restart';
 export const interactionModules: Array<new () => InteractionModule> = [
   CustomModule,
   SayModule,
+  TellModule,
   LiveStreamModule,
   TrustedModule,
   RestartModule


### PR DESCRIPTION
Closes https://github.com/momentum-mod/website/issues/1107

- Refactored shared logic needed for `/say` and `/tell` into `buildCustomCommandResponse()` 
- Added `/tell` command (private version of `/say` that shows responses only to the sender)

### Screenshots (if applicable)

Tested in my own server, works a treat:

<img width="363" height="496" alt="image" src="https://github.com/user-attachments/assets/7c7a1b44-1059-4d18-aa58-b710e8280442" />


### Checks

- [X] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [X] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [X] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [X] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [X] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
