### PR TITLE
Allow mod/admins to bypass approving review requirement

### DIFF
--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -3617,6 +3617,27 @@ describe('Maps', () => {
         });
       });
 
+      it("should allow changing from PUBLIC_TESTING to FINAL_APPROVAL if map doesn't have at least one approving review if submitter is a mod", async () => {
+        const data = structuredClone(createMapData);
+        data.status = MapStatus.PUBLIC_TESTING;
+        data.reviews = { createMany: { data: [] } };
+        data.submitter = { connect: { id: mod.id } };
+        data.submission.create.dates.create.push({
+          status: MapStatus.PUBLIC_TESTING,
+          date: new Date(Date.now() - (MIN_PUBLIC_TESTING_DURATION + 1000)),
+          user: { connect: { id: user.id } }
+        });
+
+        const map = await db.createMap(data);
+
+        await req.patch({
+          url: `maps/${map.id}`,
+          status: 204,
+          body: { status: MapStatus.FINAL_APPROVAL },
+          token: modToken
+        });
+      });
+
       it('should generate new leaderboards if suggestions change', async () => {
         const map = await db.createMap({
           ...createMapData,

--- a/apps/backend/src/app/modules/maps/maps.service.ts
+++ b/apps/backend/src/app/modules/maps/maps.service.ts
@@ -1738,12 +1738,15 @@ export class MapsService {
       throw new ForbiddenException('Map has unresolved reviews');
     }
 
-    // Must have at least one approving review.
+    // Must have at least one approving review unless you're mod/admin
     const hasApprovingReview = await this.db.mapReview.exists({
       where: { mapID: map.id, approves: true }
     });
 
-    if (!hasApprovingReview) {
+    if (
+      !hasApprovingReview &&
+      !Bitflags.has(roles, CombinedRoles.MOD_OR_ADMIN)
+    ) {
       throw new ForbiddenException('Map has no approving reviews');
     }
   }


### PR DESCRIPTION
### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
