### PR TITLE
feat(front): disable map submission button when limit is reached

### DIFF
--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
@@ -16,7 +16,16 @@
           <p>No maps submitted</p>
         }
       </m-card>
-      <button class="btn btn-blue" type="button" routerLink="/map-edit/submit">Submit a Map</button>
+      <button
+        class="btn btn-blue"
+        type="button"
+        routerLink="/map-edit/submit"
+        [disabled]="isMapLimitReached"
+        [pTooltip]="isMapLimitReached ? 'You have reached your submission limit of ' + mapSubmissionLimit + ' maps!' : ''"
+        tooltipPosition="top"
+      >
+        Submit a Map
+      </button>
     }
   </div>
 

--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.ts
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.ts
@@ -12,7 +12,8 @@ import {
   MapSortTypeName,
   MMap,
   PagedResponse,
-  User
+  User,
+  limits
 } from '@momentum/constants';
 import {
   FormControl,
@@ -37,6 +38,7 @@ import { DropdownComponent } from '../../../components/dropdown/dropdown.compone
 import { IconComponent } from '../../../icons';
 import { setupPersistentForm } from '../../../util/form-utils.util';
 import { fastValuesNumeric } from '@momentum/enum';
+import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   templateUrl: 'user-maps-browser.component.html',
@@ -50,7 +52,8 @@ import { fastValuesNumeric } from '@momentum/enum';
     ReactiveFormsModule,
     DropdownComponent,
     FormsModule,
-    IconComponent
+    IconComponent,
+    TooltipModule 
   ]
 })
 export class UserMapsBrowserComponent implements OnInit {
@@ -86,6 +89,9 @@ export class UserMapsBrowserComponent implements OnInit {
 
   protected hasSubmissionBan = false;
 
+  protected isMapLimitReached = false;
+  protected readonly mapSubmissionLimit = limits.MAP_SUBMISSION_LIMIT;
+
   protected readonly filters = new FormGroup({
     name: new FormControl<string>(''),
     status: new FormControl<MapsGetAllUserSubmissionFilter>([], {
@@ -111,6 +117,16 @@ export class UserMapsBrowserComponent implements OnInit {
       this.hasSubmissionBan = true;
       return;
     }
+
+    this.localUserService
+      .getLocalUser()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((user) => {
+        if (user?.profile?.mapSubmissionsCount) {
+          this.isMapLimitReached =
+            user.profile.mapSubmissionsCount >= this.mapSubmissionLimit;
+        }
+      });
 
     setupPersistentForm(this.filters, 'USER_MAPS_FILTERS', this.destroyRef);
 


### PR DESCRIPTION
Closes #1346

## Description

This pull request implements a check to see if a user has reached their map submission limit on the "Your Maps" page.

- If the user is at or over their submission limit, the "Submit a Map" button is now disabled.
- A tooltip has been added to the disabled button to inform the user why they cannot submit a new map.

This improves the user experience by preventing users from filling out the entire submission form only to be rejected at the end.

### Screenshots (if applicable)

*(You can drag and drop your screenshot here if you took one)*

### Checks

- [ ] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits