### PR TITLE
fix(back): bad null handling for maps with no bonuses

### DIFF
--- a/apps/backend/src/app/modules/maps/leaderboard-handler.util.ts
+++ b/apps/backend/src/app/modules/maps/leaderboard-handler.util.ts
@@ -67,7 +67,7 @@ export function getCompatibleLeaderboards<T extends LeaderboardProps>(
         ({ trackType, trackNum, gamemode }) =>
           trackType !== TrackType.BONUS ||
           GamemodeCategories.get(GamemodeCategory.DEFRAG).includes(gamemode) ||
-          !zones.tracks.bonuses[trackNum - 1]?.defragModifiers // ignore if undefined or 0
+          !zones.tracks.bonuses?.[trackNum - 1]?.defragModifiers // ignore if undefined or 0
       )
   );
 }


### PR DESCRIPTION
Should fix 6787699844 on Sentry

### Screenshots (if applicable)

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
