### PR TITLE
Increase JWT expiration times

### DIFF
--- a/libs/constants/src/consts/jwt.const.ts
+++ b/libs/constants/src/consts/jwt.const.ts
@@ -1,3 +1,3 @@
-export const JWT_WEB_EXPIRY_TIME = '15m';
+export const JWT_WEB_EXPIRY_TIME = '24h';
 export const JWT_GAME_EXPIRY_TIME = '24h';
-export const JWT_REFRESH_EXPIRY_TIME = '5d';
+export const JWT_REFRESH_EXPIRY_TIME = '30d';


### PR DESCRIPTION
15min expiry is absurdly low. 1day/1month seems pretty common practice for JWTs. If we were uber-concerned with security we probably wouldn't be using JWTs anyway.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
