### PR TITLE
feat(back): provide custom request throttler tracker and trust proxy IP

### DIFF
--- a/apps/backend/src/app/app.module.ts
+++ b/apps/backend/src/app/app.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { APP_FILTER, APP_GUARD } from '@nestjs/core';
+import { APP_FILTER } from '@nestjs/core';
 import { LoggerModule, Params as PinoParams } from 'nestjs-pino';
 import pino from 'pino';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { ThrottlerGuard, ThrottlerModule, seconds } from '@nestjs/throttler';
+import { ThrottlerModule, seconds } from '@nestjs/throttler';
 import { SentryModule } from '@sentry/nestjs/setup';
 import { ScheduleModule } from '@nestjs/schedule';
 import * as Sentry from '@sentry/node';
@@ -186,10 +186,6 @@ import { ValkeyModule } from './modules/valkey/valkey.module';
     {
       provide: APP_FILTER,
       useClass: ExceptionHandlerFilter
-    },
-    {
-      provide: APP_GUARD,
-      useClass: ThrottlerGuard
     }
   ]
 })

--- a/apps/backend/src/app/modules/auth/auth.module.ts
+++ b/apps/backend/src/app/modules/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { JwtGuard } from './jwt/jwt.guard';
 import { JwtAuthService } from './jwt/jwt-auth.service';
 import { SteamOpenIDService } from './steam/steam-openid.service';
 import { LimitedGuard } from './limited.guard';
+import { UserIPThrottlerGuard } from './user-ip-throttler.guard';
 
 @Module({
   imports: [
@@ -34,6 +35,12 @@ import { LimitedGuard } from './limited.guard';
     {
       provide: APP_GUARD,
       useClass: LimitedGuard
+    },
+    {
+      // Provide throttler guard here instread of the app module
+      // so that it runs after the request user is set
+      provide: APP_GUARD,
+      useClass: UserIPThrottlerGuard
     },
     JwtAuthService,
     SteamOpenIDService

--- a/apps/backend/src/app/modules/auth/user-ip-throttler.guard.ts
+++ b/apps/backend/src/app/modules/auth/user-ip-throttler.guard.ts
@@ -1,0 +1,13 @@
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { Injectable } from '@nestjs/common';
+import { FastifyRequest } from 'fastify';
+
+@Injectable()
+export class UserIPThrottlerGuard extends ThrottlerGuard {
+  protected async getTracker(req: FastifyRequest): Promise<string> {
+    const ip = req.ips.length > 0 ? req.ips[0] : req.ip;
+    const uid = req.user?.id ?? -1;
+
+    return `${uid}@${ip}`;
+  }
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -17,7 +17,7 @@ import cors from '@fastify/cors';
 import multipart from '@fastify/multipart';
 import { Logger } from 'nestjs-pino';
 import cluster from 'node:cluster';
-import { Environment } from './app/config';
+import { Config, Environment } from './app/config';
 import { AppModule } from './app/app.module';
 import { VALIDATION_PIPE_CONFIG } from './app/dto';
 import { FIRST_WORKER_ENV_VAR } from './clustered';
@@ -30,9 +30,13 @@ async function bootstrap() {
     return this.toString();
   };
 
+  const env: Environment = Config.env;
+
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,
-    new FastifyAdapter(),
+    new FastifyAdapter({
+      trustProxy: env === Environment.PRODUCTION
+    }),
     {
       bufferLogs: true, // Buffer logs until Pino is attached
       rawBody: true // So we can use RawBodyRequest
@@ -43,7 +47,6 @@ async function bootstrap() {
   app.useLogger(app.get(Logger));
 
   const configService = app.get(ConfigService);
-  const env: Environment = configService.getOrThrow('env');
 
   // Steam game auth and replay submission from game send raw octet-streams.
   // Steam auth we could limit to 2kb, but replays can be massive. Limiting


### PR DESCRIPTION
Fixes rate limit being applied globally on prod, since prod uses cloudflare tunnels
Also sets a tracker so that rate limiting is done per-user 

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `./create-migration.sh <name>` and committed the migration if I've made DB schema changes__
- [ ] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
