### PR TITLE
fix(back): fix problems related to dynamic ranking

### DIFF
--- a/apps/backend/src/app/modules/runs/leaderboard-runs.service.ts
+++ b/apps/backend/src/app/modules/runs/leaderboard-runs.service.ts
@@ -47,7 +47,8 @@ export class LeaderboardRunsService {
     });
 
     if (
-      [query.userIDs, query.steamIDs, query.filter].filter(Boolean).length > 1
+      [query.userIDs, query.steamIDs, query.filter?.[0]].filter(Boolean)
+        .length > 1
     ) {
       throw new BadRequestException(
         'Only one of userIDs, steamIDs or filter may be included'

--- a/apps/backend/src/app/modules/session/run/run-session.service.ts
+++ b/apps/backend/src/app/modules/session/run/run-session.service.ts
@@ -544,7 +544,7 @@ export class RunSessionService {
         }
       });
     } else {
-      newPB = await this.db.leaderboardRun.create({
+      newPB = await tx.leaderboardRun.create({
         data: {
           userID: submittedRun.userID,
           mapID: submittedRun.mapID,
@@ -562,11 +562,12 @@ export class RunSessionService {
     }
 
     newPB.rank = await this.leaderboardRunsDbService.getUserRank({
+      transaction: tx,
       mapID: submittedRun.mapID,
       gamemode: submittedRun.gamemode,
       trackType: submittedRun.trackType,
       trackNum: submittedRun.trackNum,
-      style: Style.NORMAL,
+      style: style,
       userID: submittedRun.userID
     });
 


### PR DESCRIPTION
Fixes ranks in chat messages being shown for previous run
Fixes ranks being -1 for kz runs
Fixes fetching leaderboards for lobbies

### Checks

- [ ] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [ ] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [ ] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [ ] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [ ] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
