### PR TITLE
fix(front): multi-use popovers not working

### DIFF
--- a/apps/frontend/src/app/components/chips/chips.component.html
+++ b/apps/frontend/src/app/components/chips/chips.component.html
@@ -1,4 +1,4 @@
-<div [style.anchor-name]="'--chip-anchor'" class="inputlike flex flex-wrap items-center gap-1.5 px-1.5 py-1.5">
+<div [style.anchor-name]="anchorName" class="inputlike flex flex-wrap items-center gap-1.5 px-1.5 py-1.5">
   <button
     (click)="op.toggle()"
     [mTooltip]="available.length > 0 ? 'Add ' + typeName : null"
@@ -41,7 +41,7 @@
     </div>
   }
 </div>
-<m-popover #op [classList]="'p-0'" anchorName="--chip-anchor">
+<m-popover #op [classList]="'p-0'" [anchorName]="anchorName">
   <div class="flex max-w-xl flex-wrap gap-2">
     @for (chip of available; track $index) {
       <button

--- a/apps/frontend/src/app/components/chips/chips.component.ts
+++ b/apps/frontend/src/app/components/chips/chips.component.ts
@@ -59,6 +59,8 @@ export class ChipsComponent implements ControlValueAccessor {
 
   @Input() typeName = 'Chip';
 
+  protected readonly anchorName = `--chips-${Math.random().toString(36).substring(2, 12)}`;
+
   /**
    * You can provide a function that maps values to strings.
    */

--- a/apps/frontend/src/app/components/popover/popover.component.ts
+++ b/apps/frontend/src/app/components/popover/popover.component.ts
@@ -27,6 +27,9 @@ export class PopoverComponent {
   /**
    * https://www.oddbird.net/2025/01/29/anchor-position-validity/
    * an anchor should typically be a sibling element, or sibling to an ancestor, but not a direct ancestor
+   * Name must include "--".
+   * Each name must be unique, if you need to dynamically generate anchor names, you can do the following:
+   * protected readonly anchorName = `--someMenu-${Math.random().toString(36).substring(2, 12)}`;
    */
   @Input() anchorName: string;
 

--- a/apps/frontend/src/app/components/search/user-search.component.html
+++ b/apps/frontend/src/app/components/search/user-search.component.html
@@ -1,5 +1,5 @@
-<div [style.anchor-scope]="'--popover-anchor'">
-  <div #searchMain [style.anchor-name]="'--popover-anchor'" class="relative flex w-full items-center gap-2">
+<div [style.anchor-scope]="anchorName">
+  <div #searchMain [style.anchor-name]="anchorName" class="relative flex w-full items-center gap-2">
     <input
       class="textinput min-w-[15rem] flex-grow"
       [mSpinner]="search.pending"
@@ -18,7 +18,7 @@
     />
   </div>
   @if (useOverlay) {
-    <m-popover #searchOverlay anchorName="--popover-anchor">
+    <m-popover #searchOverlay [anchorName]="anchorName">
       <ng-container *ngTemplateOutlet="results" />
     </m-popover>
   } @else {

--- a/apps/frontend/src/app/components/search/user-search.component.ts
+++ b/apps/frontend/src/app/components/search/user-search.component.ts
@@ -54,6 +54,7 @@ export class UserSearchComponent
   public itemsName = 'users';
   protected searchBySteam = false;
   protected selectedIdx = 0;
+  protected readonly anchorName = `--userSearch-${Math.random().toString(36).substring(2, 12)}`;
 
   /**
    * Show a button for opening the user profile in a separate tab. Used when a


### PR DESCRIPTION
Fixes issue with not being able to edit Required Games, also fixed previously half-working user search popovers.
The problem was multiple popovers with the same name.
Solution is kinda janky, but works for now. Same thing as I did for the dropdown component before

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
