### PR TITLE
Use per-gamemode channels for discord map status notifications

### DIFF
--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -22,7 +22,6 @@ import {
   TrackType,
   LeaderboardType,
   FlatMapList,
-  GamemodeCategory,
   MAX_OPEN_MAP_SUBMISSIONS,
   MapTag,
   MapSortType,
@@ -5481,7 +5480,7 @@ describe('Maps', () => {
       );
     });
 
-    it('should send multiple discord notifications for different gamemode categories', async () => {
+    it('should send multiple discord notifications for different gamemodes', async () => {
       const map = await db.createMap({
         ...createMapData,
         status: MapStatus.FINAL_APPROVAL,
@@ -5553,8 +5552,8 @@ describe('Maps', () => {
 
       const requestUrls = restPostMock.mock.calls.map((call) => call[0]);
       expect(requestUrls.sort()).toEqual(
-        [GamemodeCategory.RJ, GamemodeCategory.CONC].map((gc) =>
-          Routes.channelMessages(gc.toString())
+        [Gamemode.CONC, Gamemode.RJ].map((gm) =>
+          Routes.channelMessages(gm.toString())
         )
       );
 

--- a/apps/backend/src/app/config/config.interface.ts
+++ b/apps/backend/src/app/config/config.interface.ts
@@ -1,4 +1,4 @@
-﻿import { GamemodeCategory } from '@momentum/constants';
+﻿import { Gamemode } from '@momentum/constants';
 import * as pino from 'pino';
 
 export enum Environment {
@@ -67,7 +67,7 @@ export interface ConfigInterface {
     guild: string;
     contentApprovalChannel: string;
     reviewChannel: string;
-    statusChannels: Record<GamemodeCategory, string>;
+    statusChannels: Record<Gamemode, string>;
     unrankedNotifications: boolean;
   };
   mapListUpdateSchedule: string;

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -13,7 +13,7 @@
   JWT_REFRESH_EXPIRY_TIME,
   MAX_MAP_IMAGE_SIZE,
   PRE_SIGNED_URL_EXPIRE_TIME,
-  GamemodeCategory
+  Gamemode
 } from '@momentum/constants';
 import * as Enum from '@momentum/enum';
 import { ConfigInterface, Environment } from './config.interface';
@@ -95,14 +95,13 @@ export const ConfigFactory = (): ConfigInterface => {
         process.env['DISCORD_CONTENT_APPROVAL_CHANNEL'] ?? '',
       reviewChannel: process.env['DISCORD_REVIEW_CHANNEL'] ?? '',
       statusChannels: Object.fromEntries(
-        Enum.values(GamemodeCategory).map((cat) => [
-          cat,
+        Enum.values(Gamemode).map((gm) => [
+          gm,
           isTest
             ? ''
-            : (process.env[`DISCORD_STATUS_CHANNEL_${GamemodeCategory[cat]}`] ??
-              '')
+            : (process.env[`DISCORD_STATUS_CHANNEL_${Gamemode[gm]}`] ?? '')
         ])
-      ) as Record<GamemodeCategory, string>,
+      ) as Record<Gamemode, string>,
       unrankedNotifications:
         process.env['DISCORD_UNRANKED_NOTIFICATIONS'] === 'true'
     },

--- a/apps/backend/src/app/modules/maps/map-discord-notifications.service.ts
+++ b/apps/backend/src/app/modules/maps/map-discord-notifications.service.ts
@@ -12,7 +12,6 @@ import {
 import { DiscordService } from '../discord/discord.service';
 import {
   MapSubmissionSuggestion,
-  GamemodeCategories,
   GamemodeInfo,
   TrackType,
   imgLargePath,
@@ -22,7 +21,6 @@ import {
   Gamemode,
   steamAvatarUrl,
   MapStatuses,
-  GamemodeCategory,
   MapReviewSuggestion,
   TrackTypeName,
   mapTagEnglishName
@@ -119,21 +117,16 @@ export class MapDiscordNotifications {
       }
     });
 
-    const categories = this.getGamemodeCategories(
-      info.rankedGamemodes,
-      info.unrankedGamemodes
-    );
-
-    await this.broadcastToCategories(
+    await this.broadcastToGamemodes(
       `:warning: A new map is available for public testing! :warning: Post feedback in ${thread.url}`,
       mapEmbed,
-      categories.ranked
+      info.rankedGamemodes
     );
     if (this.config.getOrThrow('discord.unrankedNotifications'))
-      await this.broadcastToCategories(
+      await this.broadcastToGamemodes(
         `:warning: A new **UNRANKED** map is available for public testing! :warning: Post feedback in ${thread.url}`,
         mapEmbed,
-        categories.unranked
+        info.unrankedGamemodes
       );
   }
 
@@ -148,22 +141,17 @@ export class MapDiscordNotifications {
       info.leaderboards
     );
 
-    const categories = this.getGamemodeCategories(
-      info.rankedGamemodes,
-      info.unrankedGamemodes
-    );
-
-    await this.broadcastToCategories(
+    await this.broadcastToGamemodes(
       ':white_check_mark: A new map has been fully approved and added! :white_check_mark:',
       mapEmbed,
-      categories.ranked,
+      info.rankedGamemodes,
       true
     );
     if (this.config.getOrThrow('discord.unrankedNotifications'))
-      await this.broadcastToCategories(
+      await this.broadcastToGamemodes(
         ':white_check_mark: A new **UNRANKED** map has been fully approved and added! :white_check_mark:',
         mapEmbed,
-        categories.unranked,
+        info.unrankedGamemodes,
         true
       );
   }
@@ -289,20 +277,20 @@ export class MapDiscordNotifications {
     return embed;
   }
 
-  private async broadcastToCategories(
+  private async broadcastToGamemodes(
     text: string,
     embed: APIEmbed,
-    categories: Array<GamemodeCategory>,
+    gamemodes: Array<Gamemode>,
     crosspost = false
   ): Promise<void> {
-    await Promise.all(
-      categories.map(async (category) => {
-        if (!this.discord.isEnabled()) return;
+    const channelIDs = gamemodes
+      .map((gm) => this.config.getOrThrow(`discord.statusChannels.${gm}`))
+      .filter(Boolean)
+      .filter((id, i, arr) => arr.indexOf(id) === i);
 
-        const channelID = this.config.getOrThrow(
-          `discord.statusChannels.${category}`
-        );
-        if (channelID === '') return;
+    await Promise.all(
+      channelIDs.map(async (channelID) => {
+        if (!this.discord.isEnabled()) return;
 
         // Cached in Discord.js
         const channel = await this.discord.channels.fetch(channelID);
@@ -374,27 +362,6 @@ export class MapDiscordNotifications {
         .filter(({ type }) => type === LeaderboardType.UNRANKED)
         .map(({ gamemode }) => gamemode)
     };
-  }
-
-  private getGamemodeCategories(
-    rankedGamemodes: Gamemode[],
-    unrankedGamemodes: Gamemode[]
-  ): {
-    ranked: GamemodeCategory[];
-    unranked: GamemodeCategory[];
-  } {
-    const ranked = GamemodeCategories.entries()
-      .toArray()
-      .filter(([, modes]) => modes.some((gm) => rankedGamemodes.includes(gm)))
-      .map(([cat]) => cat);
-
-    const unranked = GamemodeCategories.entries()
-      .toArray()
-      .filter(([, modes]) => modes.some((gm) => unrankedGamemodes.includes(gm)))
-      .map(([cat]) => cat)
-      .filter((cat) => !ranked.includes(cat));
-
-    return { ranked, unranked };
   }
 }
 

--- a/apps/backend/src/app/modules/maps/maps.service.ts
+++ b/apps/backend/src/app/modules/maps/maps.service.ts
@@ -1429,7 +1429,7 @@ export class MapsService {
           )
         ) {
           void this.discordNotificationService.sendMapContentApprovalNotification(
-            await this.getMapInfoForNotification(map.id)
+            await this.getMapInfoForNotification(map.id, tx)
           );
         } else if (
           newStatus === MapStatus.PUBLIC_TESTING &&
@@ -1438,7 +1438,7 @@ export class MapsService {
           )
         ) {
           void this.discordNotificationService.sendPublicTestingNotification(
-            await this.getMapInfoForNotification(map.id)
+            await this.getMapInfoForNotification(map.id, tx)
           );
         } else if (
           newStatus === MapStatus.APPROVED &&
@@ -1447,7 +1447,7 @@ export class MapsService {
           )
         ) {
           void this.discordNotificationService.sendApprovedNotification(
-            await this.getMapInfoForNotification(map.id)
+            await this.getMapInfoForNotification(map.id, tx)
           );
         }
       }
@@ -2289,8 +2289,11 @@ export class MapsService {
     });
   }
 
-  async getMapInfoForNotification(mapID: number) {
-    return await this.db.mMap.findUnique({
+  async getMapInfoForNotification(
+    mapID: number,
+    transaction?: ExtendedPrismaServiceTransaction
+  ) {
+    return await (transaction ? transaction : this.db).mMap.findUnique({
       where: { id: mapID },
       include: {
         info: true,

--- a/apps/frontend/src/app/pages/admin/admin-activity/admin-activity-entry/admin-activity-entry.component.ts
+++ b/apps/frontend/src/app/pages/admin/admin-activity/admin-activity-entry/admin-activity-entry.component.ts
@@ -141,7 +141,7 @@ export class AdminActivityEntryComponent implements OnInit {
         // provided, we just show that.
         const data = activity.oldData;
         return {
-          actionText: `deleted run on ${data.map.name} (mapID ${data.mapID} trackType ${data.trackType}, trackNum ${data.trackNum}), style ${data.style} for user`,
+          actionText: `deleted run on ${data.mmap.name} (mapID ${data.mapID} trackType ${data.trackType}, trackNum ${data.trackNum}), style ${data.style} for user`,
           targetName: data.user.alias,
           targetLink: '/profile/' + data.user.id
         };


### PR DESCRIPTION
Also contains a small fix for admin activity component on front

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
