### PR TITLE
fix(front): array forms not resetting

### DIFF
--- a/apps/frontend/src/app/components/map-review/map-review-form.component.ts
+++ b/apps/frontend/src/app/components/map-review/map-review-form.component.ts
@@ -183,7 +183,7 @@ export class MapReviewFormComponent {
               this.map.name
             }`
           });
-          this.form.reset();
+          this.form.reset({ suggestions: [], images: [] });
         },
         error: (httpError: HttpErrorResponse) => {
           if (httpError.status === 409)

--- a/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/admin-maps-browser.component.html
@@ -12,7 +12,7 @@
         <m-user-select formControlName="credit" />
         <m-dropdown [entries]="MapCreditOptions" [nameFn]="MapCreditNameFn" formControlName="creditType" />
       </div>
-      <button (click)="filters.reset()" type="button" class="btn size-8 p-0">
+      <button (click)="filters.reset({ status: [] })" type="button" class="btn size-8 p-0">
         <m-icon icon="filter-remove" class="size-5" />
       </button>
     </div>

--- a/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
@@ -49,7 +49,7 @@
         <m-user-select formControlName="credit" />
         <m-dropdown [entries]="MapCreditOptions" [nameFn]="MapCreditNameFn" formControlName="creditType" />
       </div>
-      <button (click)="filters.reset()" type="button" class="btn size-8 p-0">
+      <button (click)="filters.reset({ tagsAndQualifiers: [] })" type="button" class="btn size-8 p-0">
         <m-icon icon="filter-remove" class="size-5" />
       </button>
     </div>

--- a/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
@@ -16,7 +16,7 @@
         <m-user-select formControlName="credit" />
         <m-dropdown [entries]="MapCreditOptions" [nameFn]="MapCreditNameFn" formControlName="creditType" />
       </div>
-      <button (click)="filters.reset()" type="button" class="btn size-8 p-0">
+      <button (click)="filters.reset({ status: [] })" type="button" class="btn size-8 p-0">
         <m-icon icon="filter-remove" class="size-5" />
       </button>
     </div>

--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
@@ -34,7 +34,7 @@
             tooltipPosition="top"
           />
         </div>
-        <button (click)="filters.reset()" type="button" class="btn size-8 p-0">
+        <button (click)="filters.reset({ status: [] })" type="button" class="btn size-8 p-0">
           <m-icon icon="filter-remove" class="size-5" />
         </button>
       </div>


### PR DESCRIPTION
Closes #1402

Turns out nonnullable forms is using reference semantics, so on reset it sets the value back to the original object you gave it, not a new one.
This is currently only a problem for the map review images and files (as we don't reset in other places).
The other changes are just precautionary, e.g. to stop it breaking if we move off primeng.

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
