### PR TITLE
enhancement(sidebar): Add docs and main site links

### DIFF
--- a/apps/frontend/src/app/icons/packs/material-design-icons.icons.ts
+++ b/apps/frontend/src/app/icons/packs/material-design-icons.icons.ts
@@ -96,5 +96,6 @@ export {
   mdiHeartOutline,
   mdiHeartBroken,
   mdiFullscreen,
-  mdiCheckDecagram
+  mdiCheckDecagram,
+  mdiWeb
 } from '@mdi/js';

--- a/apps/frontend/src/app/side-menu.const.ts
+++ b/apps/frontend/src/app/side-menu.const.ts
@@ -103,5 +103,25 @@ export const SIDENAV_ITEMS: Array<{
         pack: 'si'
       }
     ]
+  },
+  {
+    title: 'Our Other Sites',
+    isPublic: true,
+    items: [
+      {
+        title: 'Docs Home',
+        link: 'https://docs.momentum-mod.org',
+        external: true,
+        icon: 'home',
+        isPublic: true
+      },
+      {
+        title: 'Main Site',
+        link: 'https://momentum-mod.org',
+        external: true,
+        icon: 'web',
+        isPublic: true
+      }
+    ]
   }
 ];


### PR DESCRIPTION
Closes #1343

This pull request adds two important external links to the top of the main sidebar under a new "Navigation" section:

-   **Docs Home**: Links to `https://docs.momentum-mod.org` for easy access back to the documentation homepage.
-   **Main Site**: Links to `https://momentum-mod.org` to allow users to return to the main website.

This addresses the request in issue #1343 to improve site-wide navigation.

### Screenshots (if applicable)
I was able to make the code changes but ran into some trouble getting the project running locally to provide a screenshot.
*(If you were able to run the project, drag your screenshot here. If not, you can just delete this section or leave it as is.)*

### Checks

- [ ] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits