### PR TITLE
Improve handling of expired access tokens

### DIFF
--- a/apps/frontend/src/app/interceptors/auth.interceptor.ts
+++ b/apps/frontend/src/app/interceptors/auth.interceptor.ts
@@ -50,6 +50,18 @@ export class AuthInterceptor implements HttpInterceptor {
     // but that should affect this code - those endpoints won't 401 without a
     // token.
     const accessToken = this.authService.getAccessToken();
+    const refreshToken = this.authService.getRefreshToken();
+
+    // If we have a refresh token, but access token is either missing or is
+    // expired (which is very likely) try getting a new access token first
+    if (
+      (!accessToken || this.authService.isAccessTokenExpired()) &&
+      refreshToken &&
+      !req.url.includes('auth/refresh')
+    ) {
+      return this.handleRefresh(req, next);
+    }
+
     if (accessToken) {
       req = this.addAccessTokenToHeader(req, accessToken);
     }

--- a/apps/frontend/src/app/services/data/auth.service.ts
+++ b/apps/frontend/src/app/services/data/auth.service.ts
@@ -28,7 +28,8 @@ export class AuthService {
 
   public isAuthenticated(): boolean {
     const accessToken = this.getAccessToken();
-    return Boolean(accessToken);
+    const refreshToken = this.getRefreshToken();
+    return Boolean(accessToken) || Boolean(refreshToken);
   }
 
   private moveCookieToLocalStorage(cookieName: string): void {
@@ -60,5 +61,28 @@ export class AuthService {
 
   public getAccessToken(): string | null {
     return localStorage.getItem('accessToken');
+  }
+
+  public isAccessTokenExpired(): boolean {
+    const accessToken = this.getAccessToken();
+    const jwtPayload = accessToken.split('.')[1];
+    const base64Payload = jwtPayload
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(jwtPayload.length + ((4 - (jwtPayload.length % 4)) % 4), '=');
+    try {
+      const payload = JSON.parse(atob(base64Payload));
+      if (payload.exp < Date.now() / 1000) {
+        return true;
+      }
+    } catch (e) {
+      console.error('Failed to decode JWT payload', e);
+      return true;
+    }
+    return false;
+  }
+
+  public getRefreshToken(): string | null {
+    return localStorage.getItem('refreshToken');
   }
 }


### PR DESCRIPTION
Improves overall experience on dashboard. Since out access tokens are very short lived, and refreshing logic only runs when there is a web request, and not on, for example, switching to another page, users are getting redirected to authentication page much more frequently.

Also fixes a "not found" error when opening a beta map link with expired access token. Since map pages can be accessed without authentication, validity of jwt token is not checked there, so the error returned to client is 403, rather then 401, which triggers refresh.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
