### PR TITLE
fix(back): tier 1 and 10 filter not showing maps

### DIFF
--- a/apps/backend-e2e/src/maps.e2e-spec.ts
+++ b/apps/backend-e2e/src/maps.e2e-spec.ts
@@ -538,7 +538,7 @@ describe('Maps', () => {
         await req.get({
           url: 'maps',
           status: 200,
-          query: { difficultyLow: 2 },
+          query: { difficultyLow: 2, difficultyHigh: 10 },
           token: u1Token,
           validatePaged: { type: MapDto, count: 3 }
         });
@@ -567,7 +567,7 @@ describe('Maps', () => {
         await req.get({
           url: 'maps',
           status: 200,
-          query: { difficultyHigh: 4 },
+          query: { difficultyLow: 1, difficultyHigh: 4 },
           token: u1Token,
           validatePaged: { type: MapDto, count: 3 }
         });

--- a/apps/backend/src/app/modules/maps/maps.service.ts
+++ b/apps/backend/src/app/modules/maps/maps.service.ts
@@ -192,15 +192,13 @@ export class MapsService {
         leaderboardSome.type = { not: LeaderboardType.HIDDEN };
       }
 
-      if (query.difficultyHigh && query.difficultyLow) {
+      if (query.difficultyLow === query.difficultyHigh) {
+        leaderboardSome.tier = { equals: query.difficultyLow };
+      } else {
         leaderboardSome.tier = {
           lte: query.difficultyHigh,
           gte: query.difficultyLow
         };
-      } else if (query.difficultyLow) {
-        leaderboardSome.tier = { gte: query.difficultyLow };
-      } else if (query.difficultyHigh) {
-        leaderboardSome.tier = { lte: query.difficultyHigh };
       }
 
       if (query.linear != null) {

--- a/apps/frontend/src/app/pages/maps/browsers/map-browser.component.ts
+++ b/apps/frontend/src/app/pages/maps/browsers/map-browser.component.ts
@@ -207,8 +207,8 @@ export class MapBrowserComponent implements OnInit {
             options.gamemode = gamemode;
 
             const [low, high] = tiers;
-            if (low > 1 && low <= 10) options.difficultyLow = low;
-            if (high > 1 && high < 10) options.difficultyHigh = high;
+            if (low >= 1 && low <= 10) options.difficultyLow = low;
+            if (high >= 1 && high <= 10) options.difficultyHigh = high;
 
             if (tagsAndQualifiers.length > 0) {
               options.tagsWithQualifiers = tagsAndQualifiers.map(


### PR DESCRIPTION
Closes #1505

Made slider values 1 to 10 inclusive for low and high respectively. Previously it was getting undefined values. Updated difficulty query logic in `getAll()`.

### Screenshots (if applicable)

Tier 1 (unranked)
<img width="2246" height="1106" alt="image" src="https://github.com/user-attachments/assets/b9b50c56-42d4-4afc-afde-e05e08747bbd" />
Tier 10
<img width="2264" height="1142" alt="image" src="https://github.com/user-attachments/assets/053b2b66-23bc-49c2-82d5-3bb551a860c5" />


### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [x] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [ ] All changes requested in review have been `fixup`ed into my original commits
