### PR TITLE
feat(back-e2e): nuke valkey

### DIFF
--- a/apps/backend-e2e/src/support/global-setup.ts
+++ b/apps/backend-e2e/src/support/global-setup.ts
@@ -8,6 +8,7 @@ import {
 import { faker } from '@faker-js/faker';
 import * as dotenv from 'dotenv';
 import path from 'node:path';
+import Valkey from 'iovalkey';
 
 export default async function globalSetup() {
   // Load .env file in project root. Nx does this automatically, but this helps
@@ -27,6 +28,9 @@ export default async function globalSetup() {
 
   // Clear out the S3 bucket
   await nukeS3();
+
+  // Clear Valkey storage
+  await nukeValkey();
 
   // Explicitly set test environment. When running this Nx it seems to be 'dev',
   // probably because it's loading .env later. So it probably doesn't matter in
@@ -75,4 +79,12 @@ async function nukeS3() {
         }
       })
     );
+}
+
+async function nukeValkey() {
+  const valkey = new Valkey({
+    port: +process.env.VALKEY_PORT,
+    host: process.env.VALKEY_HOST || 'localhost'
+  });
+  await valkey.flushall();
 }


### PR DESCRIPTION
There is a test that breaks if you have stuff left in valkey. This should clear it

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
