### PR TITLE
fix(back): error on removing last user credit when only non-account placeholders remain

### DIFF
--- a/apps/backend/src/app/modules/maps/map-credits.service.ts
+++ b/apps/backend/src/app/modules/maps/map-credits.service.ts
@@ -75,10 +75,6 @@ export class MapCreditsService {
     body: CreateMapCreditDto[],
     loggedInUserID: number
   ): Promise<MapCreditDto[]> {
-    if (body.length === 0) {
-      throw new BadRequestException('Empty body');
-    }
-
     const maxCredits = this.config.getOrThrow('limits.maxCreditsExceptTesters');
     for (const type of [
       MapCreditType.AUTHOR,
@@ -109,8 +105,9 @@ export class MapCreditsService {
           map.submission.placeholders as unknown as MapSubmissionPlaceholder[]
         )?.some(({ type }) => type === MapCreditType.AUTHOR)
       )
-    )
+    ) {
       throw new BadRequestException('Credits do not contain an AUTHOR');
+    }
 
     const { roles } = await this.db.user.findUnique({
       where: { id: loggedInUserID },


### PR DESCRIPTION
Closes #1353 

Needed to remove the backend length check as non-account placeholders are handled separately.
There is already logic for checking that author exists in either of given account credits or existing placeholder json.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
