### PR TITLE
fix(front): show map creation date by default

### DIFF
--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -157,11 +157,12 @@
             </ng-template>
           }
           <div class="flex items-center gap-1" [mTooltip]="dateTooltip">
-            <p class="font-display text-24 drop-shadow-md">{{ map.createdAt | date }}</p>
+            <p class="font-display text-24 drop-shadow-md">{{ map.info?.creationDate || map.createdAt | date }}</p>
             <m-icon class="text-24 drop-shadow-md" icon="calendar"></m-icon>
           </div>
           <ng-template #dateTooltip>
             <p class="text-right"><b>Created On - </b>{{ map.info?.creationDate | date }}</p>
+            <p class="text-right"><b>Added in Momentum - </b>{{ map.createdAt | date }}</p>
             @if (map.info?.approvedDate) {
               <p class="text-right"><b>Released in Momentum - </b>{{ map.info?.approvedDate | date }}</p>
             }


### PR DESCRIPTION
Show map creation date instead of when map was added to momentum

### Checks

- [ ] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [ ] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
