### PR TITLE
feat(back): increase normalize depth in Sentry traces

### DIFF
--- a/apps/backend/src/instrumentation.ts
+++ b/apps/backend/src/instrumentation.ts
@@ -27,7 +27,7 @@ const opts: Sentry.NodeOptions = {
   tracesSampleRate: sampleRate,
   profilesSampleRate: sampleRate,
   debug: false,
-  normalizeDepth: 6,
+  normalizeDepth: 10,
   integrations,
   _experiments: { enableLogs: true }
 };


### PR DESCRIPTION
Run validation errors don't have enough depth to see the whole structure 

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
