### PR TITLE
Limit leaderboard entries in map status notifications to one per gamemode

### DIFF
--- a/apps/backend/src/app/modules/maps/map-discord-notifications.service.ts
+++ b/apps/backend/src/app/modules/maps/map-discord-notifications.service.ts
@@ -328,8 +328,10 @@ export class MapDiscordNotifications {
 
     let leaderboards: MapSubmissionSuggestion[] | Leaderboard[] =
       extendedMap.leaderboards?.filter(
-        ({ trackType, type }) =>
-          trackType === TrackType.MAIN && type !== LeaderboardType.HIDDEN
+        ({ trackType, type, gamemode }, i, a) =>
+          trackType === TrackType.MAIN &&
+          type !== LeaderboardType.HIDDEN &&
+          a.findIndex((lb) => lb.gamemode === gamemode) === i
       );
 
     if (MapStatuses.IN_SUBMISSION.includes(extendedMap.status)) {


### PR DESCRIPTION
Removes duplicate gamemode fields caused by style leaderboards

### Checks

- [x] __!! DONT IGNORE ME !! I have ran `nx run db:create-migration <name>` and committed the migration if I've made DB schema changes__
- [ ] I have included/updated tests where applicable (see [Testing](https://github.com/momentum-mod/website/wiki/Testing))
- [x] I have followed [semantic commit messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716) e.g. `feat: Add foo`, `chore: Update bar`, etc...
- [x] My branch has a clear history of changes that can be easy to follow when being reviewed commit-by-commit
- [x] My branch is functionally complete; the only changes to be done will be those potentially requested in code review
- [x] All changes requested in review have been `fixup`ed into my original commits
