### PR TITLE
refactor(front): replace primeng tooltips

### DIFF
--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -71,6 +71,7 @@
           "outputHashing": "all"
         },
         "development": {
+          "outputHashing": "media",
           "buildOptimizer": false,
           "optimization": false,
           "extractLicenses": false,
@@ -82,7 +83,7 @@
       "defaultConfiguration": "production"
     },
     "serve": {
-      "executor": "@angular-devkit/build-angular:dev-server",
+      "executor": "@nx/angular:dev-server",
       "options": {
         "proxyConfig": "apps/frontend/proxy.conf.json"
       },

--- a/apps/frontend/src/app/components/chips/chips.component.html
+++ b/apps/frontend/src/app/components/chips/chips.component.html
@@ -1,7 +1,7 @@
-<div [style.anchor-name]="anchorName" class="inputlike flex flex-wrap items-center gap-1.5 px-1.5 py-1.5">
+<div #chipsAnchor class="inputlike flex flex-wrap items-center gap-1.5 px-1.5 py-1.5">
   <button
     (click)="op.toggle()"
-    [mTooltip]="available.length > 0 ? 'Add ' + typeName : null"
+    [mTooltip]="available.length > 0 ? 'Add ' + typeName : undefined"
     [disabled]="available.length === 0"
     type="button"
     class="grid size-7 rounded bg-white bg-opacity-10 p-0.5 text-white opacity-50 transition-colors [&:not(:disabled)]:hover:bg-opacity-20 [&:not(:disabled)]:hover:opacity-80"
@@ -11,7 +11,7 @@
   <button
     type="button"
     (click)="reset()"
-    [mTooltip]="available.length > 0 ? 'Reset ' + typeName : null"
+    [mTooltip]="available.length > 0 ? 'Reset ' + typeName : undefined"
     [disabled]="selected.length === 0"
     class="grid size-7 rounded bg-white bg-opacity-10 p-0.5 text-white opacity-50 transition-colors [&:not(:disabled)]:hover:bg-opacity-20 [&:not(:disabled)]:hover:opacity-80"
   >
@@ -41,7 +41,7 @@
     </div>
   }
 </div>
-<m-popover #op [classList]="'p-0'" [anchorName]="anchorName">
+<m-popover #op [classList]="'p-0'" [anchor]="chipsAnchor">
   <div class="flex max-w-xl flex-wrap gap-2">
     @for (chip of available; track $index) {
       <button

--- a/apps/frontend/src/app/components/chips/chips.component.ts
+++ b/apps/frontend/src/app/components/chips/chips.component.ts
@@ -59,8 +59,6 @@ export class ChipsComponent implements ControlValueAccessor {
 
   @Input() typeName = 'Chip';
 
-  protected readonly anchorName = `--chips-${Math.random().toString(36).substring(2, 12)}`;
-
   /**
    * You can provide a function that maps values to strings.
    */

--- a/apps/frontend/src/app/components/layout/header.component.css
+++ b/apps/frontend/src/app/components/layout/header.component.css
@@ -1,6 +1,6 @@
 /*
 * This component's game UI sibling lives at
-* https://github.com/momentum-mod/panorama/blob/master/styles/pages/main-menu.scss#L131 
+* https://github.com/momentum-mod/panorama/blob/master/styles/pages/main-menu.scss#L131
 */
 
 /* This isn't a pointless div, it's needed for variable sidenav width (seriously) */
@@ -37,7 +37,7 @@
     }
   }
 
