### PR TITLE
fix(ci): explicitly install prisma cli in backend docker container

### DIFF
--- a/prod/backend/Dockerfile
+++ b/prod/backend/Dockerfile
@@ -12,7 +12,7 @@ COPY ./libs/db/src/migrations/ ./prisma/migrations/
 RUN chown -R backend:backend .
 
 USER backend
-RUN npm --omit=dev --ignore-scripts install
+RUN npm --omit=dev --ignore-scripts install prisma
 RUN node_modules/.bin/prisma generate --schema ./prisma/schema.prisma
 
 RUN rm package.json package-lock.json


### PR DESCRIPTION
I have no clue why prisma dependency is missing now. We haven't updated our packages, we haven't changed any library dependencies related to prisma, and yet the prisma package that includes cli tools we use for migrations is no longer being installed. I added it to docker files manually, and it should work as before now.