### PR TITLE
fix(front): fix clicking second author linking to first author

### DIFF
--- a/apps/frontend/src/app/components/map-list/map-list-item.component.html
+++ b/apps/frontend/src/app/components/map-list/map-list-item.component.html
@@ -99,7 +99,7 @@
         <!-- prettier-ignore -->
         @if (authors.length > 1) {,
             @if (authors[1]?.id) {
-              <a class="link text-gray-50" [routerLink]="'/profile/' + authors[0]?.id">{{ authors[1].alias }}</a>
+              <a class="link text-gray-50" [routerLink]="'/profile/' + authors[1]?.id">{{ authors[1].alias }}</a>
             } @else {
               <span class="text-gray-200">{{ authors[1].alias }}</span>
             }


### PR DESCRIPTION
Closes #1396

In the map browser, fixes the link of the 2nd map author linking to the first author. 

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
