### PR TITLE
feat(shared): enable KZT on dashboard

### DIFF
--- a/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
@@ -1,6 +1,6 @@
 <form class="mb-4 flex" [formGroup]="filters">
   <div class="flex basis-4/10 flex-col">
-    <div class="flex flex-wrap items-end gap-x-4 gap-y-1">
+    <div class="-mt-4 flex flex-wrap items-end gap-x-4 gap-y-1">
       <ng-template #gm let-mode="mode" let-name="name" let-size="size">
         <button type="button" (click)="gamemode.setValue(mode)">
           <p
@@ -16,7 +16,24 @@
       </ng-template>
       <ng-container *ngTemplateOutlet="gm; context: { mode: null, name: 'All modes' }" />
       <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.SURF, name: 'Surf' }" />
-      <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.BHOP, name: 'Bhop' }" />
+      <div class="grid grid-cols-2 grid-rows-1 gap-x-2">
+        <p
+          class="pointer-events-none col-span-2 font-display text-24 font-bold leading-none text-gray-400 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)]"
+        >
+          Bhop
+        </p>
+        <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.BHOP, name: 'CSS' }" />
+        <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.BHOP_HL1, name: 'HL1' }" />
+      </div>
+      <div class="grid grid-cols-2 grid-rows-1 gap-x-2">
+        <p
+          class="pointer-events-none col-span-2 font-display text-24 font-bold leading-none text-gray-400 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)]"
+        >
+          Climb
+        </p>
+        <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.CLIMB_KZT, name: 'KZT' }" />
+        <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.CLIMB_16, name: '1.6' }" />
+      </div>
       <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.RJ, name: 'Rocket Jump' }" />
       <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.SJ, name: 'Sticky Jump' }" />
       <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.AHOP, name: 'Ahop' }" />
@@ -30,15 +47,6 @@
         <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.DEFRAG_CPM, name: 'CPM' }" />
         <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.DEFRAG_VQ3, name: 'VQ3' }" />
         <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.DEFRAG_VTG, name: 'VTG' }" />
-      </div>
-      <!-- TODO more climb modes when they get added. -->
-      <div class="grid grid-cols-1 grid-rows-1 gap-x-2">
-        <p
-          class="pointer-events-none col-span-1 font-display text-24 font-bold leading-none text-gray-400 drop-shadow-[0_2px_4px_rgb(0_0_0/0.3)]"
-        >
-          Climb
-        </p>
-        <ng-container *ngTemplateOutlet="gm; context: { mode: Gamemode.CLIMB_16, name: '1.6' }" />
       </div>
     </div>
   </div>

--- a/libs/constants/src/sets/disabled-gamemodes.set.ts
+++ b/libs/constants/src/sets/disabled-gamemodes.set.ts
@@ -5,7 +5,4 @@ import { Gamemode } from '../enums/gamemode.enum';
  * In the future this will probably be empty, but helpful for handling
  * in-development modes that don't have full leaderboards support yet.
  */
-export const DisabledGamemodes = new Set<Gamemode>([
-  Gamemode.CLIMB_MOM,
-  Gamemode.CLIMB_KZT
-]);
+export const DisabledGamemodes = new Set<Gamemode>([Gamemode.CLIMB_MOM]);

--- a/libs/formats/zone/src/zones.stub.ts
+++ b/libs/formats/zone/src/zones.stub.ts
@@ -189,7 +189,7 @@ export const ZonesStubLeaderboards = [
       { gamemode, trackType: TrackType.STAGE, trackNum: 2, linear: null  }
   ]),
   ...Enum.values(GM)
-    .filter((gamemode => gamemode !== GM.CLIMB_KZT && gamemode !== GM.CLIMB_MOM ))
+    .filter((gamemode => gamemode !== GM.CLIMB_MOM ))
     .map((gamemode) => (
       { gamemode, trackType: TrackType.BONUS, trackNum: 1, linear: null }))
 ].sort();


### PR DESCRIPTION
Also add hl1 bhop to main map browser filter, also modes are ordered how they are in-game now.

This should be merged when we have KZT ready

I added back the evil negative margin that I removed when editing last time, would look silly otherwise.

<img width="1785" height="339" alt="vivaldi_G3jOawDrpL" src="https://github.com/user-attachments/assets/d41d523d-752f-4732-b53c-df4c77dbf0de" />


### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
