### PR TITLE
fix(front): map edit description styling

### DIFF
--- a/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.html
+++ b/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.html
@@ -1,5 +1,5 @@
 <div class="flex gap-4 md:flex-wrap" [formGroup]="formGroup">
-  <div class="grid h-fit max-w-[35%] gap-4 [grid-template-columns:auto_1fr]">
+  <div class="grid h-fit max-w-[30%] gap-4 [grid-template-columns:auto_1fr]">
     <div class="flex flex-col">
       <label class="my-auto text-lg leading-4">
         Map Name
@@ -118,11 +118,12 @@
               </div>
             </ng-template>
           </label>
-          <span class="ml-2 text-sm italic text-gray-200">Minimum {{ MIN_MAP_DESCRIPTION_LENGTH }} characters required</span>
         </div>
-        <span class="mr-2 mt-auto text-sm"
-          >{{ MAX_MAP_DESCRIPTION_LENGTH - description.value?.length | plural: 'character' }} remaining</span
-        >
+        @if (MAX_MAP_DESCRIPTION_LENGTH / 2 < description.value.length) {
+          <span class="mr-2 mt-auto text-sm"
+            >{{ MAX_MAP_DESCRIPTION_LENGTH - description.value.length | plural: 'character' }} remaining</span
+          >
+        }
       </div>
       <textarea
         id="description"
@@ -130,34 +131,34 @@
         rows="2"
         [formControl]="description"
         [maxLength]="MAX_MAP_DESCRIPTION_LENGTH"
+        [placeholder]="'Minimum ' + MIN_MAP_DESCRIPTION_LENGTH + ' characters required'"
       ></textarea>
     </div>
-
-    @if (submissionType.value === MapSubmissionType.PORT) {
-      <div class="flex flex-1 flex-col">
-        <div class="mb-2 flex">
-          <div class="my-auto flex flex-grow items-center">
-            <label for="portingChangelog" class="text-lg">
-              Porting Changelog
-
-              <m-icon icon="tooltip-question-outline" class="ml-1 align-middle" [mTooltip]="changelogInfo" />
-
-              <ng-template #changelogInfo>
-                <div class="prose p-3">
-                  <p>Any major changes made when porting from the original game to Momentum.</p>
-                  <p>Changes that required a recompile, especially altering map geometry, must be listed here.</p>
-                </div>
-              </ng-template>
-            </label>
-          </div>
-        </div>
-        <textarea
-          id="portingChangelog"
-          class="textinput textinput-validated flex-grow"
-          rows="2"
-          [formControl]="portingChangelog"
-        ></textarea>
-      </div>
-    }
   </div>
+  @if (submissionType.value === MapSubmissionType.PORT) {
+    <div class="flex flex-1 flex-col">
+      <div class="mb-2 flex">
+        <div class="my-auto flex flex-grow items-center">
+          <label for="portingChangelog" class="text-lg">
+            Porting Changelog
+
+            <m-icon icon="tooltip-question-outline" class="ml-1 align-middle" [mTooltip]="changelogInfo" />
+
+            <ng-template #changelogInfo>
+              <div class="prose p-3">
+                <p>Any major changes made when porting from the original game to Momentum.</p>
+                <p>Changes that required a recompile, especially altering map geometry, must be listed here.</p>
+              </div>
+            </ng-template>
+          </label>
+        </div>
+        @if (MAX_CHANGELOG_LENGTH / 2 < portingChangelog.value.length) {
+          <span class="mr-2 mt-auto text-sm"
+            >{{ MAX_CHANGELOG_LENGTH - portingChangelog.value.length | plural: 'character' }} remaining</span
+          >
+        }
+      </div>
+      <textarea id="portingChangelog" class="textinput textinput-validated flex-grow" rows="2" [formControl]="portingChangelog"></textarea>
+    </div>
+  }
 </div>

--- a/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.ts
+++ b/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import {
   MapSubmissionType,
+  MAX_CHANGELOG_LENGTH,
   MAX_MAP_DESCRIPTION_LENGTH,
   MAX_MAP_NAME_LENGTH,
   MIN_MAP_DESCRIPTION_LENGTH,
@@ -61,6 +62,7 @@ export class MapDetailsFormComponent implements OnInit {
   protected readonly SteamGames = Enum.values(SteamGame);
   protected readonly MIN_MAP_DESCRIPTION_LENGTH = MIN_MAP_DESCRIPTION_LENGTH;
   protected readonly MAX_MAP_DESCRIPTION_LENGTH = MAX_MAP_DESCRIPTION_LENGTH;
+  protected readonly MAX_CHANGELOG_LENGTH = MAX_CHANGELOG_LENGTH;
   protected readonly maxDate = new Date();
   protected mapSubmissionTypeOptions: Array<{
     type: MapSubmissionType;


### PR DESCRIPTION
Somewhat reverts the styling for the map edit descriptions that were done.
This is mostly on me for not realizing the usability issue.

Keeps the required games as icons.
I've tried to limit the games form from growing in width when adding games, but can't figure it out :(

Conditionally shows "remaining characters" text, and added it for porting changelog.

<img width="1616" height="455" alt="vivaldi_D9WoF7NriU" src="https://github.com/user-attachments/assets/0d779c4f-84c2-428e-b1d4-e3370be420cc" />


### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