-  & m-icon {
+  & > * > m-icon {
     padding: 0.875rem;
     width: 4.5rem;
 

--- a/apps/frontend/src/app/components/layout/header.component.html
+++ b/apps/frontend/src/app/components/layout/header.component.html
@@ -6,12 +6,15 @@
     <img src="assets/images/logo.svg" width="279" height="45" alt="Momentum Mod Logo" />
   </a>
 
-  <div class="item" [style.anchor-name]="'--multisearch-anchor'" (click)="searchOverlay.toggle()">
+  <div #multisearchAnchor class="item" (click)="searchOverlay.toggle()">
     <m-icon class="h-auto" icon="magnify"></m-icon>
   </div>
+  <m-popover #searchOverlay [anchor]="multisearchAnchor">
+    <m-multisearch (selected)="searchOverlay.hide()" />
+  </m-popover>
 
   @if (localUserService.user | async) {
-    <div class="item relative" [style.anchor-name]="'--notification-anchor'" (click)="notificationsOverlay.toggle()">
+    <div #notificationAnchor class="item relative" (click)="notificationsOverlay.toggle()">
       @if (unreadNotificationsCount > 0) {
         <p class="badge badge-blue absolute right-1.5 top-1.5 z-10">
           {{ unreadNotificationsCount.toString() }}
@@ -22,24 +25,21 @@
 
     <p-menu #userMenu [model]="profileDropdownMenu" [popup]="true"></p-menu>
     <m-player-card (click)="userMenu.toggle($event)" />
+    <m-popover
+      #notificationsOverlay
+      [anchor]="notificationAnchor"
+      (onShow)="markingAsReadEnabled = true"
+      (onHide)="markingAsReadEnabled = false"
+    >
+      <m-notifications-menu
+        class="max-h-[80vh] w-[30rem]"
+        (unreadNotificationsCount)="updateUnreadNotificationsCount($event)"
+        [markingAsReadEnabled]="markingAsReadEnabled"
+      />
+    </m-popover>
   } @else {
     <button type="button" class="ml-2 mr-3 transition-all hover:brightness-110" (click)="localUserService.login()">
       <img src="/assets/images/steam-login-green-large.png" />
     </button>
   }
 </div>
-<m-popover #searchOverlay anchorName="--multisearch-anchor">
-  <m-multisearch (selected)="searchOverlay.hide()" />
-</m-popover>
-<m-popover
-  #notificationsOverlay
-  anchorName="--notification-anchor"
-  (onShow)="markingAsReadEnabled = true"
-  (onHide)="markingAsReadEnabled = false"
->
-  <m-notifications-menu
-    class="max-h-[80vh] w-[30rem]"
-    (unreadNotificationsCount)="updateUnreadNotificationsCount($event)"
-    [markingAsReadEnabled]="markingAsReadEnabled"
-  />
-</m-popover>

--- a/apps/frontend/src/app/components/layout/sidenav.component.html
+++ b/apps/frontend/src/app/components/layout/sidenav.component.html
@@ -3,12 +3,17 @@
     <p class="category">{{ category.title }}</p>
     @for (item of category.items; track item.title) {
       @if (item.external) {
-        <a [href]="item.link" class="item" target="_blank" [mTooltip]="item.title" [tooltipDisabled]="!collapsed">
+        <a [href]="item.link" class="item" target="_blank" [mTooltip]="item.title" [tooltipDisabled]="(collapsed | async) === false">
           <m-icon [icon]="item.icon" [pack]="item.pack" />
           <p>{{ item.title }}</p>
         </a>
       } @else {
-        <a [routerLink]="[item.link]" class="item" [mTooltip]="category.title + ' - ' + item.title" [tooltipDisabled]="!collapsed">
+        <a
+          [routerLink]="[item.link]"
+          class="item"
+          [mTooltip]="category.title + ' - ' + item.title"
+          [tooltipDisabled]="(collapsed | async) === false"
+        >
           <m-icon [icon]="item.icon" [pack]="item.pack" />
           <p>{{ item.title }}</p>
         </a>

--- a/apps/frontend/src/app/components/map-forms/map-credits-selection/map-credits-selection.component.html
+++ b/apps/frontend/src/app/components/map-forms/map-credits-selection/map-credits-selection.component.html
@@ -1,11 +1,13 @@
 @for (type of MapCreditNames | keyvalue; track type) {
   <div class="flex h-full flex-col">
-    <p class="mb-1 ml-1 text-xl font-medium">
-      {{ type.value }}
+    <div class="mb-1 ml-1 flex flex-row items-center gap-1">
+      <p class="text-xl font-medium">
+        {{ type.value }}
+      </p>
       @if (type.key === MapCreditType.AUTHOR) {
-        <m-icon icon="asterisk" class="mb-0.5 p-0.5 align-middle" mTooltip="Required" />
+        <m-icon icon="asterisk" class="p-0.5 align-middle" mTooltip="Required" />
       }
-    </p>
+    </div>
     <div
       class="inputlike flex-grow rounded border bg-black bg-opacity-25"
       id="{{ type.key }}"
@@ -14,8 +16,8 @@
       (cdkDropListDropped)="drop($event)"
       [cdkDropListConnectedTo]="connectedTo"
       mTooltip
-      [tooltipContext]="type.key"
-      tooltipPosition="top"
+      [tooltipId]="type.key.toString()"
+      [tooltipDuration]="2000"
       tooltipEvent="noop"
     >
       @for (credit of value[type.key]; track credit) {
@@ -63,22 +65,21 @@
         />
       </div>
     </ng-template>
-
-    <ng-template #creditsInfo>
-      <div class="prose p-3">
-        <p>
-          Placeholder users are a way to credit someone that doesn't have a Momentum account. Just submit an alias and a 'placeholder'
-          account will be created on approval.
-        </p>
-        <p>
-          If that person signs up for Momentum in the future, they can contact an admin to have any placeholder accounts merged into their
-          real account.
-        </p>
-        <p>
-          If the person you want to credit may have been involved with other maps in the past, try searching for their username to see if
-          there exists any other placeholders already (displayed with a question mark icon).
-        </p>
-      </div>
-    </ng-template>
   </div>
 }
+<ng-template #creditsInfo>
+  <div class="prose p-3">
+    <p>
+      Placeholder users are a way to credit someone that doesn't have a Momentum account. Just submit an alias and a 'placeholder' account
+      will be created on approval.
+    </p>
+    <p>
+      If that person signs up for Momentum in the future, they can contact an admin to have any placeholder accounts merged into their real
+      account.
+    </p>
+    <p>
+      If the person you want to credit may have been involved with other maps in the past, try searching for their username to see if there
+      exists any other placeholders already (displayed with a question mark icon).
+    </p>
+  </div>
+</ng-template>

--- a/apps/frontend/src/app/components/map-forms/map-credits-selection/map-credits-selection.component.ts
+++ b/apps/frontend/src/app/components/map-forms/map-credits-selection/map-credits-selection.component.ts
@@ -52,7 +52,8 @@ export class MapCreditsSelectionComponent implements ControlValueAccessor {
   protected value: GroupedMapCredits;
 
   protected readonly MapCreditType = MapCreditType;
-  protected readonly MapCreditNames = MapCreditNames;
+  protected readonly MapCreditNames: ReadonlyMap<MapCreditType, string> =
+    MapCreditNames;
 
   protected readonly connectedTo = Enum.values(MapCreditType).map(String);
 
@@ -68,12 +69,15 @@ export class MapCreditsSelectionComponent implements ControlValueAccessor {
       .getAll()
       .find((userEntry) => userEntry.userID === user.id);
     if (existingUserCredit) {
-      TooltipDirective.findByContext(this.tooltips, type).setAndShow(
-        `User is already in the "${MapCreditNames.get(
-          existingUserCredit.type
-        )}" credits, just drag the credit instead!`,
-        true
-      );
+      this.tooltips
+        .find((item) => {
+          return item.tooltipId === type.toString();
+        })
+        .setAndShow(
+          `User is already in the "${MapCreditNames.get(
+            existingUserCredit.type
+          )}" credits, just drag the credit instead!`
+        );
     } else {
       searchComponent.resetSearchBox();
       this.value.add({ user, type, description: null });
@@ -99,12 +103,15 @@ export class MapCreditsSelectionComponent implements ControlValueAccessor {
           placeholderEntry.alias === searchComponent.search.value
       );
     if (existingPlaceholderCredit) {
-      TooltipDirective.findByContext(this.tooltips, type).setAndShow(
-        `Placeholder is already in the "${MapCreditNames.get(
-          existingPlaceholderCredit.type
-        )}" credits, just drag the credit instead!`,
-        true
-      );
+      this.tooltips
+        .find((item) => {
+          return item.tooltipId === type.toString();
+        })
+        .setAndShow(
+          `Placeholder is already in the "${MapCreditNames.get(
+            existingPlaceholderCredit.type
+          )}" credits, just drag the credit instead!`
+        );
       return;
     }
 

--- a/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.html
+++ b/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.html
@@ -1,9 +1,9 @@
-<div class="flex gap-4 md:flex-wrap" [formGroup]="formGroup">
-  <div class="grid h-fit max-w-[30%] gap-4 [grid-template-columns:auto_1fr]">
+<div class="flex flex-wrap gap-4" [formGroup]="formGroup">
+  <div class="grid h-fit w-full auto-rows-[1fr] grid-cols-[auto_1fr] gap-4 lg:max-w-lg">
     <div class="flex flex-col">
       <label class="my-auto text-lg leading-4">
         Map Name
-        <m-icon icon="tooltip-question-outline" class="ml-1 align-middle" [mTooltip]="mapNameInfo" />
+        <m-icon icon="tooltip-question-outline" class="ml-1 align-middle" [mTooltip]="mapNameInfo" tooltipPosition="top span-right" />
         <ng-template #mapNameInfo>
           <div class="prose p-3">
             <p>
@@ -17,26 +17,28 @@
       <span class="text-sm italic leading-4 text-gray-200">Required </span>
     </div>
     <input
+      #mapNameTooltip="tooltip"
       id="name"
       class="textinput textinput-validated !max-w-full"
       type="text"
       mTooltip
-      tooltipContext="mapNameError"
       tooltipEvent="noop"
       [formControl]="name"
     />
     <div class="flex flex-col">
       <label class="my-auto text-lg leading-4">
         Submission Type
-        <m-icon icon="tooltip-question-outline" class="mb-[1px] ml-0.5 align-middle" [mTooltip]="subType" />
+        <m-icon
+          icon="tooltip-question-outline"
+          class="mb-[1px] ml-0.5 align-middle"
+          [mTooltip]="subType"
+          tooltipPosition="top span-right"
+        />
         <ng-template #subType><m-submission-type-info /></ng-template>
       </label>
       <span class="text-sm italic leading-4 text-gray-200">Required</span>
     </div>
     <p-select
-      mTooltip
-      tooltipContext="mapNameError"
-      tooltipEvent="noop"
       class="textinput-validate"
       [formControl]="submissionType"
       [options]="mapSubmissionTypeOptions"
@@ -47,7 +49,12 @@
     <div class="flex flex-col">
       <label for="creationDate" class="my-auto text-lg leading-4">
         Creation Date
-        <m-icon icon="tooltip-question-outline" class="ml-1 align-middle" [mTooltip]="mapCreationDateInfo" />
+        <m-icon
+          icon="tooltip-question-outline"
+          class="ml-1 align-middle"
+          [mTooltip]="mapCreationDateInfo"
+          tooltipPosition="top span-right"
+        />
         <ng-template #mapCreationDateInfo>
           <div class="prose p-3">
             <p>This is the date the map was finished.</p>
@@ -64,7 +71,12 @@
     <p-date-picker id="creationDate" class="w-full [&>*]:w-full" [maxDate]="maxDate" [formControl]="creationDate" appendTo="body" utc />
     <label for="youtubeID" class="my-auto text-lg leading-4">
       Youtube ID
-      <m-icon icon="tooltip-question-outline" class="mb-[1px] ml-0.5 align-middle" [mTooltip]="youtubeIDInfo" />
+      <m-icon
+        icon="tooltip-question-outline"
+        class="mb-[1px] ml-0.5 align-middle"
+        [mTooltip]="youtubeIDInfo"
+        tooltipPosition="top span-right"
+      />
       <ng-template #youtubeIDInfo>
         <div class="prose p-3">
           <p>An optional Youtube video showcasing your map.</p>
@@ -82,7 +94,12 @@
     />
     <label for="requiredGames" class="my-auto text-lg leading-4">
       Required Games
-      <m-icon icon="tooltip-question-outline" class="mb-[1px] ml-0.5 align-middle" [mTooltip]="requiredGamesInfo" />
+      <m-icon
+        icon="tooltip-question-outline"
+        class="mb-[1px] ml-0.5 align-middle"
+        [mTooltip]="requiredGamesInfo"
+        tooltipPosition="top span-right"
+      />
       <ng-template #requiredGamesInfo>
         <div class="prose p-3">
           <p>Source games that the map uses assets from</p>
@@ -99,41 +116,39 @@
     />
   </div>
   <div class="flex flex-1 flex-col">
-    <div class="flex flex-1 flex-col">
-      <div class="mb-2 flex">
-        <div class="my-auto flex flex-grow items-center">
-          <label for="description" class="text-lg">
-            Description
-            <m-icon icon="tooltip-question-outline" class="ml-1 align-middle" [mTooltip]="descriptionInfo" />
-            <ng-template #descriptionInfo>
-              <div class="prose p-3">
-                <p>
-                  A general description of your map. You can include pretty much anything here, just keep in mind we have dedicated sections
-                  for credits, including special thanks!
-                </p>
-                <p>
-                  If you can't think of anything at all, just do something super simple like
-                  <i>"A short bhop map based on the life and works of Philip Seymour Hoffman"</i>.
-                </p>
-              </div>
-            </ng-template>
-          </label>
-        </div>
-        @if (MAX_MAP_DESCRIPTION_LENGTH / 2 < description.value.length) {
-          <span class="mr-2 mt-auto text-sm"
-            >{{ MAX_MAP_DESCRIPTION_LENGTH - description.value.length | plural: 'character' }} remaining</span
-          >
-        }
+    <div class="mb-2 flex">
+      <div class="my-auto flex flex-grow items-center">
+        <label for="description" class="text-lg">
+          Description
+          <m-icon icon="tooltip-question-outline" class="ml-1 align-middle" [mTooltip]="descriptionInfo" />
+          <ng-template #descriptionInfo>
+            <div class="prose p-3">
+              <p>
+                A general description of your map. You can include pretty much anything here, just keep in mind we have dedicated sections
+                for credits, including special thanks!
+              </p>
+              <p>
+                If you can't think of anything at all, just do something super simple like
+                <i>"A short bhop map based on the life and works of Philip Seymour Hoffman"</i>.
+              </p>
+            </div>
+          </ng-template>
+        </label>
       </div>
-      <textarea
-        id="description"
-        class="textinput textinput-validated flex-grow"
-        rows="2"
-        [formControl]="description"
-        [maxLength]="MAX_MAP_DESCRIPTION_LENGTH"
-        [placeholder]="'Minimum ' + MIN_MAP_DESCRIPTION_LENGTH + ' characters required'"
-      ></textarea>
+      @if (MAX_MAP_DESCRIPTION_LENGTH / 2 < description.value.length) {
+        <span class="mr-2 mt-auto text-sm"
+          >{{ MAX_MAP_DESCRIPTION_LENGTH - description.value.length | plural: 'character' }} remaining</span
+        >
+      }
     </div>
+    <textarea
+      id="description"
+      class="textinput textinput-validated flex-grow"
+      rows="2"
+      [formControl]="description"
+      [maxLength]="MAX_MAP_DESCRIPTION_LENGTH"
+      [placeholder]="'Minimum ' + MIN_MAP_DESCRIPTION_LENGTH + ' characters required'"
+    ></textarea>
   </div>
   @if (submissionType.value === MapSubmissionType.PORT) {
     <div class="flex flex-1 flex-col">

--- a/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.ts
+++ b/apps/frontend/src/app/components/map-forms/map-details-form/map-details-form.component.ts
@@ -3,9 +3,8 @@ import {
   DestroyRef,
   Input,
   OnInit,
-  QueryList,
-  ViewChildren,
-  inject
+  inject,
+  ViewChild
 } from '@angular/core';
 import {
   MapSubmissionType,
@@ -97,8 +96,7 @@ export class MapDetailsFormComponent implements OnInit {
       });
   }
 
-  @ViewChildren(TooltipDirective)
-  tooltips: QueryList<TooltipDirective>;
+  @ViewChild('mapNameTooltip') private mapNameTooltip: TooltipDirective;
 
   ngOnInit() {
     this.name.statusChanges
@@ -107,12 +105,8 @@ export class MapDetailsFormComponent implements OnInit {
   }
 
   onNameStatusChange(status: FormControlStatus) {
-    const tooltip = TooltipDirective.findByContext(
-      this.tooltips,
-      'mapNameError'
-    );
     if (status !== 'INVALID') {
-      tooltip.hide();
+      this.mapNameTooltip.hide();
       return;
     }
 
@@ -126,10 +120,12 @@ export class MapDetailsFormComponent implements OnInit {
       } else if (errors['pattern']) {
         str =
           'Name must consist of lowercase letters, _ and -, and cannot start with a number.';
+      } else if (errors['required']) {
+        str = 'Map name cannot be empty';
       }
-      tooltip.setAndShow(str);
+      this.mapNameTooltip.setAndShow(str);
     } else {
-      tooltip.hide();
+      this.mapNameTooltip.hide();
     }
   }
 

--- a/apps/frontend/src/app/components/map-forms/map-image-selection/map-image-selection.component.html
+++ b/apps/frontend/src/app/components/map-forms/map-image-selection/map-image-selection.component.html
@@ -11,10 +11,10 @@
   />
   <div class="flex flex-grow gap-4">
     <div class="lg:w-1/3">
-      <p class="mb-1 ml-1 text-lg">
-        Thumbnail
-        <m-icon icon="asterisk" class="mb-1 h-5 w-5 align-middle" mTooltip="Required" />
-      </p>
+      <div class="mb-1 ml-1 flex flex-row items-center gap-1">
+        <p class="text-lg">Thumbnail</p>
+        <m-icon icon="asterisk" class="h-5 w-5 align-middle" mTooltip="Required" />
+      </div>
       <!-- We want to keep setting the width and height of this container based on 1/3 width and 16/9
         aspect ratio at all times, so we use a hacky 1/1 grid to stack each item, so an item being
         dragged over existing thumbnail gets plonked on top of it.  -->

--- a/apps/frontend/src/app/components/map-forms/map-status-form/map-final-approval-form.component.html
+++ b/apps/frontend/src/app/components/map-forms/map-status-form/map-final-approval-form.component.html
@@ -4,7 +4,7 @@
       <div class="flex flex-col gap-8 bg-black bg-opacity-10 p-8 pt-6 shadow-inner">
         @for (leaderboard of group.value.leaderboards; track $index) {
           @if (leaderboard.trackType !== TrackType.STAGE) {
-            <div class="grid grid-cols-[auto_20rem_20rem] gap-12">
+            <div class="grid grid-cols-[auto_20rem] gap-12">
               <div class="flex flex-col gap-2">
                 <p>
                   <span class="text-xl font-medium">
@@ -112,12 +112,14 @@
                   />
                 </div>
               </div>
-              @if (leaderboard.averageTier) {
-                <p-chart type="bar" [data]="leaderboard.graphs.tiers" [options]="TierChartOptions" />
-              }
-              @if (leaderboard.averageRating) {
-                <p-chart type="bar" [data]="leaderboard.graphs.ratings" [options]="RatingChartOptions" />
-              }
+              <div class="flex flex-col">
+                @if (leaderboard.averageTier) {
+                  <p-chart class="flex-1" type="bar" [data]="leaderboard.graphs.tiers" [options]="TierChartOptions" />
+                }
+                @if (leaderboard.averageRating) {
+                  <p-chart class="flex-1" type="bar" [data]="leaderboard.graphs.ratings" [options]="RatingChartOptions" />
+                }
+              </div>
             </div>
           }
         }

--- a/apps/frontend/src/app/components/map-forms/map-test-invite-selection/map-test-invite-selection.component.html
+++ b/apps/frontend/src/app/components/map-forms/map-test-invite-selection/map-test-invite-selection.component.html
@@ -4,8 +4,8 @@
     'pointer-events-none opacity-25': disabled
   }"
 >
-  <div class="md:w-full lg:w-1/2">
-    <m-user-search #searchInput (selected)="addUser($event, searchInput)" mTooltip tooltipEvent="noop" />
+  <div class="md:w-full lg:w-1/2" mTooltip [tooltipDuration]="2000" tooltipEvent="noop">
+    <m-user-search #searchInput (selected)="addUser($event, searchInput)" />
   </div>
   <div class="flex flex-col overflow-y-auto rounded bg-black bg-opacity-25 py-2 md:w-full lg:w-1/2">
     @for (user of users; track user) {

--- a/apps/frontend/src/app/components/map-forms/map-test-invite-selection/map-test-invite-selection.component.ts
+++ b/apps/frontend/src/app/components/map-forms/map-test-invite-selection/map-test-invite-selection.component.ts
@@ -32,9 +32,9 @@ export class MapTestInviteSelectionComponent implements ControlValueAccessor {
 
   addUser(user: User, searchInput: UserSearchComponent): void {
     if (this.users.length >= this.MAX_TESTING_REQUESTS) {
-      this.tooltip.setAndShow('Maximum number of users reached!', true);
+      this.tooltip.setAndShow('Maximum number of users reached!');
     } else if (this.users.some(({ id }) => id === user.id)) {
-      this.tooltip.setAndShow('User already added!', true);
+      this.tooltip.setAndShow('User already added!');
     } else {
       searchInput.resetSearchBox();
       this.users.push(user);

--- a/apps/frontend/src/app/components/map-review/map-review-form.component.html
+++ b/apps/frontend/src/app/components/map-review/map-review-form.component.html
@@ -53,7 +53,10 @@
     }
     <button type="button" class="btn btn-blue btn-thin" (click)="suggs.addEmptyItem()">
       Add Tier/Ranking Suggestions
-      <m-icon class="ml-2" icon="tooltip-question-outline" [mTooltip]="suggestionInfo" />
+      <!--      div & styles needed here to revert button styles affecting the tooltip-->
+      <div class="ml-2 flex items-center justify-center text-start font-normal">
+        <m-icon icon="tooltip-question-outline" [mTooltip]="suggestionInfo" />
+      </div>
     </button>
     <ng-template #suggestionInfo>
       <div class="prose p-3">

--- a/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.html
+++ b/apps/frontend/src/app/components/map-review/map-review-suggestions-form.component.html
@@ -5,9 +5,9 @@
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Gamemode</th>
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Track Type</th>
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Track Number</th>
-        <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">
-          Tier
-          <m-icon icon="asterisk" class="mb-0.5 p-1 align-middle" mTooltip="Required" />
+        <th class="my-auto flex flex-row items-center gap-1 pl-1 pr-4">
+          <span class="text-left text-sm font-medium text-gray-200">Tier</span>
+          <m-icon icon="asterisk" class="size-4 align-middle" mTooltip="Required" />
         </th>
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Rating</th>
         <th class="my-auto pl-1 pr-4 text-left text-sm font-medium text-gray-200">Tags</th>

--- a/apps/frontend/src/app/components/popover/popover.component.css
+++ b/apps/frontend/src/app/components/popover/popover.component.css
@@ -1,4 +1,4 @@
-[popover] {
+:host {
   /* styling */
   background-color: #18181b;
   border: 1px solid rgb(255 255 255 / 0.05);
@@ -13,33 +13,16 @@
 
   /* positioning */
   position-try-fallbacks:
-    bottom span-left,
-    top span-right,
-    top span-left;
+    flip-block,
+    flip-inline,
+    flip-block flip-inline;
   position-try-order: most-width;
-  position-visibility: anchors-visible;
+  position-visibility: anchors-visible; /* for some reason doesn't work on firefox */
   position-area: bottom span-right;
-  position: fixed;
+  position: absolute;
 
   /* animations */
-  transition:
-    opacity 0.2s,
-    transform 0.2s,
-    display 0.2s allow-discrete;
-  opacity: 0;
-  /*transform: translateY(3rem);*/
-
-  &:popover-open {
-    opacity: 1;
-    /*transform: none;*/
-
-    @starting-style {
-      & {
-        opacity: 0;
-        /*transform: translateY(-1rem);*/
-      }
-    }
-  }
+  animation: fadeIn 0.1s ease-in;
 }
 
 /*TODO: animation, popover caret*/

--- a/apps/frontend/src/app/components/popover/popover.component.ts
+++ b/apps/frontend/src/app/components/popover/popover.component.ts
@@ -2,43 +2,33 @@ import {
   Component,
   ElementRef,
   EventEmitter,
+  inject,
   Input,
-  Output,
-  ViewChild
+  Output
 } from '@angular/core';
 
 @Component({
   selector: 'm-popover',
-  template: `
-    <div
-      #popover
-      popover
-      [style]="{
-        'position-anchor': this.anchorName
-      }"
-      (toggle)="onToggle($event)"
-    >
-      <ng-content />
-    </div>
-  `,
+  template: '<ng-content />',
+  host: {
+    popover: '',
+    '(toggle)': 'onToggle($event)'
+  },
   styleUrl: './popover.component.css'
 })
 export class PopoverComponent {
   /**
    * https://www.oddbird.net/2025/01/29/anchor-position-validity/
    * an anchor should typically be a sibling element, or sibling to an ancestor, but not a direct ancestor
-   * Name must include "--".
-   * Each name must be unique, if you need to dynamically generate anchor names, you can do the following:
-   * protected readonly anchorName = `--someMenu-${Math.random().toString(36).substring(2, 12)}`;
    */
-  @Input() anchorName: string;
+  @Input() anchor: HTMLElement;
 
   // eslint-disable-next-line @angular-eslint/no-output-on-prefix
   @Output() onShow = new EventEmitter();
   // eslint-disable-next-line @angular-eslint/no-output-on-prefix
   @Output() onHide = new EventEmitter();
 
-  @ViewChild('popover') popover: ElementRef<HTMLElement>;
+  private popover: ElementRef<HTMLElement> = inject(ElementRef);
 
   private active = false;
 
@@ -53,7 +43,9 @@ export class PopoverComponent {
   }
 
   show() {
-    this.popover.nativeElement.showPopover();
+    // @ts-expect-error need to update typescript to >v6 for popover API
+    // this creates implicit popovertarget/anchor association between elements, rather than needing to set in css
+    this.popover.nativeElement.showPopover({ source: this.anchor });
   }
 
   hide() {

--- a/apps/frontend/src/app/components/search/user-search.component.html
+++ b/apps/frontend/src/app/components/search/user-search.component.html
@@ -1,5 +1,5 @@
-<div [style.anchor-scope]="anchorName">
-  <div #searchMain [style.anchor-name]="anchorName" class="relative flex w-full items-center gap-2">
+<div>
+  <div #searchMain class="relative flex w-full items-center gap-2">
     <input
       class="textinput min-w-[15rem] flex-grow"
       [mSpinner]="search.pending"
@@ -18,7 +18,7 @@
     />
   </div>
   @if (useOverlay) {
-    <m-popover #searchOverlay [anchorName]="anchorName">
+    <m-popover #searchOverlay [anchor]="searchMain">
       <ng-container *ngTemplateOutlet="results" />
     </m-popover>
   } @else {

--- a/apps/frontend/src/app/components/search/user-search.component.ts
+++ b/apps/frontend/src/app/components/search/user-search.component.ts
@@ -54,7 +54,6 @@ export class UserSearchComponent
   public itemsName = 'users';
   protected searchBySteam = false;
   protected selectedIdx = 0;
-  protected readonly anchorName = `--userSearch-${Math.random().toString(36).substring(2, 12)}`;
 
   /**
    * Show a button for opening the user profile in a separate tab. Used when a

--- a/apps/frontend/src/app/directives/tooltip.directive.ts
+++ b/apps/frontend/src/app/directives/tooltip.directive.ts
@@ -1,186 +1,138 @@
-import { Tooltip as PTooltip, TooltipStyle } from 'primeng/tooltip';
-import { Directive, Input, QueryList, TemplateRef } from '@angular/core';
-import { UniqueComponentId } from 'primeng/utils';
-import { DomHandler } from 'primeng/dom';
+import {
+  Directive,
+  ElementRef,
+  Input,
+  Renderer2,
+  TemplateRef,
+  inject,
+  ViewContainerRef,
+  AfterViewInit,
+  OnChanges,
+  SimpleChanges
+} from '@angular/core';
 
-/**
- * Overriden PrimeNG Tooltip directive adding extra utilities for
- * programmatically displaying tooltips.
- *
- * https://primeng.org/tooltip
- * https://github.com/primefaces/primeng/blob/master/packages/primeng/src/tooltip/tooltip.ts
- */
 @Directive({
   selector: '[mTooltip]',
-  host: { class: 'p-element' },
-  standalone: true,
-  providers: [TooltipStyle]
+  exportAs: 'tooltip',
+  standalone: true
 })
-export class TooltipDirective extends PTooltip {
-  /**
-   * Event to show the tooltip.
-   * If any string other than 'hover' or 'focus' are given, it won't register
-   * event listeners.
-   *
-   * @default hover
-   */
-  @Input() override tooltipEvent: 'hover' | 'focus' | 'noop' | any = 'hover';
+export class TooltipDirective implements AfterViewInit, OnChanges {
+  @Input() tooltipEvent: 'default' | 'noop' = 'default';
+  @Input() tooltipPosition: 'top' | 'top span-right' | 'top-span-left' = 'top';
+  @Input('mTooltip') content?: string | TemplateRef<any> = undefined;
+  @Input() tooltipId?: string;
+  @Input() tooltipDuration?: number;
+  @Input() tooltipDisabled = false;
 
-  /**
-   * Content of the tooltip.
-   */
-  @Input('mTooltip') override content:
-    | string
-    | TemplateRef<HTMLElement>
-    | undefined = undefined;
+  private popoverElement?: HTMLElement;
+  private popoverContent?: HTMLElement[];
+  private timeoutId?: number;
+  private readonly el = inject(ElementRef);
+  private readonly vcr = inject(ViewContainerRef);
+  private readonly renderer = inject(Renderer2);
 
-  /**
-   * String by which to distuingish multiple instances in a QueryList
-   */
-  @Input() tooltipContext?: any;
-
-  /**
-   * Overriden position to make `top` the default.
-   */
-  @Input() override tooltipPosition: 'top' | 'left' | 'right' | 'bottom' =
-    'top';
-
-  // Needed to actually override.
-  //
-  // https://github.com/primefaces/primeng/blob/master/src/app/components/tooltip/tooltip.ts#L117
-  override _tooltipOptions = {
-    tooltipLabel: null,
-    tooltipPosition: 'top', // PrimeNG has this as 'right'.
-    tooltipEvent: 'hover',
-    appendTo: 'body',
-    positionStyle: null,
-    tooltipStyleClass: null,
-    tooltipZIndex: 'auto',
-    escape: true,
-    disabled: null,
-    showDelay: null,
-    hideDelay: null,
-    positionTop: null,
-    positionLeft: null,
-    life: null,
-    autoHide: true,
-    hideOnEscape: true,
-    id: UniqueComponentId() + '_tooltip'
-  };
-
-  override alignTop() {
-    this.preAlign('top');
-
-    const viewport = DomHandler.getViewport();
-    const hostOffset = this.getHostOffset();
-    const tooltipWidth = this.getBoxWidth(this.container);
-
-    let offsetLeft =
-      (this.getBoxWidth(this.el.nativeElement) - tooltipWidth) / 2;
-    const offsetTop = DomHandler.getOuterHeight(this.container);
-
-    if (hostOffset.left + offsetLeft < 0) {
-      offsetLeft = 0;
-    }
-
-    if (hostOffset.left + offsetLeft + tooltipWidth > viewport.width) {
-      offsetLeft = viewport.width - tooltipWidth - hostOffset.left;
-    }
-
-    this.alignTooltip(Math.floor(offsetLeft), -offsetTop);
-
-    const arrowElement = this.getArrowElement();
-    arrowElement.style.top = null;
-    arrowElement.style.right = null;
-    arrowElement.style.bottom = '0';
-    arrowElement.style.left = this.getParentCenterOffset() + 'px';
+  constructor() {
+    this.constructPopover();
   }
 
-  override alignBottom() {
-    this.preAlign('bottom');
-
-    const viewport = DomHandler.getViewport();
-    const hostOffset = this.getHostOffset();
-    const tooltipWidth = this.getBoxWidth(this.container);
-
-    let offsetLeft =
-      (this.getBoxWidth(this.el.nativeElement) - tooltipWidth) / 2;
-    const offsetTop = DomHandler.getOuterHeight(this.el.nativeElement);
-
-    if (hostOffset.left + offsetLeft < 0) {
-      offsetLeft = 0;
-    }
-
-    if (hostOffset.left + offsetLeft + tooltipWidth > viewport.width) {
-      offsetLeft = viewport.width - tooltipWidth - hostOffset.left;
-    }
-
-    this.alignTooltip(Math.floor(offsetLeft), offsetTop);
-
-    const arrowElement = this.getArrowElement();
-    arrowElement.style.top = '0';
-    arrowElement.style.right = null;
-    arrowElement.style.bottom = null;
-    arrowElement.style.left = this.getParentCenterOffset() + 'px';
+  show() {
+    if (this.tooltipDisabled || !this.content) return;
+    // @ts-expect-error need to update typescript to >v6 for popover API
+    this.popoverElement.showPopover({ source: this.el.nativeElement });
   }
 
-  override alignLeft() {
-    super.alignLeft();
-    this.resetArrowOffset();
-  }
-
-  override alignRight() {
-    super.alignRight();
-    this.resetArrowOffset();
-  }
-
-  private getParentCenterOffset() {
-    const parent = this.el.nativeElement;
-    const parrentOffset = DomHandler.getOffset(parent);
-    const parentWidth = DomHandler.getOuterWidth(parent);
-    const tootltipOffset = DomHandler.getOffset(this.container);
-    return parentWidth / 2 + parrentOffset.left - tootltipOffset.left;
-  }
-
-  private resetArrowOffset() {
-    const arrowElement = this.getArrowElement();
-    arrowElement.style.top = null;
-    arrowElement.style.right = null;
-    arrowElement.style.bottom = null;
-    arrowElement.style.left = null;
-  }
-
-  private getBoxWidth(el: HTMLElement) {
-    return el.getBoundingClientRect().width;
-  }
-
-  override getArrowElement() {
-    return DomHandler.findSingle(this.container, '.p-tooltip-arrow');
-  }
-
-  /**
-   * Pick out a specific tooltip from a @ViewChildren querylist based on some
-   * property.
-   */
-  static findByContext(
-    tooltips: QueryList<TooltipDirective>,
-    context: any
-  ): TooltipDirective | undefined {
-    return tooltips.find((t) => t.tooltipContext === context);
-  }
-
-  /**
-   * Set the contents of a tooltip and show it. Duration sets a limit period,
-   * if just `true` is given, shows for 2s.
-   */
-  setAndShow(content: string, duration?: number | true): void {
+  setAndShow(content: string | TemplateRef<any>) {
     this.content = content;
-    this.setOption({ tooltipLabel: content });
+    this.initContent();
     this.show();
+  }
 
-    // Not messing with underlying tooltipOptions.life stuff, badly documented
-    // and can't get to work well.
-    if (duration)
-      setTimeout(() => this.hide(), duration === true ? 2000 : duration);
+  hide() {
+    if (this.tooltipDisabled || !this.content) return;
+    this.popoverElement.hidePopover();
+  }
+
+  private onMouseEnter(_: MouseEvent) {
+    this.show();
+  }
+
+  private onMouseLeave(_: MouseEvent) {
+    this.hide();
+  }
+
+  private onToggle(event: ToggleEvent) {
+    if (event.newState === 'open' && this.tooltipDuration) {
+      this.timeoutId = window?.setTimeout(() => {
+        this.popoverElement?.hidePopover();
+      }, this.tooltipDuration);
+    } else if (event.newState === 'closed' && this.timeoutId) {
+      window?.clearTimeout(this.timeoutId);
+    }
+  }
+
+  private constructPopover() {
+    this.popoverElement = this.renderer.createElement('div');
+    this.renderer.setAttribute(this.popoverElement, 'popover', 'hint');
+    this.renderer.setAttribute(this.popoverElement, 'class', 'm-tooltip');
+    this.popoverElement.addEventListener('toggle', this.onToggle.bind(this));
+  }
+
+  private initContent() {
+    if (this.popoverContent) {
+      this.popoverContent.forEach((node) => {
+        this.renderer.removeChild(this.popoverElement, node);
+      });
+      this.popoverContent = undefined;
+    }
+    if (!this.content) return;
+    if (typeof this.content === 'string') {
+      this.popoverContent = [this.renderer.createElement('span')];
+      this.renderer.appendChild(
+        this.popoverContent[0],
+        this.renderer.createText(this.content)
+      );
+    } else {
+      const embeddedView = this.vcr.createEmbeddedView(this.content);
+      this.popoverContent = embeddedView.rootNodes;
+    }
+    this.popoverContent.forEach((node) => {
+      this.renderer.appendChild(this.popoverElement, node);
+    });
+    // insert same lvl as host, since popover can't be child of <input />'s
+    // shouldn't affect layouts since position: absolute
+    this.renderer.insertBefore(
+      this.renderer.parentNode(this.el.nativeElement),
+      this.popoverElement,
+      this.el.nativeElement
+    );
+  }
+
+  ngAfterViewInit() {
+    if (this.tooltipEvent !== 'noop') {
+      this.renderer.listen(
+        this.el.nativeElement,
+        'mouseenter',
+        this.onMouseEnter.bind(this)
+      );
+      this.renderer.listen(
+        this.el.nativeElement,
+        'mouseleave',
+        this.onMouseLeave.bind(this)
+      );
+    }
+    if (this.tooltipPosition !== 'top') {
+      this.renderer.setStyle(
+        this.popoverElement,
+        'position-area',
+        this.tooltipPosition
+      );
+    }
+    this.initContent();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['content']) {
+      this.initContent();
+    }
   }
 }

--- a/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-browser.component.html
@@ -87,7 +87,9 @@
               { icon: 'trophy', color: 'blue' },
               { icon: 'trophy-broken', color: 'red' }
             ]"
-            mTooltip="Any / Ranked / Unranked Leaderboard (You must select a gamemode to use this filter)"
+            [mTooltip]="
+              'Any / Ranked / Unranked Leaderboard' + (gamemode.value == null ? ' (You must select a gamemode to use this filter)' : '')
+            "
             formControlName="rankedUnranked"
           />
           <m-n-state-button

--- a/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/map-submission-browser.component.html
@@ -1,7 +1,8 @@
 <div class="mb-4 flex items-start gap-4">
-  <p class="card-title flex text-nowrap text-48">
-    Beta Maps <m-icon class="ml-2 size-5 self-start pt-1" icon="help-circle" [mTooltip]="infoTooltip" />
-  </p>
+  <div class="flex flex-row">
+    <p class="card-title flex text-nowrap text-48">Beta Maps</p>
+    <m-icon class="ml-2 size-5 self-start pt-1" icon="help-circle" [mTooltip]="infoTooltip" />
+  </div>
   <ng-template #infoTooltip>
     <div class="prose p-3">
       <p>Beta maps are maps currently in the submission pipeline.</p>

--- a/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
+++ b/apps/frontend/src/app/pages/maps/browsers/user-maps-browser.component.html
@@ -31,7 +31,6 @@
             [nameFn]="MapCreditNameFn"
             formControlName="creditType"
             mTooltip="Searching for yourself requires inputting your profile in the user searchbox"
-            tooltipPosition="top"
           />
         </div>
         <button (click)="filters.reset({ status: [] })" type="button" class="btn size-8 p-0">

--- a/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-info.component.html
@@ -34,16 +34,11 @@
         </button>
         @if (map.currentVersion.downloadURL; as bsp) {
           <div>
-            <a
-              (click)="downloadOverlay.show()"
-              [style.anchor-name]="'--download-anchor'"
-              class="btn btn-purple"
-              mTooltip="Download map file"
-            >
+            <a #downloadAnchor (click)="downloadOverlay.show()" class="btn btn-purple" mTooltip="Download map file">
               <m-icon class="pb-0.5" icon="download" />
             </a>
-            <m-popover #downloadOverlay anchorName="--download-anchor">
-              <div class="max-w-lg">
+            <m-popover #downloadOverlay [anchor]="downloadAnchor">
+              <div class="min-w-[15rem] max-w-lg">
                 <p class="mb-1 text-sm italic text-gray-200">
                   For convenience we recommend downloading and launching maps through the in-game map browser!
                 </p>

--- a/apps/frontend/src/app/pages/maps/map-info/map-leaderboard/map-leaderboard.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-leaderboard/map-leaderboard.component.html
@@ -52,11 +52,13 @@
           T{{ activeMode.tier }}
         </p>
       }
-      @if (activeMode.type === LeaderboardType.UNRANKED) {
-        <m-icon class="absolute -bottom-3 -right-3 drop-shadow" icon="numeric-off" [mTooltip]="unrankedLbInfo" />
-      } @else if (activeMode.type === LeaderboardType.HIDDEN) {
-        <m-icon class="absolute -bottom-3 -right-3 drop-shadow" icon="eye-off" [mTooltip]="hiddenLbInfo" />
-      }
+      <div class="text-start">
+        @if (activeMode.type === LeaderboardType.UNRANKED) {
+          <m-icon class="absolute -bottom-3 -right-3 drop-shadow" icon="numeric-off" [mTooltip]="unrankedLbInfo" />
+        } @else if (activeMode.type === LeaderboardType.HIDDEN) {
+          <m-icon class="absolute -bottom-3 -right-3 drop-shadow" icon="eye-off" [mTooltip]="hiddenLbInfo" />
+        }
+      </div>
     </button>
 
     @if (activeMode.stages > 0) {
@@ -109,11 +111,13 @@
             T{{ bonus.tier }}
           </p>
         }
-        @if (bonus.type === LeaderboardType.UNRANKED) {
-          <m-icon class="absolute -bottom-3 -right-3 drop-shadow" icon="numeric-off" [mTooltip]="unrankedLbInfo" />
-        } @else if (bonus.type === LeaderboardType.HIDDEN) {
-          <m-icon class="absolute -bottom-3 -right-3 drop-shadow" icon="eye-off" [mTooltip]="hiddenLbInfo" />
-        }
+        <div class="text-start">
+          @if (bonus.type === LeaderboardType.UNRANKED) {
+            <m-icon class="absolute -bottom-3 -right-3 drop-shadow" icon="numeric-off" [mTooltip]="unrankedLbInfo" />
+          } @else if (bonus.type === LeaderboardType.HIDDEN) {
+            <m-icon class="absolute -bottom-3 -right-3 drop-shadow" icon="eye-off" [mTooltip]="hiddenLbInfo" />
+          }
+        </div>
       </button>
     }
 

--- a/apps/frontend/src/app/pages/maps/map-info/map-submission/map-submission.component.html
+++ b/apps/frontend/src/app/pages/maps/map-info/map-submission/map-submission.component.html
@@ -4,11 +4,11 @@
   <p class="mt-1 text-sm font-medium uppercase text-gray-200">Submitted By</p>
   <m-user [user]="map.submitter" avatarClass="!h-5" />
 
-  <p class="mt-4 text-sm font-medium uppercase text-gray-200">
-    Type
-    <m-icon [mTooltip]="subType" class="ml-0.5 pt-0.5 text-sm" icon="help-circle" />
+  <div class="mt-4 flex flex-row items-center gap-1">
+    <p class="text-sm font-medium uppercase text-gray-200">Type</p>
+    <m-icon [mTooltip]="subType" class="ml-0.5 text-sm" icon="help-circle" />
     <ng-template #subType><m-submission-type-info /></ng-template>
-  </p>
+  </div>
   <p class="text-lg">{{ MapSubmissionType[map.submission.type] | titlecase }}</p>
 
   <p class="mt-4 text-sm font-medium uppercase text-gray-200">Timeline</p>

--- a/apps/frontend/src/app/pages/maps/submission-form/map-submission-form.component.html
+++ b/apps/frontend/src/app/pages/maps/submission-form/map-submission-form.component.html
@@ -39,10 +39,10 @@
       </div>
       <div class="card card--fancy mt-6 grid gap-4 p-4 pt-6 md:grid-cols-1 lg:grid-cols-3" [formGroup]="files">
         <div class="flex flex-col">
-          <p class="mt-2 text-center text-xl font-medium">
-            BSP File
-            <m-icon icon="asterisk" class="mb-1 p-0.5 align-middle" mTooltip="Required" />
-          </p>
+          <div class="my-1 flex flex-row items-center justify-center gap-1">
+            <p class="text-center text-xl font-medium">BSP File</p>
+            <m-icon icon="asterisk" class="p-0.5 align-middle" mTooltip="Required" />
+          </div>
           <p class="mb-6 mt-3 block w-auto flex-grow text-balance px-3 text-center text-sm">
             This is the main map file for your map. It should have all custom assets packed into it, and must be
             <a class="link" href="https://docs.momentum-mod.org/guide/map_submission/map_porting/#step-4-compress-the-map">compressed</a>.
@@ -77,10 +77,10 @@
           <m-file-upload [formControl]="bsp" typeName="BSP" acceptExtensions=".bsp" icon="land-plots" />
         </div>
         <div class="flex flex-col">
-          <h5 class="mt-1 text-center text-xl font-medium">
-            Zones File
-            <m-icon icon="asterisk" class="mb-1 p-0.5 align-middle" mTooltip="Required" />
-          </h5>
+          <div class="my-1 flex flex-row items-center justify-center gap-1">
+            <p class="text-center text-xl font-medium">Zones File</p>
+            <m-icon icon="asterisk" class="p-0.5 align-middle" mTooltip="Required" />
+          </div>
           <p class="mb-6 mt-3 block w-auto flex-grow text-balance px-3 text-center text-sm">The zones for your map</p>
           <div>
             @if (zon.errors?.['required'] && zon.dirty) {
@@ -99,7 +99,7 @@
           <m-file-upload [formControl]="zon" typeName=".json" icon="vector-polygon" acceptExtensions=".json" />
         </div>
         <div class="flex flex-col">
-          <p class="mt-1 text-center text-xl font-medium">VMF File(s)</p>
+          <p class="my-1 text-center text-xl font-medium">VMF File(s)</p>
           <p class="mb-6 mt-3 block w-auto flex-grow text-balance px-3 text-center text-sm">
             The VMF source files your map. Not required, but helps us archive file maps, and may be helpful for other mappers!
           </p>

--- a/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.html
+++ b/apps/frontend/src/app/pages/profile/profile-edit/profile-edit.component.html
@@ -63,12 +63,12 @@
           <p class="text-lg">Socials</p>
           <div class="grid gap-3 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5" formGroupName="socials">
             @for (social of SocialsData | unsortedKeyvalue; track social) {
-              <div [mTooltip]="'Example: ' + social.value.example">
+              <div>
                 <div class="ml-1 flex items-center gap-2">
                   <m-icon class="h-5 w-5" [icon]="social.value.icon" pack="si" />
                   <h4>{{ social.key }}</h4>
                 </div>
-                <input [formControlName]="social.key" class="textinput" type="text" />
+                <input [mTooltip]="'Example: ' + social.value.example" [formControlName]="social.key" class="textinput" type="text" />
               </div>
             }
           </div>

--- a/apps/frontend/src/app/pages/profile/profile.component.html
+++ b/apps/frontend/src/app/pages/profile/profile.component.html
@@ -2,7 +2,7 @@
   <div class="grid grid-cols-5 gap-4">
     <div class="col-span-full flex flex-col xl:col-span-3">
       <div
-        class="mb-4 flex gap-4 rounded border border-white border-opacity-10 bg-cover bg-center bg-no-repeat p-4 text-xl"
+        class="mb-4 flex gap-4 rounded border border-white border-opacity-10 bg-cover bg-center bg-no-repeat p-4"
         style="background-image: url('/assets/images/playercard_bg.png')"
       >
         @if (avatarLoaded) {
@@ -14,21 +14,24 @@
           ></div>
         }
         <div class="flex flex-grow flex-col justify-between">
-          <div class="flex gap-1">
-            <h1
-              class="flex flex-grow items-center gap-2 font-medium"
-              [fontSizeLerp]="{ chars: user.alias.length, startAt: 16, baseRem: 2.25 }"
-            >
-              {{ user.alias }}
+          <div class="flex flex-row gap-1">
+            <div class="flex flex-grow items-center gap-2">
+              <h1 class="text-xl font-medium" [fontSizeLerp]="{ chars: user.alias.length, startAt: 16, baseRem: 2.25 }">
+                {{ user.alias }}
+              </h1>
               @if (user.country && user.country.length === 2) {
-                <span [title]="countryDisplayName" class="rounded inline-block w-7 text-4 fi fi-{{ user.country.toLowerCase() }}"></span>
+                <span
+                  [title]="countryDisplayName"
+                  [fontSizeLerp]="{ chars: user.alias.length, startAt: 16, baseRem: 2.25 }"
+                  class="rounded inline-block text-4 w-7 fi fi-{{ user.country.toLowerCase() }}"
+                ></span>
               }
               @if (!hasRole(Role.PLACEHOLDER) && !hasRole(Role.DELETED)) {
                 <a href="https://steamcommunity.com/profiles/{{ user.steamID }}" target="_blank" mTooltip="Steam Profile">
                   <m-icon class="h-7 w-7 text-gray-50 transition duration-100 ease-out hover:text-blue-500" icon="steam" pack="si" />
                 </a>
               }
-            </h1>
+            </div>
             <div class="flex gap-1">
               @if (!isLocal && (localUserService.user | async) && !localUserService.isLimited) {
                 <m-report-button
@@ -72,8 +75,8 @@
           </div>
           <m-role-badges class="h-10 !gap-0" [roles]="user.roles" classes="p-1" />
           @if (!hasRole(Role.DELETED)) {
-            <div class="flex w-full gap-2 font-display text-2xl">
-              <div class="flex-grow">
+            <div class="flex w-full gap-2">
+              <div class="flex-grow font-display text-2xl">
                 <p class="pb-1 leading-none">{{ xp - currLevelXp }} / {{ nextLevelXp - currLevelXp }} xp</p>
                 <p-progressBar class="h-2 w-full" [showValue]="false" [value]="(100 * (xp - currLevelXp)) / (nextLevelXp - currLevelXp)" />
               </div>
@@ -90,15 +93,17 @@
           <div class="grid gap-2 md:grid-cols-3 lg:grid-cols-4">
             @for (social of user.profile.socials | unsortedKeyvalue; track social) {
               @if (social.value) {
-                <a
-                  class="m-1 overflow-hidden text-ellipsis whitespace-nowrap transition duration-100 ease-out hover:!text-blue-500"
-                  href="https://{{ SocialsData[social.key].url }}/{{ social.value }}"
-                  target="_blank"
-                  [mTooltip]="social.key"
-                >
-                  <m-icon class="mr-1 h-7 w-7 align-middle text-white" [icon]="SocialsData[social.key].icon" pack="si" />
-                  {{ social.value }}
-                </a>
+                <div class="w-fit">
+                  <a
+                    class="m-1 overflow-hidden text-ellipsis whitespace-nowrap transition duration-100 ease-out hover:!text-blue-500"
+                    href="https://{{ SocialsData[social.key].url }}/{{ social.value }}"
+                    target="_blank"
+                    [mTooltip]="social.key"
+                  >
+                    <m-icon class="mr-1 h-7 w-7 align-middle text-white" [icon]="SocialsData[social.key].icon" pack="si" />
+                    {{ social.value }}
+                  </a>
+                </div>
               }
             }
           </div>

--- a/apps/frontend/src/app/theme/styles.css
+++ b/apps/frontend/src/app/theme/styles.css
@@ -512,6 +512,22 @@
       }
     }
   }
+
+  .m-tooltip {
+    inset: auto;
+    position: absolute;
+    background-color: #52525b;
+    position-area: top;
+    position-try-fallbacks: flip-block;
+    margin: 0.25rem;
+    padding: 0.5rem;
+    border-radius: 4px;
+    box-shadow:
+      0 11px 15px -7px rgba(0, 0, 0, 0.2),
+      0 24px 38px 3px rgba(0, 0, 0, 0.14),
+      0 9px 46px 8px rgba(0, 0, 0, 0.12);
+    animation: fadeIn 0.2s ease-in;
+  }
 }
 
 @layer utilities {
@@ -603,5 +619,14 @@
     text-shadow:
       0 1px 1px rgba(0, 0, 0, 0.4),
       0 1px 4px rgba(0, 0, 0, 0.3);
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 }


### PR DESCRIPTION
- Replacing primeng tooltips with native popopver components
  - maintaining same api (attribute directive) for compatibility
  - default position is adjustable using `[tooltipPosition]` using any valid `position-area` anchor-positioning value 
  - missing tooltip tail ://
  - missing fancier animations, just fadein
- updating `<m-popover>` using `popover.showPopover({source: <source element>})` so we don't need to assign all these anchor names anymore. 
  - Current typescript version doesn't recognize the param, but works in browser. Should look to update typescript and all other depencies
- Updated some styles to be more responsive (shown in screenshots)

Closes #1499

<!-- Describe what your pull request is doing here -->

### Screenshots (if applicable)
#### Typical tooltip
##### Before:
<img width="161" height="102" alt="image" src="https://github.com/user-attachments/assets/620e2ee1-b764-47f4-973f-699d2f261b11" />

##### After:
<img width="155" height="105" alt="image" src="https://github.com/user-attachments/assets/fa11a76e-b5c9-42ab-ba59-dbad1e42bfea" />

\
<img width="283" height="442" alt="image" src="https://github.com/user-attachments/assets/db483fd6-8e85-4402-8bb9-3a08a9f77853" />

\
<img width="739" height="443" alt="image" src="https://github.com/user-attachments/assets/23a03743-c972-43de-b31b-9753a21ab758" />



### layout/style updates

#### map-final-approval form

##### before: 

(on 14inch macbook)
<img width="2510" height="1352" alt="image" src="https://github.com/user-attachments/assets/29461046-81c3-496f-afc7-40d1c7fb22fa" />

##### after:
<img width="2380" height="946" alt="image" src="https://github.com/user-attachments/assets/f25d3591-1474-4122-85d4-3ab66ad5d034" />

#### map-details-form
on small viewport

##### before:
<img width="757" height="539" alt="image" src="https://github.com/user-attachments/assets/ceb6965b-f425-47e6-a5a2-226126c20f8d" />

##### after:
<img width="738" height="509" alt="image" src="https://github.com/user-attachments/assets/7b0aadbe-9a75-4b6d-a624-6df760e6f137" />






<!-- Attach screenshots here, if your PR contains any visual changes, e.g. frontend work -->

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
