### PR TITLE
fix(shared): fix profile discord username not accepting periods

### DIFF
--- a/libs/constants/src/consts/socials.const.ts
+++ b/libs/constants/src/consts/socials.const.ts
@@ -11,7 +11,7 @@ export const SocialsData: Readonly<
 > = {
   Discord: {
     icon: 'discord',
-    regex: /^[\w-]{2,32}$/,
+    regex: /^[\w-.]{2,32}$/,
     example: 'username',
     url: 'discordapp.com/users'
   },


### PR DESCRIPTION
Closes #1381 

Fixes profile edit page not accepting Discord usernames with periods. (huge first commit I know...)

### Screenshots (if applicable)

<!-- Attach screenshots here, if your PR contains any visual changes, e.g. frontend work -->

### Checks

- [X] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [X] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [X] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [X] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [X] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [X] All changes requested in review have been `fixup`ed into my original commits
