### PR TITLE
fix(ci): change syntax of expose field

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -45,7 +45,7 @@ services:
       - ${MINIO_SERVER_PORT}:${MINIO_SERVER_PORT}
       - ${MINIO_CONSOLE_PORT}:${MINIO_CONSOLE_PORT}
     expose:
-      - ${MINIO_SERVER_PORT}:${MINIO_SERVER_PORT}
+      - ${MINIO_SERVER_PORT}
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:${MINIO_SERVER_PORT}/minio/health/live']
       interval: 5s


### PR DESCRIPTION
Docker 29 doesn't support the port:port syntax anymore
