### PR TITLE
refactor(front): use nonNullableFormBuilder

### DIFF
--- a/apps/frontend/src/app/components/map-review/map-review.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review.component.ts
@@ -26,6 +26,7 @@ import { PaginatorModule } from 'primeng/paginator';
 import {
   FormControl,
   FormGroup,
+  NonNullableFormBuilder,
   ReactiveFormsModule,
   Validators
 } from '@angular/forms';
@@ -81,6 +82,7 @@ export class MapReviewComponent {
   private readonly localUserService = inject(LocalUserService);
   private readonly confirmationService = inject(ConfirmationService);
   private readonly adminService = inject(AdminService);
+  private readonly nnfb = inject(NonNullableFormBuilder);
 
   protected readonly TrackType = TrackType;
   protected readonly GamemodeInfo = GamemodeInfo;
@@ -104,7 +106,7 @@ export class MapReviewComponent {
   }
 
   protected suggestions: GroupedMapReviewSuggestions;
-  protected images: GalleryImageItem[];
+  protected images: GalleryImageItem[] = [];
   protected activeImageDialogIndex = 0;
 
   // Extremely annoying that we need this, but review editing needs this, this
@@ -112,8 +114,8 @@ export class MapReviewComponent {
   @Input({ required: true }) map!: MMap;
   @Output() public readonly updatedOrDeleted = new EventEmitter<void>();
 
-  protected readonly commentInput = new FormGroup({
-    textInput: new FormControl<string>('', {
+  protected readonly commentInput = this.nnfb.group({
+    textInput: this.nnfb.control<string>('', {
       validators: [
         Validators.minLength(1),
         Validators.maxLength(MAX_REVIEW_COMMENT_LENGTH)
@@ -259,8 +261,8 @@ export class MapReviewComponent {
 
     this.editModeComments.set(
       commentID,
-      new FormGroup({
-        textInput: new FormControl<string>(
+      this.nnfb.group({
+        textInput: this.nnfb.control<string>(
           this._review.comments.find(({ id }) => id === commentID).text,
           {
             validators: [

--- a/apps/frontend/src/app/components/report/create-report-dialog/create-report-dialog.component.ts
+++ b/apps/frontend/src/app/components/report/create-report-dialog/create-report-dialog.component.ts
@@ -1,5 +1,9 @@
 import { Component, Input, OnInit, inject } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
 import { ReportCategory, ReportType } from '@momentum/constants';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -16,7 +20,7 @@ import { Select } from 'primeng/select';
 })
 export class CreateReportDialogComponent implements OnInit {
   protected readonly ref = inject(DynamicDialogRef);
-  private readonly fb = inject(FormBuilder);
+  private readonly nnfb = inject(NonNullableFormBuilder);
   private readonly reportService = inject(ReportService);
   private readonly messageService = inject(MessageService);
 
@@ -33,11 +37,18 @@ export class CreateReportDialogComponent implements OnInit {
   @Input() reportType: ReportType;
   @Input() reportData: number;
 
-  protected readonly createReportForm = this.fb.group({
-    data: [0, Validators.required],
-    type: [ReportType.USER_PROFILE_REPORT, Validators.required],
-    category: [ReportCategory.INAPPROPRIATE_CONTENT, Validators.required],
-    message: ['', [Validators.required, Validators.maxLength(1000)]]
+  protected readonly createReportForm = this.nnfb.group({
+    data: this.nnfb.control<number>(0, { validators: Validators.required }),
+    type: this.nnfb.control<ReportType>(ReportType.USER_PROFILE_REPORT, {
+      validators: Validators.required
+    }),
+    category: this.nnfb.control<ReportCategory>(
+      ReportCategory.INAPPROPRIATE_CONTENT,
+      { validators: Validators.required }
+    ),
+    message: this.nnfb.control<string>('', {
+      validators: [Validators.required, Validators.maxLength(1000)]
+    })
   });
 
   ngOnInit() {

--- a/apps/frontend/src/app/components/search/abstract-search.component.ts
+++ b/apps/frontend/src/app/components/search/abstract-search.component.ts
@@ -1,5 +1,5 @@
-import { Directive, EventEmitter, OnInit, Output } from '@angular/core';
-import { FormControl } from '@angular/forms';
+import { Directive, EventEmitter, inject, OnInit, Output } from '@angular/core';
+import { NonNullableFormBuilder } from '@angular/forms';
 import {
   debounceTime,
   distinctUntilChanged,
@@ -14,8 +14,11 @@ import { PagedResponse } from '@momentum/constants';
 
 @Directive()
 export abstract class AbstractSearchComponent<T> implements OnInit {
+  private readonly nnfb = inject(NonNullableFormBuilder);
+
   @Output() public readonly selected = new EventEmitter<T>();
-  public readonly search = new FormControl<string>('');
+
+  public readonly search = this.nnfb.control<string>('');
   protected readonly pageChange = new Subject<PaginatorState>();
 
   abstract readonly itemsName: string;

--- a/apps/frontend/src/app/pages/admin/admin-activity/admin-activity.component.ts
+++ b/apps/frontend/src/app/pages/admin/admin-activity/admin-activity.component.ts
@@ -8,7 +8,11 @@ import {
   AdminActivityEntryData
 } from './admin-activity-entry/admin-activity-entry.component';
 import { AdminActivityEntryHeaderComponent } from './admin-activity-entry/admin-activity-entry-header.component';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import {
+  FormControl,
+  NonNullableFormBuilder,
+  ReactiveFormsModule
+} from '@angular/forms';
 import { UserSelectComponent } from '../../../components/user-select/user-select.component';
 import { mapHttpError } from '../../../util/rxjs/map-http-error';
 import { AccordionComponent } from '../../../components/accordion/accordion.component';
@@ -38,6 +42,7 @@ import { AdminService } from '../../../services/data/admin.service';
 export class AdminActivityComponent implements OnInit {
   private readonly adminService = inject(AdminService);
   private readonly messageService = inject(MessageService);
+  private readonly nnfb = inject(NonNullableFormBuilder);
 
   // prettier-ignore
   protected readonly AdminActivitiesFilters = [
@@ -58,8 +63,8 @@ export class AdminActivityComponent implements OnInit {
     entry: AdminActivityEntryData;
   }> = [];
 
-  protected readonly filters = new FormGroup({
-    types: new FormControl<AdminActivityType[]>([], { nonNullable: true }),
+  protected readonly filters = this.nnfb.group({
+    types: this.nnfb.control<AdminActivityType[]>([]),
     user: new FormControl<User | null>(null)
   });
 

--- a/apps/frontend/src/app/pages/admin/report-queue/update-report-dialog/update-report-dialog.component.ts
+++ b/apps/frontend/src/app/pages/admin/report-queue/update-report-dialog/update-report-dialog.component.ts
@@ -1,5 +1,9 @@
 import { Component, Input, OnInit, inject } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
 import { Report } from '@momentum/constants';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -14,15 +18,19 @@ import { HttpErrorResponse } from '@angular/common/http';
 })
 export class UpdateReportDialogComponent implements OnInit {
   private readonly ref = inject(DynamicDialogRef);
-  private readonly fb = inject(FormBuilder);
+  private readonly nnfb = inject(NonNullableFormBuilder);
   private readonly adminService = inject(AdminService);
   private readonly messageService = inject(MessageService);
 
   @Input() report: Report;
 
-  updateReportForm = this.fb.group({
-    resolved: [false, Validators.required],
-    resolutionMessage: ['', [Validators.required, Validators.maxLength(1000)]]
+  updateReportForm = this.nnfb.group({
+    resolved: this.nnfb.control<boolean>(false, {
+      validators: Validators.required
+    }),
+    resolutionMessage: this.nnfb.control<string>('', {
+      validators: [Validators.required, Validators.maxLength(1000)]
+    })
   });
 
   ngOnInit() {
@@ -41,13 +49,7 @@ export class UpdateReportDialogComponent implements OnInit {
 
   save() {
     this.adminService
-      .updateReport(
-        this.report.id,
-        this.updateReportForm.value as {
-          resolved: boolean;
-          resolutionMessage: string;
-        }
-      )
+      .updateReport(this.report.id, this.updateReportForm.getRawValue())
       .subscribe({
         next: () => {
           this.updateReportForm.reset();

--- a/apps/frontend/src/app/pages/admin/utilities/utilities.component.ts
+++ b/apps/frontend/src/app/pages/admin/utilities/utilities.component.ts
@@ -41,19 +41,24 @@ export class UtilitiesComponent implements OnInit {
     MAX_ADMIN_ANNOUNCEMENT_LENGTH;
 
   protected readonly userForm = this.nnfb.group({
-    alias: this.nnfb.control('', [Validators.required])
+    alias: this.nnfb.control<string>('', { validators: Validators.required })
   });
   protected readonly killswitchForm = this.nnfb.group(
     Object.fromEntries(
-      this.KillswitchTypes.map((type) => [type, this.nnfb.control(false)])
+      this.KillswitchTypes.map((type) => [
+        type,
+        this.nnfb.control<boolean>(false)
+      ])
     )
   );
   protected readonly announcementForm = this.nnfb.group({
-    message: this.nnfb.control('', [
-      Validators.required,
-      Validators.minLength(20), // Reasonable length to require some context.
-      Validators.maxLength(MAX_ADMIN_ANNOUNCEMENT_LENGTH)
-    ])
+    message: this.nnfb.control<string>('', {
+      validators: [
+        Validators.required,
+        Validators.minLength(20), // Reasonable length to require some context.
+        Validators.maxLength(MAX_ADMIN_ANNOUNCEMENT_LENGTH)
+      ]
+    })
   });
 
   ngOnInit() {

--- a/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
@@ -12,7 +12,7 @@
         <m-user-select formControlName="credit" />
         <m-dropdown [entries]="MapCreditOptions" [nameFn]="MapCreditNameFn" formControlName="creditType" />
       </div>
-      <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
+      <button (click)="filters.reset()" type="button" class="btn size-8 p-0">
         <m-icon icon="filter-remove" class="size-5" />
       </button>
     </div>

--- a/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.ts
+++ b/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.ts
@@ -15,8 +15,8 @@ import {
 import * as Enum from '@momentum/enum';
 import {
   FormControl,
-  FormGroup,
   FormsModule,
+  NonNullableFormBuilder,
   ReactiveFormsModule
 } from '@angular/forms';
 
@@ -49,6 +49,7 @@ export class AdminMapsBrowserComponent implements OnInit {
   private readonly adminService = inject(AdminService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly nnfb = inject(NonNullableFormBuilder);
 
   // Set value as if submitter was last entry in MapCredit enum.
   protected readonly submitterCreditValue =
@@ -86,12 +87,12 @@ export class AdminMapsBrowserComponent implements OnInit {
     })
   );
 
-  protected readonly filters = new FormGroup({
-    name: new FormControl<string>(''),
-    status: new FormControl<MapsGetAllAdminFilter>([], { nonNullable: true }),
+  protected readonly filters = this.nnfb.group({
+    name: this.nnfb.control<string>(''),
+    status: this.nnfb.control<MapsGetAllAdminFilter>([]),
     credit: new FormControl<User | null>(null),
-    creditType: new FormControl<number>(MapCreditType.AUTHOR),
-    sortType: new FormControl<MapSortType>(this.MapSortOptions[0])
+    creditType: this.nnfb.control<number>(MapCreditType.AUTHOR),
+    sortType: this.nnfb.control<MapSortType>(this.MapSortOptions[0])
   });
 
   protected maps: MMap[] = [];
@@ -162,15 +163,5 @@ export class AdminMapsBrowserComponent implements OnInit {
           this.loading = false;
         }
       });
-  }
-
-  resetFilters() {
-    this.filters.reset({
-      name: '',
-      status: [],
-      credit: null,
-      creditType: MapCreditType.AUTHOR,
-      sortType: this.MapSortOptions[0]
-    });
   }
 }

--- a/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
@@ -49,7 +49,7 @@
         <m-user-select formControlName="credit" />
         <m-dropdown [entries]="MapCreditOptions" [nameFn]="MapCreditNameFn" formControlName="creditType" />
       </div>
-      <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
+      <button (click)="filters.reset()" type="button" class="btn size-8 p-0">
         <m-icon icon="filter-remove" class="size-5" />
       </button>
     </div>

--- a/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
@@ -16,7 +16,7 @@
         <m-user-select formControlName="credit" />
         <m-dropdown [entries]="MapCreditOptions" [nameFn]="MapCreditNameFn" formControlName="creditType" />
       </div>
-      <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
+      <button (click)="filters.reset()" type="button" class="btn size-8 p-0">
         <m-icon icon="filter-remove" class="size-5" />
       </button>
     </div>

--- a/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.ts
+++ b/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.ts
@@ -14,8 +14,8 @@ import {
 import * as Enum from '@momentum/enum';
 import {
   FormControl,
-  FormGroup,
   FormsModule,
+  NonNullableFormBuilder,
   ReactiveFormsModule
 } from '@angular/forms';
 import { EMPTY, merge, of, Subject } from 'rxjs';
@@ -55,6 +55,7 @@ export class MapSubmissionBrowserComponent implements OnInit {
   private readonly mapsService = inject(MapsService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly nnfb = inject(NonNullableFormBuilder);
 
   // Default for users. More options get added if user is mod/admin.
   protected StatusDropdown = [
@@ -90,15 +91,13 @@ export class MapSubmissionBrowserComponent implements OnInit {
   protected readonly MapSortNameFn = (type: MapSortType): string =>
     MapSortTypeName.get(type);
 
-  protected readonly filters = new FormGroup({
-    name: new FormControl<string>(''),
-    status: new FormControl<MapsGetAllSubmissionFilter>([], {
-      nonNullable: true
-    }),
-    hasApprovingReviews: new FormControl<0 | 1 | 2>(0, { nonNullable: true }),
+  protected readonly filters = this.nnfb.group({
+    name: this.nnfb.control<string>(''),
+    status: this.nnfb.control<MapsGetAllSubmissionFilter>([]),
+    hasApprovingReviews: this.nnfb.control<0 | 1 | 2>(0),
     credit: new FormControl<User | null>(null),
-    creditType: new FormControl<number>(this.submitterCreditValue),
-    sortType: new FormControl<MapSortType>(this.MapSortOptions[0])
+    creditType: this.nnfb.control<number>(this.submitterCreditValue),
+    sortType: this.nnfb.control<MapSortType>(this.MapSortOptions[0])
   });
 
   protected maps: MMap[] = [];
@@ -199,16 +198,5 @@ export class MapSubmissionBrowserComponent implements OnInit {
           this.loading = false;
         }
       });
-  }
-
-  resetFilters() {
-    this.filters.reset({
-      name: '',
-      status: [],
-      hasApprovingReviews: 0,
-      credit: null,
-      creditType: this.submitterCreditValue,
-      sortType: this.MapSortOptions[0]
-    });
   }
 }

--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
@@ -34,7 +34,7 @@
             tooltipPosition="top"
           />
         </div>
-        <button (click)="resetFilters()" type="button" class="btn size-8 p-0">
+        <button (click)="filters.reset()" type="button" class="btn size-8 p-0">
           <m-icon icon="filter-remove" class="size-5" />
         </button>
       </div>

--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.ts
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.ts
@@ -16,8 +16,8 @@ import {
 } from '@momentum/constants';
 import {
   FormControl,
-  FormGroup,
   FormsModule,
+  NonNullableFormBuilder,
   ReactiveFormsModule
 } from '@angular/forms';
 
@@ -59,6 +59,7 @@ export class UserMapsBrowserComponent implements OnInit {
   private readonly localUserService = inject(LocalUserService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly nnfb = inject(NonNullableFormBuilder);
 
   protected readonly MapStatusName = MapStatusName;
   protected readonly StatusDropdown = [
@@ -88,14 +89,12 @@ export class UserMapsBrowserComponent implements OnInit {
 
   protected hasSubmissionBan = false;
 
-  protected readonly filters = new FormGroup({
-    name: new FormControl<string>(''),
-    status: new FormControl<MapsGetAllUserSubmissionFilter>([], {
-      nonNullable: true
-    }),
+  protected readonly filters = this.nnfb.group({
+    name: this.nnfb.control<string>(''),
+    status: this.nnfb.control<MapsGetAllUserSubmissionFilter>([]),
     credit: new FormControl<User | null>(null),
-    creditType: new FormControl<MapCreditType>(MapCreditType.AUTHOR),
-    sortType: new FormControl<MapSortType>(this.MapSortOptions[0])
+    creditType: this.nnfb.control<MapCreditType>(MapCreditType.AUTHOR),
+    sortType: this.nnfb.control<MapSortType>(this.MapSortOptions[0])
   });
 
   protected maps: MMap[] = [];
@@ -175,15 +174,5 @@ export class UserMapsBrowserComponent implements OnInit {
           this.loading = false;
         }
       });
-  }
-
-  resetFilters() {
-    this.filters.reset({
-      name: '',
-      status: [],
-      credit: null,
-      creditType: MapCreditType.AUTHOR,
-      sortType: this.MapSortOptions[0]
-    });
   }
 }

--- a/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.ts
+++ b/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.ts
@@ -1,7 +1,8 @@
 import { Component, DestroyRef, OnInit, inject } from '@angular/core';
 import {
-  FormBuilder,
+  FormControl,
   FormGroup,
+  NonNullableFormBuilder,
   ReactiveFormsModule,
   Validators
 } from '@angular/forms';
@@ -71,7 +72,7 @@ export class ProfileEditComponent implements OnInit {
   private readonly authService = inject(AuthService);
   private readonly messageService = inject(MessageService);
   private readonly dialogService = inject(DialogService);
-  private readonly fb = inject(FormBuilder);
+  private readonly nnfb = inject(NonNullableFormBuilder);
   private readonly destroyRef = inject(DestroyRef);
   private readonly titleService = inject(TitleService);
 
@@ -92,21 +93,21 @@ export class ProfileEditComponent implements OnInit {
   adminEditForm: FormGroup;
 
   get alias() {
-    return this.form.get('alias');
+    return this.form.get('alias') as FormControl<string>;
   }
   get bio() {
-    return this.form.get('bio');
+    return this.form.get('bio') as FormControl<string>;
   }
   get country() {
-    return this.form.get('country');
+    return this.form.get('country') as FormControl<string>;
   }
   get socials() {
-    return this.form.get('socials');
+    return this.form.get('socials') as FormGroup;
   }
 
-  protected user: User = null;
-  protected mergeUser: User = null;
-  protected mergeErr = null;
+  protected user: User | null = null;
+  protected mergeUser: User | null = null;
+  protected mergeErr = '';
   protected isLocal = false;
   protected isAdmin = false;
   protected isModOrAdmin = false;
@@ -119,33 +120,35 @@ export class ProfileEditComponent implements OnInit {
       socialsForm[name] = ['', [Validators.pattern(regex)]];
     }
 
-    this.form = this.fb.group({
-      alias: [
-        '',
-        [
+    this.form = this.nnfb.group({
+      alias: this.nnfb.control<string>('', {
+        validators: [
           Validators.required,
           Validators.maxLength(32),
           Validators.pattern(NON_WHITESPACE_REGEXP)
         ]
-      ],
-      bio: ['', [Validators.maxLength(MAX_BIO_LENGTH)]],
-      country: [''],
-      socials: this.fb.group(socialsForm),
-      resetAvatar: [false]
+      }),
+      bio: this.nnfb.control<string>('', {
+        validators: Validators.maxLength(MAX_BIO_LENGTH)
+      }),
+      country: this.nnfb.control<string>(''),
+      socials: this.nnfb.group(socialsForm),
+      resetAvatar: this.nnfb.control<boolean>(false)
     });
 
-    this.adminEditForm = this.fb.group({
-      banAlias: [false],
-      banBio: [false],
-      banAvatar: [false],
-      banLeaderboards: [false],
-      banMapSubmission: [false],
-      verified: [false],
-      mapper: [false],
-      porter: [false],
-      reviewer: [false],
-      moderator: [false],
-      admin: [false]
+    // prettier-ignore
+    this.adminEditForm = this.nnfb.group({
+      banAlias:         this.nnfb.control<boolean>(false),
+      banBio:           this.nnfb.control<boolean>(false),
+      banAvatar:        this.nnfb.control<boolean>(false),
+      banLeaderboards:  this.nnfb.control<boolean>(false),
+      banMapSubmission: this.nnfb.control<boolean>(false),
+      verified:         this.nnfb.control<boolean>(false),
+      mapper:           this.nnfb.control<boolean>(false),
+      porter:           this.nnfb.control<boolean>(false),
+      reviewer:         this.nnfb.control<boolean>(false),
+      moderator:        this.nnfb.control<boolean>(false),
+      admin:            this.nnfb.control<boolean>(false)
     });
   }
 
@@ -373,7 +376,7 @@ export class ProfileEditComponent implements OnInit {
       this.mergeErr = 'Cannot merge the same user onto themselves!';
       return;
     }
-    this.mergeErr = null;
+    this.mergeErr = '';
     this.mergeUser = user1;
   }
 

--- a/apps/frontend/src/app/pages/profile/profile-run-history/profile-run-history.component.ts
+++ b/apps/frontend/src/app/pages/profile/profile-run-history/profile-run-history.component.ts
@@ -1,12 +1,15 @@
 import { Component, Input, OnInit, inject } from '@angular/core';
 import { merge, Observable, Subject } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
-import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import {
+  FormGroup,
+  NonNullableFormBuilder,
+  ReactiveFormsModule
+} from '@angular/forms';
 import { Order, PastRun, RunsGetAllOrder, User } from '@momentum/constants';
 import { MessageService } from 'primeng/api';
 import { SelectModule } from 'primeng/select';
-import { PaginatorModule } from 'primeng/paginator';
-import { PaginatorState } from 'primeng/paginator/paginator.interface';
+import { PaginatorModule, PaginatorState } from 'primeng/paginator';
 
 import { PastRunsService } from '../../../services/data/past-runs.service';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -40,7 +43,7 @@ import { TimeAgoPipe } from '../../../pipes/time-ago.pipe';
 export class ProfileRunHistoryComponent implements OnInit {
   private readonly pastRunsService = inject(PastRunsService);
   private readonly messageService = inject(MessageService);
-  private readonly fb = inject(FormBuilder);
+  private readonly nnfb = inject(NonNullableFormBuilder);
 
   protected readonly OrderByDropdown = [
     { label: 'Sort by Date', type: RunsGetAllOrder.DATE },
@@ -66,11 +69,11 @@ export class ProfileRunHistoryComponent implements OnInit {
   protected readonly load = new Subject<void>();
   protected readonly pageChange = new Subject<PaginatorState>();
 
-  filterFG: FormGroup = this.fb.group({
-    isPersonalBest: [false],
-    map: [''],
-    orderBy: [RunsGetAllOrder.DATE],
-    order: [Order.DESC]
+  filterFG: FormGroup = this.nnfb.group({
+    isPersonalBest: this.nnfb.control<boolean>(false),
+    map: this.nnfb.control<string>(''),
+    orderBy: this.nnfb.control<RunsGetAllOrder>(RunsGetAllOrder.DATE),
+    order: this.nnfb.control<Order>(Order.DESC)
   });
 
   currentFilter: {


### PR DESCRIPTION
Convert all nonnullable formcontrols to be created with nonNullableFormBuilder.
When those values are reset they are now set to their initial values, instead of to null (even strings!).

related to #792 

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
