### PR TITLE
Make users search use "contains" instead of "startsWith"

### DIFF
--- a/apps/backend/src/app/modules/users/users.service.ts
+++ b/apps/backend/src/app/modules/users/users.service.ts
@@ -73,7 +73,7 @@ export class UsersService {
 
     if (query.search) {
       where.alias = {
-        startsWith: query.search,
+        contains: query.search,
         mode: 'insensitive'
       };
     }
@@ -86,6 +86,15 @@ export class UsersService {
       skip: query.skip,
       take
     });
+
+    if (query.search) {
+      const search = query.search.toLowerCase();
+      dbResponse[0].sort((a, b) => {
+        const Alias = a.alias.toLowerCase().startsWith(search);
+        const Blias = b.alias.toLowerCase().startsWith(search);
+        return Alias === Blias ? 0 : Alias ? -1 : 1;
+      });
+    }
 
     return new PagedResponseDto(UserDto, dbResponse);
   }


### PR DESCRIPTION
Also sorts the results where results with the search term in the start return first

### Screenshots (if applicable)
<img width="535" height="318" alt="изображение" src="https://github.com/user-attachments/assets/5eb947a8-18fe-42a3-9d01-e0c87db7df1a" />

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
