### PR TITLE
fix(front): center credit text if no description

### DIFF
--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -210,7 +210,7 @@
                       @if (!credit.placeholder) {
                         <a routerLink="/profile/{{ credit.userID }}" class="flex">
                           <m-avatar class="mr-4 h-8 w-8 shrink-0" [url]="credit.avatarURL" />
-                          <div class="flex flex-col">
+                          <div class="flex flex-col" [ngClass]="!credit.description ? 'justify-center' : null">
                             <p class="text-shadow font-medium leading-none">{{ credit.alias }}</p>
                             <p class="font-gray-100 text-shadow col-start-2 text-sm italic [overflow-wrap:anywhere]">
                               {{ credit.description }}


### PR DESCRIPTION
fixes a small styling thing I missed in the other PR. Seed script always adds a description to the credits :(

After fix:
<img width="448" height="463" alt="vivaldi_fsXWZBK8tl" src="https://github.com/user-attachments/assets/8f3c04b8-584c-4970-932e-d0fddd0deee5" />


### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
