### PR TITLE
fix(front): show placeholders for disabled maps

### DIFF
--- a/apps/frontend/src/app/components/map-list/map-list-item.component.ts
+++ b/apps/frontend/src/app/components/map-list/map-list-item.component.ts
@@ -85,7 +85,8 @@ export class MapListItemComponent implements OnChanges {
     this.prefix = prefix;
     this.authors = [
       ...this.map.credits,
-      ...(MapStatuses.IN_SUBMISSION.includes(this.map.status)
+      ...(MapStatuses.IN_SUBMISSION.includes(this.map.status) ||
+      this.map.status === MapStatus.DISABLED
         ? (this.map.submission?.placeholders ?? [])
         : [])
     ]


### PR DESCRIPTION
Fixes the issue where map list doesn't work if a map was disabled before getting approved

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
