### PR TITLE
feat(back): allow disabling unranked discord map status notifications

### DIFF
--- a/apps/backend/src/app/config/config.interface.ts
+++ b/apps/backend/src/app/config/config.interface.ts
@@ -68,6 +68,7 @@ export interface ConfigInterface {
     contentApprovalChannel: string;
     reviewChannel: string;
     statusChannels: Record<GamemodeCategory, string>;
+    unrankedNotifications: boolean;
   };
   mapListUpdateSchedule: string;
   logLevel: pino.LevelWithSilent;

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -102,7 +102,9 @@ export const ConfigFactory = (): ConfigInterface => {
             : (process.env[`DISCORD_STATUS_CHANNEL_${GamemodeCategory[cat]}`] ??
               '')
         ])
-      ) as Record<GamemodeCategory, string>
+      ) as Record<GamemodeCategory, string>,
+      unrankedNotifications:
+        process.env['DISCORD_UNRANKED_NOTIFICATIONS'] === 'true'
     },
     mapListUpdateSchedule:
       process.env['MAP_LIST_UPDATE_SCHEDULE'] ?? '* * * * *',

--- a/apps/backend/src/app/modules/maps/map-discord-notifications.service.ts
+++ b/apps/backend/src/app/modules/maps/map-discord-notifications.service.ts
@@ -129,11 +129,12 @@ export class MapDiscordNotifications {
       mapEmbed,
       categories.ranked
     );
-    await this.broadcastToCategories(
-      `:warning: A new **UNRANKED** map is available for public testing! :warning: Post feedback in ${thread.url}`,
-      mapEmbed,
-      categories.unranked
-    );
+    if (this.config.getOrThrow('discord.unrankedNotifications'))
+      await this.broadcastToCategories(
+        `:warning: A new **UNRANKED** map is available for public testing! :warning: Post feedback in ${thread.url}`,
+        mapEmbed,
+        categories.unranked
+      );
   }
 
   async sendApprovedNotification(extendedMap: MapWithInfoApproved) {
@@ -157,11 +158,12 @@ export class MapDiscordNotifications {
       mapEmbed,
       categories.ranked
     );
-    await this.broadcastToCategories(
-      ':white_check_mark: A new **UNRANKED** map has been fully approved and added! :white_check_mark:',
-      mapEmbed,
-      categories.unranked
-    );
+    if (this.config.getOrThrow('discord.unrankedNotifications'))
+      await this.broadcastToCategories(
+        ':white_check_mark: A new **UNRANKED** map has been fully approved and added! :white_check_mark:',
+        mapEmbed,
+        categories.unranked
+      );
   }
 
   async sendMapReviewToMapThread(review: ReviewWithInfo) {

--- a/libs/test-utils/src/utils/discord.util.ts
+++ b/libs/test-utils/src/utils/discord.util.ts
@@ -24,6 +24,8 @@ export async function mockDiscordService(app: NestFastifyApplication) {
           return reviewChannelId;
         case 'statusChannels':
           return parts[2];
+        case 'unrankedNotifications':
+          return true;
       }
     }
     return getOrThrow.bind(configService)(path);


### PR DESCRIPTION
### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
