### PR TITLE
fix(front): fix various user links not being middle-mouse clickable

### DIFF
--- a/apps/frontend/src/app/components/user/user.component.ts
+++ b/apps/frontend/src/app/components/user/user.component.ts
@@ -1,8 +1,8 @@
-import { Component, HostListener, Input, inject } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { User } from '@momentum/constants';
 import { AvatarComponent } from '../avatar/avatar.component';
 import { NgClass } from '@angular/common';
-import { Router } from '@angular/router';
+import { RouterLink } from '@angular/router';
 import { RoleBadgesComponent } from '../role-badges/role-badges.component';
 
 /**
@@ -14,19 +14,20 @@ import { RoleBadgesComponent } from '../role-badges/role-badges.component';
  */
 @Component({
   selector: 'm-user',
-  imports: [AvatarComponent, NgClass, RoleBadgesComponent],
+  imports: [AvatarComponent, NgClass, RoleBadgesComponent, RouterLink],
   template: ` @if (user) {
     <m-avatar
       class="h-8 shadow"
       [ngClass]="avatarClass"
       [url]="user.avatarURL"
     />
-    <p
+    <a
+      [routerLink]="'/profile/' + user.id"
       class="text-lg text-shadow transition-colors [:hover>&]:text-blue-200"
       [ngClass]="aliasClass"
     >
       {{ user.alias }}
-    </p>
+    </a>
     @if (badges && user.roles > 0) {
       <m-role-badges [roles]="user.roles" [ngClass]="badgesClass" />
     }
@@ -43,15 +44,9 @@ import { RoleBadgesComponent } from '../role-badges/role-badges.component';
   ]
 })
 export class UserComponent {
-  private readonly router = inject(Router);
-
   @Input({ required: true }) user!: User;
   @Input() aliasClass?: string;
   @Input() avatarClass?: string;
   @Input() badges = false;
   @Input() badgesClass?: string;
-
-  @HostListener('click') click() {
-    this.router.navigate([`profile/${this.user.id}`]);
-  }
 }


### PR DESCRIPTION
Closes #1407

Fixes various user links that can't be opened in new tab with middle-mouse click. 

### Screenshots (if applicable)

<!-- Attach screenshots here, if your PR contains any visual changes, e.g. frontend work -->

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
