### PR TITLE
fix(front): better gallery styling

### DIFF
--- a/apps/frontend/src/app/components/gallery/gallery.component.html
+++ b/apps/frontend/src/app/components/gallery/gallery.component.html
@@ -27,9 +27,9 @@
       <m-icon icon="menu-right" class="size-full opacity-85" />
     </button>
 
-    <div #parent class="pointer-events-none z-10 grid aspect-video min-h-0 basis-[87.5%] place-items-center">
+    <div #parent class="pointer-events-none z-10 flex aspect-video min-h-0 basis-[87.5%] items-center justify-center">
       @if (selectedItem && selectedItem.type === 'image') {
-        <img class="pointer-events-auto h-full max-w-full rounded shadow-lg" [src]="selectedItem.full" />
+        <img class="pointer-events-auto max-h-full max-w-full rounded shadow-lg" [src]="selectedItem.full" />
       } @else if (selectedItem && selectedItem.type === 'youtube') {
         <iframe
           #youtubeIframe


### PR DESCRIPTION
Previous change doesn't work for bigger images

Before
<img width="1914" height="946" alt="изображение" src="https://github.com/user-attachments/assets/856d5712-c160-4ef1-b0ec-ebe906ca94b7" />

After
<img width="1915" height="944" alt="изображение" src="https://github.com/user-attachments/assets/c0d8b9cc-90de-4e8b-88e3-4b73566b315c" />
