### PR TITLE
feat(front): show submission page on approved maps

### DIFF
--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -14,17 +14,15 @@
       </button>
     </div>
     <div class="ml-2 flex gap-2">
-      @if (currentSection != null && inSubmission) {
-        @for (section of sections; track $index) {
-          <button
-            type="button"
-            class="mr-2 self-end justify-self-start font-display text-4xl font-bold leading-none text-gray-100 opacity-90 drop-shadow transition-colors hover:text-gray-50"
-            [ngClass]="{ '!text-white !opacity-100': currentSection === section }"
-            (click)="currentSection = section"
-          >
-            {{ MapInfoSection[section] }}
-          </button>
-        }
+      @for (section of sections; track $index) {
+        <button
+          type="button"
+          class="mr-2 self-end justify-self-start font-display text-4xl font-bold leading-none text-gray-100 opacity-90 drop-shadow transition-colors hover:text-gray-50"
+          [ngClass]="{ '!text-white !opacity-100': currentSection === section }"
+          (click)="currentSection = section"
+        >
+          {{ MapInfoSection[section] }}
+        </button>
       }
       <div class="ml-auto flex items-end gap-2">
         @if ((isSubmitter && inSubmission) || localUserService.isReviewerOrAbove) {
@@ -247,13 +245,8 @@
     </div>
     <div>
       <div class="stack card card--fancy border-opacity-[0.0675] p-4">
+        <m-map-submission [ngClass]="{ hidden: currentSection !== MapInfoSection.SUBMISSION }" [map]="map" />
         <m-map-leaderboard [ngClass]="{ hidden: currentSection !== MapInfoSection.LEADERBOARDS }" [map]="map" />
-        <!-- Don't insert this at all if not in submission, we don't want to
-             try fetch extra data/images unless we're may actually display it.
-         -->
-        @if (this.map.status !== MapStatus.APPROVED) {
-          <m-map-submission [ngClass]="{ hidden: currentSection !== MapInfoSection.SUBMISSION }" [map]="map" />
-        }
       </div>
     </div>
   </div>

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.ts
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.ts
@@ -119,7 +119,7 @@ export class MapInfoComponent implements OnInit {
   isSubmitter: boolean;
   inSubmission: boolean;
 
-  currentSection?: MapInfoSection = null;
+  currentSection = MapInfoSection.LEADERBOARDS;
   sections = Enum.values(MapInfoSection);
 
   ngOnInit() {
@@ -177,8 +177,7 @@ export class MapInfoComponent implements OnInit {
       this.map.submission?.placeholders ?? []
     );
     this.inSubmission = MapStatuses.IN_SUBMISSION.includes(map.status);
-    // Show Review section first if in review, otherwise leaderboards (and the
-    // tab view won't be visible anyway).
+    // Show Review section first if in review, otherwise leaderboards.
     this.currentSection = this.inSubmission
       ? MapInfoSection.SUBMISSION
       : MapInfoSection.LEADERBOARDS;


### PR DESCRIPTION
Closes #1355

I've not hidden anything that wasn't already hidden based on map status; for example I think still allowing gamemode tiering suggestions on approved maps is a good idea, to allow for suggestions of moving some leaderboards from unranked to ranked, etc.
Likewise I think it's preferred to still display the map version history, even if there are some dead links

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
