### PR TITLE
Featured maps

### DIFF
--- a/apps/backend/src/app/dto/index.ts
+++ b/apps/backend/src/app/dto/index.ts
@@ -5,6 +5,7 @@ export * from './jsonifiable.dto';
 export * from './auth/jwt-response.dto';
 export * from './auth/refresh-token.dto';
 export * from './map/map.dto';
+export * from './map/featured-maps.dto';
 export * from './map/map-zones.dto';
 export * from './map/map-info.dto';
 export * from './map/map-image.dto';

--- a/apps/backend/src/app/dto/map/featured-maps.dto.ts
+++ b/apps/backend/src/app/dto/map/featured-maps.dto.ts
@@ -1,0 +1,17 @@
+import { Gamemode } from '@momentum/constants';
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsArray, IsInt, IsPositive } from 'class-validator';
+import { EnumProperty } from '../decorators';
+
+export class FeaturedMapsForGamemodeDto {
+  @EnumProperty(Gamemode)
+  @Expose()
+  readonly gamemode: Gamemode;
+
+  @ApiProperty({ type: [Number], description: 'IDs of the featured maps' })
+  @IsArray()
+  @IsInt({ each: true })
+  @IsPositive({ each: true })
+  readonly mapIDs: number[];
+}

--- a/apps/backend/src/app/modules/maps/map-featured.service.spec.ts
+++ b/apps/backend/src/app/modules/maps/map-featured.service.spec.ts
@@ -1,0 +1,258 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { mockDeep } from 'jest-mock-extended';
+import { ScheduleModule } from '@nestjs/schedule';
+import {
+  Gamemode,
+  LeaderboardType,
+  MapStatus,
+  TrackType,
+  DisabledGamemodes
+} from '@momentum/constants';
+import {
+  PRISMA_MOCK_PROVIDER,
+  PrismaMock
+} from '../../../../test/prisma-mock.const';
+import { EXTENDED_PRISMA_SERVICE } from '../database/db.constants';
+import { ValkeyService } from '../valkey/valkey.service';
+import {
+  DEFAULT_FEATURED_TIERS,
+  GAMEMODE_FEATURED_TIER_OVERRIDES,
+  MapFeaturedService
+} from './map-featured.service';
+import * as Enum from '@momentum/enum';
+
+const ACTIVE_GAMEMODES = Enum.values(Gamemode).filter(
+  (gm) => !DisabledGamemodes.has(gm)
+);
+
+const valkeyKey = (gm: Gamemode) => `featured:maps:${gm}`;
+
+describe('MapFeaturedService', () => {
+  let service: MapFeaturedService;
+  let db: PrismaMock;
+  let module: TestingModule;
+
+  const pipelineMock = {
+    set: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue([])
+  };
+
+  const valkeyMock = {
+    mget: jest.fn(),
+    get: jest.fn(),
+    set: jest.fn(),
+    pipeline: jest.fn(() => pipelineMock)
+  };
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [ScheduleModule.forRoot()],
+      providers: [
+        MapFeaturedService,
+        PRISMA_MOCK_PROVIDER,
+        { provide: ValkeyService, useValue: valkeyMock }
+      ]
+    })
+      .useMocker(mockDeep)
+      .compile();
+
+    service = module.get(MapFeaturedService);
+    db = module.get(EXTENDED_PRISMA_SERVICE);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    pipelineMock.set.mockReturnThis();
+    pipelineMock.exec.mockResolvedValue([]);
+    GAMEMODE_FEATURED_TIER_OVERRIDES.clear();
+    await module.close();
+  });
+
+  //#region onModuleInit
+
+  describe('onModuleInit', () => {
+    it('should populate the cache if any gamemode key is missing', async () => {
+      // All null → triggers a full refresh
+      valkeyMock.mget.mockResolvedValueOnce(ACTIVE_GAMEMODES.map(() => null));
+      db.mMap.findMany.mockResolvedValue([]);
+
+      await service.onModuleInit();
+
+      // One pipeline.set call per active gamemode, then exec once
+      expect(pipelineMock.set).toHaveBeenCalledTimes(ACTIVE_GAMEMODES.length);
+      expect(pipelineMock.exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not refresh if all gamemode keys are already cached', async () => {
+      valkeyMock.mget.mockResolvedValueOnce(
+        ACTIVE_GAMEMODES.map(() => JSON.stringify([1, 2, 3]))
+      );
+
+      await service.onModuleInit();
+
+      expect(pipelineMock.exec).not.toHaveBeenCalled();
+    });
+  });
+
+  //#endregion
+
+  //#region getFeaturedMaps
+
+  describe('getFeaturedMaps', () => {
+    it('should return cached IDs for all gamemodes', async () => {
+      const surfIds = [10, 20, 30];
+      const bhopIds = [40, 50];
+
+      // Build a cache hit for every gamemode, using surfIds for SURF,
+      // bhopIds for BHOP, and an empty array for the rest.
+      const cached = ACTIVE_GAMEMODES.map((gm) => {
+        if (gm === Gamemode.SURF) return JSON.stringify(surfIds);
+        if (gm === Gamemode.BHOP) return JSON.stringify(bhopIds);
+        return JSON.stringify([]);
+      });
+      valkeyMock.mget.mockResolvedValueOnce(cached);
+
+      const result = await service.getFeaturedMaps();
+
+      // Gamemodes with empty arrays should be filtered out
+      expect(result).toHaveLength(2);
+
+      const surf = result.find((r) => r.gamemode === Gamemode.SURF);
+      expect(surf?.mapIDs).toEqual(surfIds);
+
+      const bhop = result.find((r) => r.gamemode === Gamemode.BHOP);
+      expect(bhop?.mapIDs).toEqual(bhopIds);
+    });
+
+    it('should return an empty array when no maps exist for any gamemode', async () => {
+      valkeyMock.mget.mockResolvedValueOnce(
+        ACTIVE_GAMEMODES.map(() => JSON.stringify([]))
+      );
+
+      const result = await service.getFeaturedMaps();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  //#endregion
+
+  //#region refreshForGamemode (via public hook)
+
+  describe('refreshForGamemode', () => {
+    const mapA = { id: 1 };
+    const mapB = { id: 2 };
+    const mapC = { id: 3 };
+
+    it('should store one map ID per tier slot', async () => {
+      db.mMap.findMany
+        .mockResolvedValueOnce([mapA] as any) // slot 1
+        .mockResolvedValueOnce([mapB] as any) // slot 2
+        .mockResolvedValueOnce([mapC] as any); // slot 3
+
+      const [key, value] = await (service as any).refreshForGamemode(
+        Gamemode.SURF
+      );
+
+      expect(key).toBe(valkeyKey(Gamemode.SURF));
+      expect(JSON.parse(value)).toEqual([mapA.id, mapB.id, mapC.id]);
+    });
+
+    it('should skip a slot when no candidates are available', async () => {
+      db.mMap.findMany
+        .mockResolvedValueOnce([mapA] as any) // slot 1
+        .mockResolvedValueOnce([]) // slot 2 – no maps
+        .mockResolvedValueOnce([mapC] as any); // slot 3
+
+      const [key, value] = await (service as any).refreshForGamemode(
+        Gamemode.SURF
+      );
+
+      expect(key).toBe(valkeyKey(Gamemode.SURF));
+      expect(JSON.parse(value)).toEqual([mapA.id, mapC.id]);
+    });
+
+    it('should not pick the same map twice across slots', async () => {
+      // Both slot 1 and slot 2 only have mapA available
+      db.mMap.findMany
+        .mockResolvedValueOnce([mapA] as any) // slot 1 picks mapA
+        .mockResolvedValueOnce([mapA] as any) // slot 2 – mapA already used, skipped
+        .mockResolvedValueOnce([mapB] as any); // slot 3
+
+      const [, value] = await (service as any).refreshForGamemode(
+        Gamemode.SURF
+      );
+      const stored: number[] = JSON.parse(value);
+
+      expect(new Set(stored).size).toBe(stored.length); // no duplicates
+      expect(stored).toContain(mapA.id);
+      expect(stored).toContain(mapB.id);
+    });
+
+    it('should store an empty array when no maps exist for the gamemode', async () => {
+      db.mMap.findMany.mockResolvedValue([]);
+
+      const [key, value] = await (service as any).refreshForGamemode(
+        Gamemode.SURF
+      );
+
+      expect(key).toBe(valkeyKey(Gamemode.SURF));
+      expect(JSON.parse(value)).toEqual([]);
+    });
+
+    it('should query using the correct leaderboard filters', async () => {
+      db.mMap.findMany.mockResolvedValue([]);
+
+      await (service as any).refreshForGamemode(Gamemode.BHOP);
+
+      const [firstCall] = db.mMap.findMany.mock.calls;
+      const where = firstCall[0].where;
+
+      expect(where.status).toBe(MapStatus.APPROVED);
+      expect(where.leaderboards.some.gamemode).toBe(Gamemode.BHOP);
+      expect(where.leaderboards.some.trackType).toBe(TrackType.MAIN);
+      expect(where.leaderboards.some.type).toBe(LeaderboardType.RANKED);
+    });
+
+    it('should apply the correct tier range for each slot', async () => {
+      db.mMap.findMany.mockResolvedValue([]);
+
+      await (service as any).refreshForGamemode(Gamemode.SURF);
+
+      const tiers = db.mMap.findMany.mock.calls.map(
+        ([args]) => args.where.leaderboards.some.tier
+      );
+
+      const [[min1, max1], [min2, max2], [min3, max3]] = DEFAULT_FEATURED_TIERS;
+      expect(tiers[0]).toEqual({ gte: min1, lte: max1 });
+      expect(tiers[1]).toEqual({ gte: min2, lte: max2 });
+      expect(tiers[2]).toEqual({ gte: min3, lte: max3 });
+    });
+
+    it('should use per-gamemode tier overrides when configured', async () => {
+      const overrideTiers: [
+        readonly [number, number],
+        readonly [number, number],
+        readonly [number, number]
+      ] = [
+        [1, 3],
+        [4, 5],
+        [6, 8]
+      ];
+      GAMEMODE_FEATURED_TIER_OVERRIDES.set(Gamemode.SURF, overrideTiers);
+      db.mMap.findMany.mockResolvedValue([]);
+
+      await (service as any).refreshForGamemode(Gamemode.SURF);
+
+      const tiers = db.mMap.findMany.mock.calls.map(
+        ([args]) => args.where.leaderboards.some.tier
+      );
+
+      expect(tiers[0]).toEqual({ gte: 1, lte: 3 });
+      expect(tiers[1]).toEqual({ gte: 4, lte: 5 });
+      expect(tiers[2]).toEqual({ gte: 6, lte: 8 });
+    });
+  });
+
+  //#endregion
+});

--- a/apps/backend/src/app/modules/maps/map-featured.service.ts
+++ b/apps/backend/src/app/modules/maps/map-featured.service.ts
@@ -1,0 +1,165 @@
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { CronJob } from 'cron';
+import {
+  DisabledGamemodes,
+  Gamemode,
+  LeaderboardType,
+  MapStatus,
+  TrackType
+} from '@momentum/constants';
+import * as Enum from '@momentum/enum';
+import { EXTENDED_PRISMA_SERVICE } from '../database/db.constants';
+import { ExtendedPrismaService } from '../database/prisma.extension';
+import { ValkeyService } from '../valkey/valkey.service';
+import { DtoFactory, FeaturedMapsForGamemodeDto } from '../../dto';
+import { isFirstWorker } from '../../../clustered';
+
+/** A min/max tier range (inclusive). */
+export type TierRange = readonly [min: number, max: number];
+
+/** The three featured slots for a gamemode, from easiest to hardest. */
+export type FeaturedTierSlots = readonly [TierRange, TierRange, TierRange];
+
+/**
+ * Default tier ranges used for all gamemodes unless overridden below.
+ *  - Slot 1 (beginner):     tier 1–2
+ *  - Slot 2 (intermediate): tier 2–3
+ *  - Slot 3 (advanced):     tier 4–6
+ */
+export const DEFAULT_FEATURED_TIERS: FeaturedTierSlots = [
+  [1, 2],
+  [2, 3],
+  [4, 6]
+] as const;
+
+/**
+ * Per-gamemode tier range overrides.
+ * Any gamemode not listed here falls back to DEFAULT_FEATURED_TIERS.
+ */
+export const GAMEMODE_FEATURED_TIER_OVERRIDES = new Map<
+  Gamemode,
+  FeaturedTierSlots
+>([
+  // Example:
+  // [Gamemode.SURF, [[1, 2], [3, 4], [5, 6]]],
+]);
+
+const FEATURED_MAPS_JOB_NAME = 'FeaturedMapsRefreshJob';
+const FEATURED_MAPS_CRON = '0 * * * *'; // top of every hour
+
+@Injectable()
+export class MapFeaturedService implements OnModuleInit {
+  private readonly logger = new Logger(MapFeaturedService.name);
+
+  constructor(
+    @Inject(EXTENDED_PRISMA_SERVICE) private readonly db: ExtendedPrismaService,
+    private readonly valkey: ValkeyService,
+    private readonly schedulerRegistry: SchedulerRegistry
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    // Only the primary worker manages the cache and schedule.
+    if (!isFirstWorker()) return;
+
+    const gamemodes = this.getActiveGamemodes();
+    const cached = await this.valkey.mget(
+      ...gamemodes.map((gm) => this.valkeyKey(gm))
+    );
+    if (cached.includes(null)) {
+      await this.refreshFeaturedMaps();
+    }
+
+    this.schedulerRegistry.addCronJob(
+      FEATURED_MAPS_JOB_NAME,
+      CronJob.from({
+        cronTime: FEATURED_MAPS_CRON,
+        onTick: this.refreshFeaturedMaps.bind(this),
+        waitForCompletion: true,
+        start: true
+      })
+    );
+  }
+
+  async getFeaturedMaps(): Promise<FeaturedMapsForGamemodeDto[]> {
+    const gamemodes = this.getActiveGamemodes();
+
+    // Fetch cached IDs for all gamemodes in a single round-trip.
+    const keys = gamemodes.map((gm) => this.valkeyKey(gm));
+    const cachedValues = await this.valkey.mget(...keys);
+
+    // For any gamemode whose cache has expired, regenerate on-demand.
+    const gamemodeIds: [Gamemode, number[]][] = await Promise.all(
+      gamemodes.map(async (gm, i) => {
+        const raw = cachedValues[i];
+        const ids: number[] = raw ? (JSON.parse(raw) as number[]) : [];
+        return [gm, ids] as [Gamemode, number[]];
+      })
+    );
+
+    return gamemodeIds
+      .filter(([, ids]) => ids.length > 0)
+      .map(([gamemode, mapIDs]) =>
+        DtoFactory(FeaturedMapsForGamemodeDto, { gamemode, mapIDs })
+      );
+  }
+
+  private async refreshFeaturedMaps(): Promise<void> {
+    this.logger.log('Refreshing featured maps cache');
+    const results = await Promise.all(
+      this.getActiveGamemodes().map((gm) => this.refreshForGamemode(gm))
+    );
+
+    const pipeline = this.valkey.pipeline();
+    for (const [key, value] of results) {
+      pipeline.set(key, value);
+    }
+    await pipeline.exec();
+  }
+
+  private async refreshForGamemode(
+    gamemode: Gamemode
+  ): Promise<[key: string, value: string]> {
+    const slots = this.getTierSlots(gamemode);
+    const mapIds: number[] = [];
+
+    for (const [minTier, maxTier] of slots) {
+      const candidates = await this.db.mMap.findMany({
+        where: {
+          status: MapStatus.APPROVED,
+          leaderboards: {
+            some: {
+              gamemode,
+              trackType: TrackType.MAIN,
+              type: LeaderboardType.RANKED,
+              tier: { gte: minTier, lte: maxTier }
+            }
+          }
+        },
+        select: { id: true }
+      });
+
+      const available = candidates.filter((c) => !mapIds.includes(c.id));
+      if (available.length > 0) {
+        const picked = available[Math.floor(Math.random() * available.length)];
+        mapIds.push(picked.id);
+      }
+    }
+
+    return [this.valkeyKey(gamemode), JSON.stringify(mapIds)];
+  }
+
+  private getActiveGamemodes(): Gamemode[] {
+    return Enum.values(Gamemode).filter((gm) => !DisabledGamemodes.has(gm));
+  }
+
+  private getTierSlots(gamemode: Gamemode): FeaturedTierSlots {
+    return (
+      GAMEMODE_FEATURED_TIER_OVERRIDES.get(gamemode) ?? DEFAULT_FEATURED_TIERS
+    );
+  }
+
+  private valkeyKey(gamemode: Gamemode): string {
+    return `featured:maps:${gamemode}`;
+  }
+}

--- a/apps/backend/src/app/modules/maps/maps.controller.ts
+++ b/apps/backend/src/app/modules/maps/maps.controller.ts
@@ -76,7 +76,8 @@ import {
   UpdateMapTestInviteDto,
   MapPreSignedUrlDto,
   VALIDATION_PIPE_CONFIG,
-  CreateMapVersionDto
+  CreateMapVersionDto,
+  FeaturedMapsForGamemodeDto
 } from '../../dto';
 import { BypassJwtAuth, BypassLimited, LoggedInUser } from '../../decorators';
 import { ParseInt32SafePipe, ParseFilesPipe } from '../../pipes';
@@ -91,6 +92,7 @@ import { MapReviewService } from '../map-review/map-review.service';
 import { LeaderboardStatsDto } from '../../dto/run/leaderboard-stats.dto';
 import { LeaderboardService } from '../runs/leaderboard.service';
 import { MapListService } from './map-list.service';
+import { MapFeaturedService } from './map-featured.service';
 import { KillswitchGuard } from '../killswitch/killswitch.guard';
 import { Killswitch } from '../killswitch/killswitch.decorator';
 import { MapReviewStatsDto } from '../../dto/map/map-review-stats.dto';
@@ -110,7 +112,8 @@ export class MapsController {
     private readonly mapTestInviteService: MapTestInviteService,
     private readonly runsService: LeaderboardRunsService,
     private readonly leaderboardService: LeaderboardService,
-    private readonly mapListService: MapListService
+    private readonly mapListService: MapListService,
+    private readonly mapFeaturedService: MapFeaturedService
   ) {}
 
   //#region Maps
@@ -740,5 +743,24 @@ export class MapsController {
     return this.mapReviewService.getReviewStats(mapID, userID);
   }
 
-  //endregion
+  //#endregion
+
+  //#region Featured Maps
+
+  @Get('/featured')
+  @BypassJwtAuth()
+  @ApiOperation({
+    summary: 'Retrieve featured maps for each gamemode, refreshed every hour'
+  })
+  @ApiOkResponse({
+    type: FeaturedMapsForGamemodeDto,
+    isArray: true,
+    description:
+      'List of featured maps grouped by gamemode. Each entry contains up to 3 maps selected from different tier (difficulty) ranges.'
+  })
+  getFeaturedMaps(): Promise<FeaturedMapsForGamemodeDto[]> {
+    return this.mapFeaturedService.getFeaturedMaps();
+  }
+
+  //#endregion
 }

--- a/apps/backend/src/app/modules/maps/maps.module.ts
+++ b/apps/backend/src/app/modules/maps/maps.module.ts
@@ -7,6 +7,7 @@ import { RunsModule } from '../runs/runs.module';
 import { AdminModule } from '../admin/admin.module';
 import { MapsController } from './maps.controller';
 import { MapsService } from './maps.service';
+import { MapFeaturedService } from './map-featured.service';
 import { MapCreditsService } from './map-credits.service';
 import { MapImageService } from './map-image.service';
 import { MapTestInviteService } from './map-test-invite.service';
@@ -35,6 +36,7 @@ import { ValkeyModule } from '../valkey/valkey.module';
   controllers: [MapsController],
   providers: [
     MapsService,
+    MapFeaturedService,
     MapCreditsService,
     MapImageService,
     MapTestInviteService,


### PR DESCRIPTION
Run a cron job at the top of every hour to select up to 3 random maps within different tier ranges for each gamemode. These maps are stored in valkey and will be displayed at the top of the map selector with a "featured" banner.

Instead of storing a flat list of map ID's, group the featured maps by gamemode to avoid having duplicate maps across gamemodes. I am trying to avoid a situation where ahop_coast gets featured and then more than 3 featured maps show up in one gamemode.

Also the map query is running 36 times (12 active gamemodes * 3 tier slots), but I don't think this is an issue since it only runs hourly and also avoids needing to load a ton of maps in memory.

### Screenshots (if applicable)

<img width="1091" height="856" alt="image" src="https://github.com/user-attachments/assets/ab2ed43b-3262-4c83-9416-e6f797c38155" />

### Checks

- [ ] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [ ] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
