### PR TITLE
fix(ci): explicitly allow nx to parse generated prisma client

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -1,0 +1,1 @@
+!libs/db/src/generated


### PR DESCRIPTION
Will fix CI failing to build the docker container